### PR TITLE
Fix test_install_commit_msg_hook

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,4 +26,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         dev.vm.provision "shell", inline: "#{INSTALL_DEPS}"
     end
 
+    if Vagrant.has_plugin?("vagrant-cachier")
+        config.cache.scope = :box
+    end
+
 end

--- a/gitlint/tests/test_hooks.py
+++ b/gitlint/tests/test_hooks.py
@@ -1,17 +1,21 @@
 from gitlint.tests.base import BaseTestCase
 from gitlint.hooks import GitHookInstaller, GitHookInstallerError, COMMIT_MSG_HOOK_SRC_PATH, COMMIT_MSG_HOOK_DST_PATH
-from mock import patch
+from mock import patch, ANY
 
 
 class HookTests(BaseTestCase):
+    @patch('os.chmod')
+    @patch('os.stat')
     @patch('gitlint.hooks.shutil.copy')
     @patch('os.path.exists', return_value=False)
     @patch('os.path.isdir', return_value=True)
-    def test_install_commit_msg_hook(self, isdir, path_exists, copy):
+    def test_install_commit_msg_hook(self, isdir, path_exists, copy, stat, chmod):
         GitHookInstaller.install_commit_msg_hook()
         isdir.assert_called_once_with('.git/hooks')
         path_exists.assert_called_once_with(COMMIT_MSG_HOOK_DST_PATH)
         copy.assert_called_once_with(COMMIT_MSG_HOOK_SRC_PATH, COMMIT_MSG_HOOK_DST_PATH)
+        stat.assert_called_once_with(COMMIT_MSG_HOOK_DST_PATH)
+        chmod.assert_called_once_with(COMMIT_MSG_HOOK_DST_PATH, ANY)
 
     @patch('gitlint.hooks.shutil.copy')
     @patch('os.path.exists', return_value=False)


### PR DESCRIPTION
When I ran run_tests.sh I got the error in the commit. So this should fix that. I'm completely new to mock etc. so excuse any mistake. I've use ANY because I have no idea how I should mock the stat response, I think that should do for now. Now that I look at it, perhaps I should have use patch.ANY instead of importing ANY.

Since I've been destroying the vagrant so frequently I've make use of the vagrant-cachier plugin so I don't have to re-download packages. The change should have no impact for people without the plugin. It is completely optional.