### PR TITLE
Accept either a file or directory for the --extra-path option (#26)

### DIFF
--- a/docs/user_defined_rules.md
+++ b/docs/user_defined_rules.md
@@ -5,7 +5,8 @@ Gitlint supports the concept of user-defined rules: the ability for users
 to write your own custom rules that are executed when gitlint is.
 
 In a nutshell, use ```--extra-path /home/joe/myextensions``` to point gitlint to a ```myextensions``` directory where it will search
-for python files containing gitlint rule classes.
+for python files containing gitlint rule classes. You can also specify a single python module, ie
+```--extra-path /home/joe/my_rules.py```.
 
 ```bash
 cat examples/commit-message-1 | gitlint --extra-path examples/
@@ -257,7 +258,7 @@ StrOption       | Strings
 IntOption       | Integers. ```IntOption``` takes an optional ```allow_negative``` parameter if you want to allow negative integers.
 BoolOption      | Booleans. Valid values: true, false. Case-insensitive.
 ListOption      | List of strings. Comma separated.
-DirectoryOption | Directory Paths. Must be an existing directory on the current host.
+PathOption      | Directory or file path. Takes an optional ```type``` parameter for specifying path type (```dir``` \| ```both```).
 
 !!! note
     Gitlint currently does not support options for all possible types (e.g. float, filepath, list of int, etc).
@@ -287,8 +288,7 @@ ultimate source of truth, here are some of the requirements that gitlint enforce
   the same id might lead to unexpected or undeterministic behavior.
 
 ### extra-path requirements ###
-- The ```extra-path``` option must point to a **directory**, not a file. However, the ```extra-path``` directory does
-  **not** need to be a proper python package, i.e. it doesn't require an ```__init__.py``` file.
+- If  ```extra-path``` is a directory, it does **not** need to be a proper python package, i.e. it doesn't require an ```__init__.py``` file.
 - Python files containing user-defined rules must have a ```.py``` extension. Files with a different extension will be ignored.
 - The ```extra-path``` will be searched non-recursively, i.e. all rule classes must be present at the top level ```extra-path``` directory.
 - User rule classes must be defined in the modules that are part of ```extra-path```, rules that are imported from outside the ```extra-path``` will be ignored.

--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -82,8 +82,8 @@ def build_config(ctx, target, config_path, c, extra_path, ignore, verbose, silen
               help="Config flags in format <rule>.<option>=<value> (e.g.: -c T1.line-length=80). " +
                    "Flag can be used multiple times to set multiple config values.")  # pylint: disable=bad-continuation
 @click.option('--commits', default="HEAD", help="The range of commits to lint. [default: HEAD]")
-@click.option('-e', '--extra-path', help="Path to a directory with extra user-defined rules",
-              type=click.Path(exists=True, resolve_path=True, file_okay=False, readable=True))
+@click.option('-e', '--extra-path', help="Path to a directory or python module with extra user-defined rules",
+              type=click.Path(exists=True, resolve_path=True, readable=True))
 @click.option('--ignore', default="", help="Ignore rules (comma-separated by id or name).")
 @click.option('-v', '--verbose', count=True, default=0,
               help="Verbosity, more v's for more verbose output (e.g.: -v, -vv, -vvv). [default: -vvv]", )

--- a/gitlint/config.py
+++ b/gitlint/config.py
@@ -68,7 +68,7 @@ class LintConfig(object):
         self._debug = options.BoolOption('debug', False, "Enable debug mode")
         self._extra_path = None
         target_description = "Path of the target git repository (default=current working directory)"
-        self._target = options.DirectoryOption('target', os.path.abspath(os.getcwd()), target_description)
+        self._target = options.PathOption('target', os.path.abspath(os.getcwd()), target_description)
         self._ignore = options.ListOption('ignore', [], 'List of rule-ids to ignore')
         self._config_path = None
 
@@ -120,8 +120,11 @@ class LintConfig(object):
             if self.extra_path:
                 self._extra_path.set(value)
             else:
-                self._extra_path = options.DirectoryOption('extra-path', value,
-                                                           "Path to a directory with extra user-defined rules")
+                self._extra_path = options.PathOption(
+                    'extra-path', value,
+                    "Path to a directory or module with extra user-defined rules",
+                    type='both'
+                )
 
             # Make sure we unload any previously loaded extra-path rules
             for rule in self.rules:

--- a/gitlint/options.py
+++ b/gitlint/options.py
@@ -87,10 +87,28 @@ class ListOption(RuleOption):
         self.value = [ustr(item.strip()) for item in the_list if item.strip() != ""]
 
 
-class DirectoryOption(RuleOption):
+class PathOption(RuleOption):
+    """ Option that accepts either a directory or both a directory and a file. """
+
+    def __init__(self, name, value, description, type='dir'):
+        self.type = type
+        super(PathOption, self).__init__(name, value, description)
+
     def set(self, value):
         value = ustr(value)
-        if not os.path.isdir(value):
-            msg = u"Option {0} must be an existing directory (current value: '{1}')".format(self.name, value)
-            raise RuleOptionError(msg)
+
+        error_msg = u""
+
+        if self.type == 'dir':
+            if not os.path.isdir(value):
+                error_msg = u"Option {0} must be an existing directory (current value: '{1}')".format(self.name, value)
+
+        elif self.type == 'both':
+            if not os.path.isdir(value) and not os.path.isfile(value):
+                error_msg = (u"Option {0} must be either an existing directory or file "
+                             u"(current value: '{1}')").format(self.name, value)
+
+        if error_msg:
+            raise RuleOptionError(error_msg)
+
         self.value = os.path.abspath(value)

--- a/gitlint/tests/test_config.py
+++ b/gitlint/tests/test_config.py
@@ -114,9 +114,9 @@ class LintConfigTests(BaseTestCase):
 
     def test_extra_path_negative(self):
         config = LintConfig()
+        regex = u"Option extra-path must be either an existing directory or file \(current value: 'föo/bar'\)"
         # incorrect extra_path
-        with self.assertRaisesRegex(LintConfigError,
-                                    u"Option extra-path must be an existing directory \(current value: 'föo/bar'\)"):
+        with self.assertRaisesRegex(LintConfigError, regex):
             config.extra_path = u"föo/bar"
 
         # extra path contains classes with errors

--- a/gitlint/tests/test_options.py
+++ b/gitlint/tests/test_options.py
@@ -3,7 +3,7 @@ import os
 
 from gitlint.tests.base import BaseTestCase
 
-from gitlint.options import IntOption, BoolOption, StrOption, ListOption, DirectoryOption, RuleOptionError
+from gitlint.options import IntOption, BoolOption, StrOption, ListOption, PathOption, RuleOptionError
 
 
 class RuleOptionTests(BaseTestCase):
@@ -117,7 +117,7 @@ class RuleOptionTests(BaseTestCase):
         self.assertListEqual(option.value, ["123"])
 
     def test_dir_option(self):
-        option = DirectoryOption("test-directory", ".", u"Test Description")
+        option = PathOption("test-directory", ".", u"Test Description")
         self.assertEqual(option.value, os.getcwd())
         self.assertEqual(option.name, "test-directory")
         self.assertEqual(option.description, u"Test Description")

--- a/gitlint/tests/test_user_rules.py
+++ b/gitlint/tests/test_user_rules.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import os
 import sys
 
 from gitlint.tests.base import BaseTestCase
@@ -47,6 +48,16 @@ class UserRuleTests(BaseTestCase):
         violations = rule_class.validate("false-commit-object (ignored)")
         self.assertListEqual(violations, [rules.RuleViolation("UC1", u"Commit violåtion 1", u"Contënt 1", 1),
                                           rules.RuleViolation("UC1", u"Commit violåtion 2", u"Contënt 2", 2)])
+
+    def test_extra_path_specified_by_file(self):
+        # Test that find_rule_classes can handle an extra path given as a file name instead of a directory
+        user_rule_path = self.get_sample_path("user_rules")
+        user_rule_module = os.path.join(user_rule_path, "my_commit_rules.py")
+        classes = find_rule_classes(user_rule_module)
+
+        rule_class = classes[0]()
+        violations = rule_class.validate("false-commit-object (ignored)")
+        self.assertListEqual(violations, [rules.RuleViolation("UC1", u"Commit violåtion 1", u"Contënt 1", 1)])
 
     def test_empty_user_classes(self):
         # Test that we don't find rules if we scan a different directory

--- a/gitlint/user_rules.py
+++ b/gitlint/user_rules.py
@@ -15,16 +15,28 @@ class UserRuleError(Exception):
 
 def find_rule_classes(extra_path):
     """
-    Searches a given directory for rule classes. This is done by finding all python modules in the given directory,
-    adding them to the python path, importing them and then finding any Rule classes in those modules.
+    Searches a given directory or python module for rule classes. This is done by
+    adding the directory path to the python path, importing the modules and then finding
+    any Rule class in those modules.
 
-    :param extra_path: absolute directory path to search for rule classes
-    :return: The list of rule classes that are found in the given directory.
+    :param extra_path: absolute directory or file path to search for rule classes
+    :return: The list of rule classes that are found in the given directory or module
     """
 
-    # Find all python files in the given path
+    files = []
     modules = []
-    for filename in os.listdir(extra_path):
+
+    if os.path.isfile(extra_path):
+        files = [os.path.basename(extra_path)]
+        directory = os.path.dirname(extra_path)
+    elif os.path.isdir(extra_path):
+        files = os.listdir(extra_path)
+        directory = extra_path
+    else:
+        raise OSError('No such file or directory')
+
+    # Filter out files that are not python modules
+    for filename in files:
         if fnmatch.fnmatch(filename, '*.py'):
             modules.append(os.path.splitext(filename)[0])
 
@@ -32,8 +44,8 @@ def find_rule_classes(extra_path):
     if len(modules) == 0:
         return []
 
-    # Append the extra_path to the python path so that we can import the newly found rule modules
-    sys.path.append(extra_path)
+    # Append the extra rules path to python path so that we can import them
+    sys.path.append(directory)
 
     # Find all the rule classes in the found python files
     rule_classes = []


### PR DESCRIPTION
The --extra-path option now allows user defined rules to be either a file or directory.

Fixes #26.