### PR TITLE
Prevent Commas in text fields from breaking git log printing

### DIFF
--- a/gitlint/git.py
+++ b/gitlint/git.py
@@ -181,9 +181,10 @@ class GitContext(object):
 
         for sha in sha_list:
             # Get info from the local git repository: https://git-scm.com/docs/pretty-formats
-            raw_commit = _git("log", sha, "-1", "--pretty=%aN,%aE,%ai,%P%n%B", _cwd=repository_path).split("\n")
+            long_format = "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B"
+            raw_commit = _git("log", sha, "-1", long_format, _cwd=repository_path).split("\n")
 
-            (name, email, date, parents), commit_msg = raw_commit[0].split(","), "\n".join(raw_commit[1:])
+            (name, email, date, parents), commit_msg = raw_commit[0].split('\x00'), "\n".join(raw_commit[1:])
 
             commit_parents = parents.split(" ")
             commit_is_merge_commit = len(commit_parents) > 1

--- a/gitlint/tests/test_cli.py
+++ b/gitlint/tests/test_cli.py
@@ -50,7 +50,7 @@ class CLITests(BaseTestCase):
         sys.stdin.isatty.return_value = True
 
         sh.git.side_effect = ["6f29bf81a8322a04071bb794666e48c443a90360",
-                              u"test åuthor,test-email@föo.com,2016-12-03 15:28:15 01:00,åbc\n"
+                              u"test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               u"commït-title\n\ncommït-body",
                               u"file1.txt\npåth/to/file2.txt\n"]
 
@@ -69,13 +69,13 @@ class CLITests(BaseTestCase):
                               "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n" +
                               "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
                               # git log --pretty <FORMAT> <SHA>
-                              u"test åuthor1,test-email1@föo.com,2016-12-03 15:28:15 01 :00,åbc\n"
+                              u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01 :00\x00åbc\n"
                               u"commït-title1\n\ncommït-body1",
                               u"file1.txt\npåth/to/file2.txt\n",  # git diff-tree <SHA>
-                              u"test åuthor2,test-email3@föo.com,2016-12-04 15:28:15 01:00,åbc\n"
+                              u"test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 01:00\x00åbc\n"
                               u"commït-title2\n\ncommït-body2",
                               u"file4.txt\npåth/to/file5.txt\n",
-                              u"test åuthor3,test-email3@föo.com,2016-12-05 15:28:15 01:00,åbc\n"
+                              u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00åbc\n"
                               u"commït-title3\n\ncommït-body3",
                               u"file6.txt\npåth/to/file7.txt\n"]
 
@@ -101,13 +101,13 @@ class CLITests(BaseTestCase):
                               "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n" +
                               "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
                               # git log --pretty <FORMAT> <SHA>
-                              u"test åuthor1,test-email1@föo.com,2016-12-03 15:28:15 01:00,åbc\n"
+                              u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               u"commït-title1\n\ncommït-body1",
                               u"file1.txt\npåth/to/file2.txt\n",  # git diff-tree <SHA>
-                              u"test åuthor2,test-email3@föo.com,2016-12-04 15:28:15 01:00,åbc\n"
+                              u"test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 01:00\x00åbc\n"
                               u"commït-title2.\n\ncommït-body2\ngitlint-ignore: T3\n",
                               u"file4.txt\npåth/to/file5.txt\n",
-                              u"test åuthor3,test-email3@föo.com,2016-12-05 15:28:15 01:00,åbc\n"
+                              u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00åbc\n"
                               u"commït-title3\n\ncommït-body3",
                               u"file6.txt\npåth/to/file7.txt\n"]
 
@@ -179,13 +179,13 @@ class CLITests(BaseTestCase):
         sh.git.side_effect = ["6f29bf81a8322a04071bb794666e48c443a90360\n"  # git rev-list <SHA>
                               "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n"
                               "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
-                              u"test åuthor1,test-email1@föo.com,2016-12-03 15:28:15 01:00,abc\n"
+                              u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01:00\x00abc\n"
                               u"commït-title1\n\ncommït-body1",
                               u"file1.txt\npåth/to/file2.txt\n",
-                              u"test åuthor2,test-email2@föo.com,2016-12-04 15:28:15 01:00,abc\n"
+                              u"test åuthor2\x00test-email2@föo.com\x002016-12-04 15:28:15 01:00\x00abc\n"
                               u"commït-title2.\n\ncommït-body2",
                               u"file4.txt\npåth/to/file5.txt\n",
-                              u"test åuthor3,test-email3@föo.com,2016-12-05 15:28:15 01:00,abc\n"
+                              u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00abc\n"
                               u"föo\nbar",
                               u"file6.txt\npåth/to/file7.txt\n"]
 

--- a/gitlint/tests/test_git.py
+++ b/gitlint/tests/test_git.py
@@ -20,7 +20,7 @@ class GitTests(BaseTestCase):
         sample_sha = "d8ac47e9f2923c7f22d8668e3a1ed04eb4cdbca9"
 
         sh.git.side_effect = [sample_sha,
-                              u"test åuthor,test-emåil@foo.com,2016-12-03 15:28:15 01:00,åbc\n"
+                              u"test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               u"cömmit-title\n\ncömmit-body",
                               u"file1.txt\npåth/to/file2.txt\n"]
 
@@ -28,7 +28,7 @@ class GitTests(BaseTestCase):
         # assert that commit info was read using git command
         expected_calls = [
             call("log", "-1", "--pretty=%H", **self.expected_sh_special_args),
-            call("log", sample_sha, "-1", "--pretty=%aN,%aE,%ai,%P%n%B", **self.expected_sh_special_args),
+            call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
             call('diff-tree', '--no-commit-id', '--name-only', '-r', sample_sha, **self.expected_sh_special_args)
         ]
         self.assertListEqual(sh.git.mock_calls, expected_calls)
@@ -49,7 +49,7 @@ class GitTests(BaseTestCase):
         sample_sha = "myspecialref"
 
         sh.git.side_effect = [sample_sha,
-                              u"test åuthor,test-emåil@foo.com,2016-12-03 15:28:15 01:00,åbc\n"
+                              u"test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               u"cömmit-title\n\ncömmit-body",
                               u"file1.txt\npåth/to/file2.txt\n"]
 
@@ -57,7 +57,7 @@ class GitTests(BaseTestCase):
         # assert that commit info was read using git command
         expected_calls = [
             call("rev-list", sample_sha, **self.expected_sh_special_args),
-            call("log", sample_sha, "-1", "--pretty=%aN,%aE,%ai,%P%n%B", **self.expected_sh_special_args),
+            call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
             call('diff-tree', '--no-commit-id', '--name-only', '-r', sample_sha, **self.expected_sh_special_args)
         ]
         self.assertListEqual(sh.git.mock_calls, expected_calls)
@@ -78,7 +78,7 @@ class GitTests(BaseTestCase):
         sample_sha = "d8ac47e9f2923c7f22d8668e3a1ed04eb4cdbca9"
 
         sh.git.side_effect = [sample_sha,
-                              u"test åuthor,test-emåil@foo.com,2016-12-03 15:28:15 01:00,åbc def\n"
+                              u"test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 01:00\x00åbc def\n"
                               u"Merge \"foo bår commit\"",
                               u"file1.txt\npåth/to/file2.txt\n"]
 
@@ -86,7 +86,7 @@ class GitTests(BaseTestCase):
         # assert that commit info was read using git command
         expected_calls = [
             call("log", "-1", "--pretty=%H", **self.expected_sh_special_args),
-            call("log", sample_sha, "-1", "--pretty=%aN,%aE,%ai,%P%n%B", **self.expected_sh_special_args),
+            call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
             call('diff-tree', '--no-commit-id', '--name-only', '-r', sample_sha, **self.expected_sh_special_args)
         ]
 


### PR DESCRIPTION
We have had a few users with names formatted as "Surname, GivenName" that would cause git lint to error. In order to remedy this, I modified the delimiter to be a nul byte (which should never occur) for the git log --pretty command. 