### PR TITLE
No longer require a TTY connected to STDIN to read from local git repo

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -28,7 +28,7 @@ argument-rgx=[a-z_][a-z0-9_]{1,30}$
 method-rgx=([a-z_][a-z0-9_]{2,50}|setUp|tearDown)$
 
 # Allow 'id' as variable name everywhere
-good-names=id,c
+good-names=id,c,_
 
 bad-names=__author__
 

--- a/gitlint/tests/test_config_precedence.py
+++ b/gitlint/tests/test_config_precedence.py
@@ -19,7 +19,8 @@ class LintConfigPrecedenceTests(BaseTestCase):
     def setUp(self):
         self.cli = CliRunner()
 
-    def test_config_precedence(self):
+    @patch('gitlint.cli.stdin_has_data', return_value=True)
+    def test_config_precedence(self, _):
         # TODO(jroovers): this test really only test verbosity, we need to do some refactoring to gitlint.cli
         # to more easily test everything
         # Test that the config precedence is followed:
@@ -55,7 +56,8 @@ class LintConfigPrecedenceTests(BaseTestCase):
             self.assertEqual(result.output, "")
             self.assertEqual(stderr.getvalue(), "1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP\"\n")
 
-    def test_ignore_precedence(self):
+    @patch('gitlint.cli.stdin_has_data', return_value=True)
+    def test_ignore_precedence(self, _):
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             # --ignore takes precedence over -c general.ignore
             result = self.cli.invoke(cli.cli, ["-c", "general.ignore=T5", "--ignore", "B6"],

--- a/qa/base.py
+++ b/qa/base.py
@@ -48,7 +48,7 @@ class BaseTestCase(TestCase):
         git("config", "core.precomposeunicode", "true", _cwd=tmp_git_repo)
         return tmp_git_repo
 
-    def _create_simple_commit(self, message, out=None, ok_code=None, env=None, git_repo=None):
+    def _create_simple_commit(self, message, out=None, ok_code=None, env=None, git_repo=None, tty_in=False):
         """ Creates a simple commit with an empty test file.
             :param message: Commit message for the commit. """
 
@@ -69,7 +69,8 @@ class BaseTestCase(TestCase):
         if not ok_code:
             ok_code = [0]
 
-        git("commit", "-m", message, _cwd=git_repo, _tty_in=True, _out=out, _ok_code=ok_code, _env=environment)
+        git("commit", "-m", message, _cwd=git_repo, _err_to_out=True, _out=out, _tty_in=tty_in,
+            _ok_code=ok_code, _env=environment)
         return test_filename
 
     @staticmethod
@@ -84,11 +85,11 @@ class BaseTestCase(TestCase):
 
     def get_last_commit_short_hash(self, git_repo=None):
         git_repo = self.tmp_git_repo if git_repo is None else git_repo
-        return git("rev-parse", "--short", "HEAD", _cwd=git_repo, _tty_in=True).replace("\n", "")
+        return git("rev-parse", "--short", "HEAD", _cwd=git_repo, _err_to_out=True).replace("\n", "")
 
     def get_last_commit_hash(self, git_repo=None):
         git_repo = self.tmp_git_repo if git_repo is None else git_repo
-        return git("rev-parse", "HEAD", _cwd=git_repo, _tty_in=True).replace("\n", "")
+        return git("rev-parse", "HEAD", _cwd=git_repo, _err_to_out=True).replace("\n", "")
 
     @staticmethod
     def get_expected(filename="", variable_dict=None):

--- a/qa/test_commits.py
+++ b/qa/test_commits.py
@@ -16,7 +16,7 @@ class CommitsTests(BaseTestCase):
         self._create_simple_commit(u"Sïmple title2\n\nSimple bödy describing the commit2")
         self._create_simple_commit(u"Sïmple title3\n\nSimple bödy describing the commit3")
         output = gitlint("--commits", "test-branch-commits-base...test-branch-commits",
-                         _cwd=self.tmp_git_repo, _tty_in=True)
+                         _cwd=self.tmp_git_repo, _err_to_out=True)
         self.assertEqual(output, "")
 
     def test_violations(self):
@@ -30,7 +30,7 @@ class CommitsTests(BaseTestCase):
         self._create_simple_commit(u"Sïmple title3.\n")
         commit_sha2 = self.get_last_commit_hash()[:10]
         output = gitlint("--commits", "test-branch-commits-violations-base...test-branch-commits-violations",
-                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[4])
+                         _cwd=self.tmp_git_repo, _err_to_out=True, _ok_code=[4])
         expected = (u"Commit {0}:\n".format(commit_sha2) +
                     u"1: T3 Title has trailing punctuation (.): \"Sïmple title3.\"\n" +
                     u"3: B6 Body message is missing\n"
@@ -48,7 +48,7 @@ class CommitsTests(BaseTestCase):
         commit_sha = self.get_last_commit_hash()
         refspec = "{0}^...{0}".format(commit_sha)
         self._create_simple_commit(u"Sïmple title3.\n")
-        output = gitlint("--commits", refspec, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[2])
+        output = gitlint("--commits", refspec, _cwd=self.tmp_git_repo, _err_to_out=True, _ok_code=[2])
         expected = (u"1: T3 Title has trailing punctuation (.): \"Sïmple title2.\"\n" +
                     u"3: B6 Body message is missing\n")
         self.assertEqual(output.exit_code, 2)
@@ -60,8 +60,8 @@ class CommitsTests(BaseTestCase):
         self._create_simple_commit(u"Sïmple title.\n\nSimple bödy describing the commit", git_repo=tmp_git_repo)
         self._create_simple_commit(u"Sïmple title", git_repo=tmp_git_repo)
         self._create_simple_commit(u"WIP: Sïmple title\n\nSimple bödy describing the commit", git_repo=tmp_git_repo)
-        output = gitlint("--commits", "HEAD", _cwd=tmp_git_repo, _tty_in=True, _ok_code=[3])
-        revlist = git("rev-list", "HEAD", _tty_in=True, _cwd=tmp_git_repo).split()
+        output = gitlint("--commits", "HEAD", _cwd=tmp_git_repo, _err_to_out=True, _ok_code=[3])
+        revlist = git("rev-list", "HEAD", _err_to_out=True, _cwd=tmp_git_repo).split()
 
         expected = (
             u"Commit {0}:\n".format(revlist[0][:10]) +

--- a/qa/test_config.py
+++ b/qa/test_config.py
@@ -14,30 +14,30 @@ class ConfigTests(BaseTestCase):
 
     def test_ignore_by_id(self):
         self._create_simple_commit(u"WIP: Thïs is a title.\nContënt on the second line")
-        output = gitlint("--ignore", "T5,B4", _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[1])
+        output = gitlint("--ignore", "T5,B4", _cwd=self.tmp_git_repo, _err_to_out=True, _ok_code=[1])
         expected = u"1: T3 Title has trailing punctuation (.): \"WIP: Thïs is a title.\"\n"
         self.assertEqual(output, expected)
 
     def test_ignore_by_name(self):
         self._create_simple_commit(u"WIP: Thïs is a title.\nContënt on the second line")
         output = gitlint("--ignore", "title-must-not-contain-word,body-first-line-empty",
-                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[1])
+                         _cwd=self.tmp_git_repo, _err_to_out=True, _ok_code=[1])
         expected = u"1: T3 Title has trailing punctuation (.): \"WIP: Thïs is a title.\"\n"
         self.assertEqual(output, expected)
 
     def test_verbosity(self):
         self._create_simple_commit(u"WIP: Thïs is a title.\nContënt on the second line")
-        output = gitlint("-v", _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3])
+        output = gitlint("-v", _cwd=self.tmp_git_repo, _err_to_out=True, _ok_code=[3])
         expected = u"1: T3\n1: T5\n2: B4\n"
         self.assertEqual(output, expected)
 
-        output = gitlint("-vv", _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3])
+        output = gitlint("-vv", _cwd=self.tmp_git_repo, _err_to_out=True, _ok_code=[3])
         expected = u"1: T3 Title has trailing punctuation (.)\n" + \
                    u"1: T5 Title contains the word 'WIP' (case-insensitive)\n" + \
                    u"2: B4 Second line is not empty\n"
         self.assertEqual(output, expected)
 
-        output = gitlint("-vvv", _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3])
+        output = gitlint("-vvv", _cwd=self.tmp_git_repo, _err_to_out=True, _ok_code=[3])
         expected = u"1: T3 Title has trailing punctuation (.): \"WIP: Thïs is a title.\"\n" + \
                    u"1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP: Thïs is a title.\"\n" + \
                    u"2: B4 Second line is not empty: \"Contënt on the second line\"\n"
@@ -49,7 +49,7 @@ class ConfigTests(BaseTestCase):
 
     def test_set_rule_option(self):
         self._create_simple_commit(u"This ïs a title.")
-        output = gitlint("-c", "title-max-length.line-length=5", _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3])
+        output = gitlint("-c", "title-max-length.line-length=5", _cwd=self.tmp_git_repo, _err_to_out=True, _ok_code=[3])
         expected = u"1: T1 Title exceeds max length (16>5): \"This ïs a title.\"\n" + \
                    u"1: T3 Title has trailing punctuation (.): \"This ïs a title.\"\n" + \
                    "3: B6 Body message is missing\n"
@@ -60,7 +60,7 @@ class ConfigTests(BaseTestCase):
                      "This line of the body is here because we need it"
         self._create_simple_commit(commit_msg)
         config_path = self.get_sample_path("config/gitlintconfig")
-        output = gitlint("--config", config_path, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[5])
+        output = gitlint("--config", config_path, _cwd=self.tmp_git_repo, _err_to_out=True, _ok_code=[5])
 
         expected = "1: T1 Title exceeds max length (42>20)\n" + \
                    "1: T5 Title contains the word 'WIP' (case-insensitive)\n" + \
@@ -76,7 +76,7 @@ class ConfigTests(BaseTestCase):
         self._create_simple_commit(commit_msg)
         commit_sha = self.get_last_commit_hash()
         config_path = self.get_sample_path("config/gitlintconfig")
-        output = gitlint("--config", config_path, "--debug", _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[5])
+        output = gitlint("--config", config_path, "--debug", _cwd=self.tmp_git_repo, _err_to_out=True, _ok_code=[5])
 
         expected_date = git("log", "-1", "--pretty=%ai", _cwd=self.tmp_git_repo)
         expected_date = arrow.get(str(expected_date), "YYYY-MM-DD HH:mm:ss Z").datetime

--- a/qa/test_hooks.py
+++ b/qa/test_hooks.py
@@ -51,7 +51,7 @@ class HookTests(BaseTestCase):
     def test_commit_hook_continue(self):
         self.responses = ["y"]
         test_filename = self._create_simple_commit(u"WIP: This ïs a title.\nContënt on the second line",
-                                                   out=self._interact)
+                                                   out=self._interact, tty_in=True)
 
         # Determine short commit-msg hash, needed to determine expected output
         short_hash = git("rev-parse", "--short", "HEAD", _cwd=self.tmp_git_repo, _tty_in=True).replace("\n", "")
@@ -69,7 +69,7 @@ class HookTests(BaseTestCase):
     def test_commit_hook_abort(self):
         self.responses = ["n"]
         test_filename = self._create_simple_commit(u"WIP: This ïs a title.\nContënt on the second line",
-                                                   out=self._interact, ok_code=1)
+                                                   out=self._interact, ok_code=1, tty_in=True)
         git("rm", "-f", test_filename, _cwd=self.tmp_git_repo)
 
         # Determine short commit-msg hash, needed to determine expected output
@@ -90,7 +90,7 @@ class HookTests(BaseTestCase):
         self.responses = ["e", "y"]
         env = {"EDITOR": ":"}
         test_filename = self._create_simple_commit(u"WIP: This ïs a title.\nContënt on the second line",
-                                                   out=self._interact, env=env, ok_code=1)
+                                                   out=self._interact, env=env, ok_code=1, tty_in=True)
         git("rm", "-f", test_filename, _cwd=self.tmp_git_repo)
 
         short_hash = git("rev-parse", "--short", "HEAD", _cwd=self.tmp_git_repo, _tty_in=True).replace("\n", "")

--- a/qa/test_user_defined.py
+++ b/qa/test_user_defined.py
@@ -11,7 +11,7 @@ class UserDefinedRuleTests(BaseTestCase):
         extra_path = self.get_example_path()
         commit_msg = u"WIP: Thi$ is å title\nContent on the second line"
         self._create_simple_commit(commit_msg)
-        output = gitlint("--extra-path", extra_path, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[4])
+        output = gitlint("--extra-path", extra_path, _cwd=self.tmp_git_repo, _err_to_out=True, _ok_code=[4])
         expected = u"1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP: Thi$ is å title\"\n" + \
                    "1: UC2 Body does not contain a 'Signed-Off-By' line\n" + \
                    u"1: UL1 Title contains the special character '$': \"WIP: Thi$ is å title\"\n" + \
@@ -23,7 +23,7 @@ class UserDefinedRuleTests(BaseTestCase):
         commit_msg = u"WIP: Thi$ is å title\nContent on the second line"
         self._create_simple_commit(commit_msg)
         output = gitlint("--extra-path", extra_path, "-c", "body-max-line-count.max-line-count=1",
-                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[5])
+                         _cwd=self.tmp_git_repo, _err_to_out=True, _ok_code=[5])
         expected = u"1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP: Thi$ is å title\"\n" + \
                    "1: UC1 Body contains too many lines (2 > 1)\n" + \
                    "1: UC2 Body does not contain a 'Signed-Off-By' line\n" + \
@@ -35,6 +35,6 @@ class UserDefinedRuleTests(BaseTestCase):
     def test_invalid_user_defined_rules(self):
         extra_path = self.get_sample_path("user_rules/incorrect_linerule")
         self._create_simple_commit("WIP: test")
-        output = gitlint("--extra-path", extra_path, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[255])
+        output = gitlint("--extra-path", extra_path, _cwd=self.tmp_git_repo, _err_to_out=True, _ok_code=[255])
         self.assertEqual(output,
                          "Config Error: User-defined rule class 'MyUserLineRule' must have a 'validate' method\n")


### PR DESCRIPTION
Before this commit, gitlint defaulted to reading the latest commit message
from the local git repository when it found a TTY connected to STDIN,
falling back to reading from STDIN in all other cases.

With this commit, gitlint will do the opposite which is more sane: it will
only read from STDIN in case there's input on STDIN, falling back to reading
from the local git repo in all other cases.

This is especially useful for environments where there is no TTY attached to
STDIN like in many CI environments.

This fixes #40, #42.