### PR TITLE
Ignore B6 when merge commit

### DIFF
--- a/examples/commit-message-6
+++ b/examples/commit-message-6
@@ -1,0 +1,1 @@
+Merge "US1234: This merge has no body and that's OK"

--- a/gitlint/rules.py
+++ b/gitlint/rules.py
@@ -233,6 +233,9 @@ class BodyMissing(MultiLineRule, CommitMessageBodyRule):
     id = "B6"
 
     def validate(self, gitcontext):
+        # ignore merges, which may have no body
+        if gitcontext.commit_msg.title.find("Merge") == 0:
+            return
         if len(gitcontext.commit_msg.body) <= 2:
             return [RuleViolation(self.id, "Body message is missing", None, 3)]
 

--- a/gitlint/tests/test_body_rules.py
+++ b/gitlint/tests/test_body_rules.py
@@ -110,6 +110,11 @@ class BodyRuleTests(BaseTestCase):
         violations = rule.validate(gitcontext)
         self.assertIsNone(violations)
 
+        # assert no error - merge commit
+        gitcontext = self.gitcontext("Merge: Title\n")
+        violations = rule.validate(gitcontext)
+        self.assertIsNone(violations)
+
         # body is too short
         expected_violation = rules.RuleViolation("B6", "Body message is missing", None, 3)
 


### PR DESCRIPTION
B6 (body-is-missing) should be ignored when the commit is a merge commit.

Merge commits can be generated by automated systems like Gerrit and
those systems copy the title from the source commit but may not copy the
body. commit-message-6 gives an example.