### PR TITLE
Handle empty commit list in --commits (#22)

### DIFF
--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -121,6 +121,12 @@ def lint(ctx):
         click.echo(ustr(e))
         ctx.exit(GIT_CONTEXT_ERROR_CODE)
 
+    number_of_commits = len(gitcontext.commits)
+
+    if number_of_commits == 0:
+        click.echo(u'No commits in range "{0}".'.format(ctx.obj[2]))
+        ctx.exit(0)
+
     config_builder = ctx.obj[1]
     last_commit = gitcontext.commits[-1]
     # Apply an additional config that is specified in the last commit message
@@ -129,7 +135,6 @@ def lint(ctx):
 
     # Let's get linting!
     linter = GitLinter(lint_config)
-    number_of_commits = len(gitcontext.commits)
     first_violation = True
 
     for commit in gitcontext.commits:

--- a/gitlint/tests/test_cli.py
+++ b/gitlint/tests/test_cli.py
@@ -202,6 +202,16 @@ class CLITests(BaseTestCase):
         result = self.cli.invoke(cli.cli)
         self.assertEqual(result.exit_code, self.GIT_CONTEXT_ERROR_CODE)
 
+    @patch('gitlint.git.sh')
+    @patch('gitlint.cli.sys')
+    def test_no_commits_in_range(self, sys, sh):
+        sys.stdin.isatty.return_value = True
+        sh.git.side_effect = lambda *_args, **_kwargs: ""
+        result = self.cli.invoke(cli.cli, ["--commits", "master...HEAD"])
+        expected = u'No commits in range "master...HEAD".\n'
+        self.assertEqual(result.output, expected)
+        self.assertEqual(result.exit_code, 0)
+
     @patch('gitlint.hooks.GitHookInstaller.install_commit_msg_hook')
     def test_install_hook(self, install_hook):
         result = self.cli.invoke(cli.cli, ["install-hook"])


### PR DESCRIPTION
This fixes a "index out of range" exception when the specified git range for --commits is empty.

Fixes #22.