### PR TITLE
fix inverted violation message

### DIFF
--- a/gitlint/rules.py
+++ b/gitlint/rules.py
@@ -185,7 +185,7 @@ class TitleRegexMatches(CommitMessageTitleRule):
         regex = self.options['regex'].value
         pattern = re.compile(regex)
         if not pattern.search(title):
-            violation_msg = "Title does match regex ({0})".format(regex)
+            violation_msg = "Title does not match regex ({0})".format(regex)
             return [RuleViolation(self.id, violation_msg, title)]
 
 

--- a/gitlint/tests/test_title_rules.py
+++ b/gitlint/tests/test_title_rules.py
@@ -142,5 +142,5 @@ class TitleRuleTests(BaseTestCase):
         # assert violation when no matching regex
         rule = TitleRegexMatches({'regex': "^UA[0-9]*"})
         violations = rule.validate(gitcontext.commits[-1].message.title, gitcontext)
-        expected_violation = RuleViolation("T7", "Title does match regex (^UA[0-9]*)", "US1234: abc")
+        expected_violation = RuleViolation("T7", "Title does not match regex (^UA[0-9]*)", "US1234: abc")
         self.assertListEqual(violations, [expected_violation])


### PR DESCRIPTION
the violation message when a title did not match the expected regex was
inverted, e.g. it said that the title "does match" when it should have
been "does not match"