### PR TITLE
Support Unicode string in commit message

### DIFF
--- a/gitlint/lint.py
+++ b/gitlint/lint.py
@@ -70,6 +70,6 @@ class GitLinter(object):
             self.display.e("{0}: {1}".format(v.line_nr, v.rule_id), exact=True)
             self.display.ee("{0}: {1} {2}".format(v.line_nr, v.rule_id, v.message), exact=True)
             if v.content:
-                self.display.eee("{0}: {1} {2}: \"{3}\"".format(v.line_nr, v.rule_id, v.message, v.content), exact=True)
+                self.display.eee("{0}: {1} {2}: \"{3}\"".format(v.line_nr, v.rule_id, v.message, v.content.encode('utf-8')), exact=True)
             else:
                 self.display.eee("{0}: {1} {2}".format(v.line_nr, v.rule_id, v.message), exact=True)


### PR DESCRIPTION
Support Unicode string in commit message.

Error info when commit message content Chinese.
Traceback (most recent call last):
  File "/usr/bin/gitlint", line 9, in <module>
    load_entry_point('gitlint==0.8.0dev', 'console_scripts', 'gitlint')()
  File "/usr/lib/python2.6/site-packages/click-6.6-py2.6.egg/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.6/site-packages/click-6.6-py2.6.egg/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.6/site-packages/click-6.6-py2.6.egg/click/core.py", line 1037, in invoke
    return Command.invoke(self, ctx)
  File "/usr/lib/python2.6/site-packages/click-6.6-py2.6.egg/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.6/site-packages/click-6.6-py2.6.egg/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.6/site-packages/click-6.6-py2.6.egg/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/lib/python2.6/site-packages/gitlint-0.8.0dev-py2.6.egg/gitlint/cli.py", line 104, in cli
    ctx.invoke(lint)
  File "/usr/lib/python2.6/site-packages/click-6.6-py2.6.egg/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.6/site-packages/click-6.6-py2.6.egg/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/lib/python2.6/site-packages/gitlint-0.8.0dev-py2.6.egg/gitlint/cli.py", line 128, in lint
    linter.print_violations(violations)
  File "/usr/lib/python2.6/site-packages/gitlint-0.8.0dev-py2.6.egg/gitlint/lint.py", line 78, in print_violations
    self.display.eee("{0}: {1} {2}: \"{3}\"".format(v.line_nr, v.rule_id, v.message, v.content), exact=True)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 5-6: ordinal not in range(128)
