### PR TITLE
Add handle of git scissors cleanup and custom comment char

### DIFF
--- a/gitlint/git.py
+++ b/gitlint/git.py
@@ -31,6 +31,17 @@ def git_version():
     return version
 
 
+def git_commentchar():
+    """ Shortcut for retrieving comment char from git config
+    """
+    try:
+        commentchar = ustr(sh.git.config('--get', 'core.commentchar')).replace(u"\n", u"")
+    except sh.ErrorReturnCode_1:  # pylint: disable=no-member
+        # exception means that default commentchar used
+        commentchar = '#'
+    return commentchar
+
+
 class GitCommitMessage(object):
     """ Class representing a git commit message. A commit message consists of the following:
       - original: The actual commit message as returned by `git log`
@@ -38,7 +49,7 @@ class GitCommitMessage(object):
       - title: the first line of full
       - body: all lines following the title
     """
-    COMMENT_CHAR = '#'
+    COMMENT_CHAR = git_commentchar()
     CUTLINE = '{0} ------------------------ >8 ------------------------'.format(COMMENT_CHAR)
 
     def __init__(self, original=None, full=None, title=None, body=None):

--- a/gitlint/git.py
+++ b/gitlint/git.py
@@ -38,6 +38,8 @@ class GitCommitMessage(object):
       - title: the first line of full
       - body: all lines following the title
     """
+    COMMENT_CHAR = '#'
+    CUTLINE = '{0} ------------------------ >8 ------------------------'.format(COMMENT_CHAR)
 
     def __init__(self, original=None, full=None, title=None, body=None):
         self.original = original
@@ -48,7 +50,12 @@ class GitCommitMessage(object):
     @staticmethod
     def from_full_message(commit_msg_str):
         """  Parses a full git commit message by parsing a given string into the different parts of a commit message """
-        lines = [line for line in commit_msg_str.splitlines() if not line.startswith("#")]
+        all_lines = commit_msg_str.splitlines()
+        try:
+            cutline_index = all_lines.index(GitCommitMessage.CUTLINE)
+        except ValueError:
+            cutline_index = None
+        lines = [line for line in all_lines[:cutline_index] if not line.startswith(GitCommitMessage.COMMENT_CHAR)]
         full = "\n".join(lines)
         title = lines[0] if len(lines) > 0 else ""
         body = lines[1:] if len(lines) > 1 else []

--- a/gitlint/tests/samples/commit_message/sample1
+++ b/gitlint/tests/samples/commit_message/sample1
@@ -7,3 +7,8 @@ This line has a trailing tab.
 # ------------------------ >8 ------------------------
 # Anything after this line should be cleaned up
 # this line appears on `git commit -v` command
+diff --git a/gitlint/tests/samples/commit_message/sample1 b/gitlint/tests/samples/commit_message/sample1
+index 82dbe7f..ae71a14 100644
+--- a/gitlint/tests/samples/commit_message/sample1
++++ b/gitlint/tests/samples/commit_message/sample1
+@@ -1 +1 @@

--- a/gitlint/tests/samples/commit_message/sample1
+++ b/gitlint/tests/samples/commit_message/sample1
@@ -4,3 +4,6 @@ This is the first line of the commit message body and it is meant to test a line
 This line has a tråiling space. 
 This line has a trailing tab.	
 # This is a cömmented  line
+# ------------------------ >8 ------------------------
+# Anything after this line should be cleaned up
+# this line appears on `git commit -v` command

--- a/gitlint/tests/test_git.py
+++ b/gitlint/tests/test_git.py
@@ -126,7 +126,12 @@ class GitTests(BaseTestCase):
                          u"This line has a tråiling space. ",
                          "This line has a trailing tab.\t"]
         expected_full = expected_title + "\n" + "\n".join(expected_body)
-        expected_original = expected_full + u"\n# This is a cömmented  line\n"
+        expected_original = expected_full + (
+            u"\n# This is a cömmented  line\n"
+            u"# ------------------------ >8 ------------------------\n"
+            u"# Anything after this line should be cleaned up\n"
+            u"# this line appears on `git commit -v` command"
+        )
 
         commit = gitcontext.commits[-1]
         self.assertEqual(commit.message.title, expected_title)

--- a/gitlint/tests/test_git.py
+++ b/gitlint/tests/test_git.py
@@ -130,7 +130,13 @@ class GitTests(BaseTestCase):
             u"\n# This is a cömmented  line\n"
             u"# ------------------------ >8 ------------------------\n"
             u"# Anything after this line should be cleaned up\n"
-            u"# this line appears on `git commit -v` command"
+            u"# this line appears on `git commit -v` command\n"
+            u"diff --git a/gitlint/tests/samples/commit_message/sample1 "
+            u"b/gitlint/tests/samples/commit_message/sample1\n"
+            u"index 82dbe7f..ae71a14 100644\n"
+            u"--- a/gitlint/tests/samples/commit_message/sample1\n"
+            u"+++ b/gitlint/tests/samples/commit_message/sample1\n"
+            u"@@ -1 +1 @@\n"
         )
 
         commit = gitcontext.commits[-1]


### PR DESCRIPTION
Fix cleaning up commit message when `git commit -v` command used.

Git adds special cutline (scissors) when using with `-v` arg. Lines after this one will not be included to commit

See [--verbose arg description](https://git-scm.com/docs/git-commit#git-commit---verbose) and [scissors clean up](https://git-scm.com/docs/git-commit#git-commit-scissors) description in docs for details

Also add handle of custom comment char [see `core.commentChar` setting](https://git-scm.com/docs/git-config#git-config-corecommentChar)