### PR TITLE
Gitlint now correctly handles refspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog #
 
-## v0.8.3 (In Progress) ##
+## v0.9.0 (In Progress) ##
 
 - New Rule: ```author-valid-email``` enforces a valid author email address. Details can be found in the
   [Rules section of the documentation](http://jorisroovers.github.io/gitlint/rules/).
+- **Breaking change**: The ```--commits``` commandline flag now strictly follows the refspec format as interpreted
+  by the [```git rev-list <refspec>```](https://git-scm.com/docs/git-rev-list) command. This means
+  that linting a single commit using ```gitlint --commits <SHA>``` won't work anymore. Instead, for single commits,
+  users now need to specificy ```gitlint --commits <SHA>^...<SHA>```. On the upside, this change also means
+  that gitlint will now understand all refspec formatters, including ```gitlint --commits HEAD``` to lint all commits
+  in the repository.
 - Debug output improvements
 
 ## v0.8.2 (2017-04-25) ##

--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -100,7 +100,7 @@ def build_config(ctx, target, config_path, c, extra_path, ignore, verbose, silen
 @click.option('-c', multiple=True,
               help="Config flags in format <rule>.<option>=<value> (e.g.: -c T1.line-length=80). " +
                    "Flag can be used multiple times to set multiple config values.")  # pylint: disable=bad-continuation
-@click.option('--commits', default="HEAD", help="The range of commits to lint. [default: HEAD]")
+@click.option('--commits', default=None, help="The range of commits to lint. [default: HEAD]")
 @click.option('-e', '--extra-path', help="Path to a directory or python module with extra user-defined rules",
               type=click.Path(exists=True, resolve_path=True, readable=True))
 @click.option('--ignore', default="", help="Ignore rules (comma-separated by id or name).")

--- a/gitlint/tests/test_cli.py
+++ b/gitlint/tests/test_cli.py
@@ -73,15 +73,15 @@ class CLITests(BaseTestCase):
                                   u"commït-title2\n\ncommït-body2",
                                   u"test åuthor3,test-email3@föo.com,2016-12-05 15:28:15 01:00,åbc\n"
                                   u"commït-title3\n\ncommït-body3", ]
-        sh.git.side_effect = ["6f29bf81a8322a04071bb794666e48c443a90360\n" +
+        sh.git.side_effect = ["6f29bf81a8322a04071bb794666e48c443a90360\n" +  # git rev-list <SHA>
                               "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n" +
                               "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
-                              u"file1.txt\npåth/to/file2.txt\n",
+                              u"file1.txt\npåth/to/file2.txt\n",  # git diff-tree <SHA>
                               u"file4.txt\npåth/to/file5.txt\n",
                               u"file6.txt\npåth/to/file7.txt\n"]
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
-            result = self.cli.invoke(cli.cli)
+            result = self.cli.invoke(cli.cli, ["--commits", "foo...bar"])
             expected = (u"Commit 6f29bf81a8:\n"
                         u'3: B5 Body message is too short (12<20): "commït-body1"\n\n'
                         u"Commit 25053ccec5:\n"
@@ -104,15 +104,15 @@ class CLITests(BaseTestCase):
                                   u"commït-title2.\n\ncommït-body2\ngitlint-ignore: T3\n",
                                   u"test åuthor3,test-email3@föo.com,2016-12-05 15:28:15 01:00,åbc\n"
                                   u"commït-title3\n\ncommït-body3", ]
-        sh.git.side_effect = ["6f29bf81a8322a04071bb794666e48c443a90360\n" +
+        sh.git.side_effect = ["6f29bf81a8322a04071bb794666e48c443a90360\n" +  # git rev-list <SHA>
                               "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n" +
                               "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
-                              u"file1.txt\npåth/to/file2.txt\n",
+                              u"file1.txt\npåth/to/file2.txt\n",  # git diff-tree <SHA>
                               u"file4.txt\npåth/to/file5.txt\n",
                               u"file6.txt\npåth/to/file7.txt\n"]
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
-            result = self.cli.invoke(cli.cli)
+            result = self.cli.invoke(cli.cli, ["--commits", "foo...bar"])
             # We expect that the second commit has no failures because of 'gitlint-ignore: T3' in its commit msg body
             expected = (u"Commit 6f29bf81a8:\n"
                         u'3: B5 Body message is too short (12<20): "commït-body1"\n\n'
@@ -182,16 +182,17 @@ class CLITests(BaseTestCase):
                                   u"commït-title2.\n\ncommït-body2",
                                   u"test åuthor3,test-email3@föo.com,2016-12-05 15:28:15 01:00,abc\n"
                                   u"föo\nbar"]
-        sh.git.side_effect = ["6f29bf81a8322a04071bb794666e48c443a90360\n"
+        sh.git.side_effect = ["6f29bf81a8322a04071bb794666e48c443a90360\n"  # git rev-list <SHA>
                               "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n"
                               "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
-                              u"file1.txt\npåth/to/file2.txt\n",
+                              u"file1.txt\npåth/to/file2.txt\n",  # git diff-tree <SHA>
                               u"file4.txt\npåth/to/file5.txt\n",
                               u"file6.txt\npåth/to/file7.txt\n"]
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             config_path = self.get_sample_path("config/gitlintconfig")
-            result = self.cli.invoke(cli.cli, ["--config", config_path, "--debug"])
+            result = self.cli.invoke(cli.cli, ["--config", config_path, "--debug", "--commits",
+                                               "foo...bar"])
 
             expected = "Commit 6f29bf81a8:\n3: B5\n\n" + \
                        "Commit 25053ccec5:\n1: T3\n3: B5\n\n" + \
@@ -331,7 +332,7 @@ class CLITests(BaseTestCase):
     def test_git_error(self, sys, sh):
         """ Tests that the cli handles git errors properly """
         sys.stdin.isatty.return_value = True
-        sh.git.side_effect = CommandNotFound("git")
+        sh.git.log.side_effect = CommandNotFound("git")
         result = self.cli.invoke(cli.cli)
         self.assertEqual(result.exit_code, self.GIT_CONTEXT_ERROR_CODE)
 

--- a/qa/test_commits.py
+++ b/qa/test_commits.py
@@ -5,7 +5,8 @@ from qa.base import BaseTestCase
 
 
 class CommitsTests(BaseTestCase):
-    """ Integration tests for linting multiple commits at once """
+    """ Integration tests for the --commits argument, i.e. linting multiple commits at once or linting specific commits
+    """
 
     def test_successful(self):
         """ Test linting multiple commits without violations """
@@ -41,13 +42,34 @@ class CommitsTests(BaseTestCase):
         self.assertEqual(output.exit_code, 4)
         self.assertEqual(output, expected)
 
-    def test_single_commit(self):
+    def test_lint_single_commit(self):
         self._create_simple_commit(u"Sïmple title.\n")
         self._create_simple_commit(u"Sïmple title2.\n")
         commit_sha = self.get_last_commit_hash()
+        refspec = "{0}^...{0}".format(commit_sha)
         self._create_simple_commit(u"Sïmple title3.\n")
-        output = gitlint("--commits", commit_sha, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[2])
+        output = gitlint("--commits", refspec, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[2])
         expected = (u"1: T3 Title has trailing punctuation (.): \"Sïmple title2.\"\n" +
                     u"3: B6 Body message is missing\n")
         self.assertEqual(output.exit_code, 2)
+        self.assertEqual(output, expected)
+
+    def test_lint_head(self):
+        """ Testing whether we can also recognize special refs like 'HEAD' """
+        tmp_git_repo = self.create_tmp_git_repo()
+        self._create_simple_commit(u"Sïmple title.\n\nSimple bödy describing the commit", git_repo=tmp_git_repo)
+        self._create_simple_commit(u"Sïmple title", git_repo=tmp_git_repo)
+        self._create_simple_commit(u"WIP: Sïmple title\n\nSimple bödy describing the commit", git_repo=tmp_git_repo)
+        output = gitlint("--commits", "HEAD", _cwd=tmp_git_repo, _tty_in=True, _ok_code=[3])
+        revlist = git("rev-list", "HEAD", _tty_in=True, _cwd=tmp_git_repo).split()
+
+        expected = (
+            u"Commit {0}:\n".format(revlist[0][:10]) +
+            u"1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP: Sïmple title\"\n\n" +
+            u"Commit {0}:\n".format(revlist[1][:10]) +
+            u"3: B6 Body message is missing\n\n" +
+            u"Commit {0}:\n".format(revlist[2][:10]) +
+            u"1: T3 Title has trailing punctuation (.): \"Sïmple title.\"\n"
+        )
+
         self.assertEqual(output, expected)


### PR DESCRIPTION
Gitlint did not correctly handle all refspec formats that were supported
by `git rev-list`. It does now :)

This fixes #23.