### PR TITLE
Exit silently when the specified commit range is empty

### DIFF
--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -168,7 +168,6 @@ def lint(ctx):
     # where users are using --commits in a check job to check the commit messages inside a CI job. By returning 0, we
     # ensure that these jobs don't fail if for whatever reason the specified commit range is empty.
     if number_of_commits == 0:
-        click.echo(u'No commits in range "{0}".'.format(ctx.obj[2]))
         ctx.exit(0)
 
     general_config_builder = ctx.obj[1]

--- a/gitlint/tests/test_cli.py
+++ b/gitlint/tests/test_cli.py
@@ -340,8 +340,6 @@ class CLITests(BaseTestCase):
         """ Test for --commits with the specified range being empty. """
         sh.git.side_effect = lambda *_args, **_kwargs: ""
         result = self.cli.invoke(cli.cli, ["--commits", "master...HEAD"])
-        expected = u'No commits in range "master...HEAD".\n'
-        self.assertEqual(result.output, expected)
         self.assertEqual(result.exit_code, 0)
 
     @patch('gitlint.hooks.GitHookInstaller.install_commit_msg_hook')


### PR DESCRIPTION
Reduce confusion on whether the lint check is successful/failed.