### PR TITLE
Add --msg-filename option

### DIFF
--- a/gitlint/files/commit-msg
+++ b/gitlint/files/commit-msg
@@ -26,7 +26,7 @@ fi
 
 run_gitlint(){
    echo "gitlint: checking commit message..."
-   cat "$1" | python -m gitlint.cli
+   python -m gitlint.cli --msg-filename "$1"
    gitlint_exit_code=$?
 }
 


### PR DESCRIPTION
The --msg-filename option enables the following:
- Easier checking in a commit-msg hook without requiring a `cat` process.
- Easy integration with http://pre-commit.com

This is related to #38