### PR TITLE
Python 2.6 support

### DIFF
--- a/gitlint/config.py
+++ b/gitlint/config.py
@@ -7,7 +7,12 @@ try:
 except ImportError:  # pragma: no cover
     # python 3.x
     from configparser import ConfigParser, Error as ConfigParserError  # pragma: no cover
-from collections import OrderedDict
+try:
+    # python >= 2.7
+    from collections import OrderedDict
+except ImportError:  # pragma: no cover
+    # python 2.4-2.6
+    from ordereddict import OrderedDict  # pragma: no cover
 import re
 import os
 import shutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ setuptools
 wheel==0.24.0
 Click==5.1
 sh==1.11
+ordereddict==1.1

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
     ],
     install_requires=[
         'Click==5.1',
-        'sh==1.11'
+        'sh==1.11',
+        'ordereddict==1.1'
     ],
     keywords='gitlint git lint',
     author='Joris Roovers',


### PR DESCRIPTION
Python 2.6 support

We have a project that uses Python 2.6 and would like 
to use this tool to verify our commit messages.

This PR imports `OrderedDict` from the `ordereddict` 
package if the built-in from `collections` is not present. 