### PR TITLE
Add title to violation_msg in TitleRegexMatches

### DIFF
--- a/gitlint/rules.py
+++ b/gitlint/rules.py
@@ -211,7 +211,7 @@ class TitleRegexMatches(LineRule):
         regex = self.options['regex'].value
         pattern = re.compile(regex, re.UNICODE)
         if not pattern.search(title):
-            violation_msg = u"Title does not match regex ({0})".format(regex)
+            violation_msg = u"Title '{0}' does not match regex /{1}/".format(title, regex)
             return [RuleViolation(self.id, violation_msg, title)]
 
 

--- a/gitlint/tests/test_title_rules.py
+++ b/gitlint/tests/test_title_rules.py
@@ -150,5 +150,6 @@ class TitleRuleTests(BaseTestCase):
         # assert violation when no matching regex
         rule = TitleRegexMatches({'regex': u"^UÅ[0-9]*"})
         violations = rule.validate(commit.message.title, commit)
-        expected_violation = RuleViolation("T7", u"Title does not match regex (^UÅ[0-9]*)", u"US1234: åbc")
+        expected_violation = RuleViolation("T7", u"Title 'US1234: åbc' does not match regex /^UÅ[0-9]*/",
+                                           u"US1234: åbc")
         self.assertListEqual(violations, [expected_violation])


### PR DESCRIPTION
When you are validating multiple commits, it's not clear which title
failed the validation.