### PR TITLE
Fix failing on existing Git comment char

### DIFF
--- a/gitlint/git.py
+++ b/gitlint/git.py
@@ -51,7 +51,7 @@ def git_commentchar():
     """ Shortcut for retrieving comment char from git config """
     commentchar = _git("config", "--get", "core.commentchar", _ok_code=[1])
     # git will return an exit code of 1 if it can't find a config value, in this case we fall-back to # as commentchar
-    if commentchar.exit_code == 1:  # pylint: disable=no-member
+    if hasattr(commentchar, 'exit_code') and commentchar.exit_code == 1:  # pylint: disable=no-member
         commentchar = "#"
     return ustr(commentchar).replace(u"\n", u"")
 

--- a/gitlint/tests/test_git.py
+++ b/gitlint/tests/test_git.py
@@ -345,6 +345,9 @@ class GitTests(BaseTestCase):
         git.return_value.__unicode__ = lambda _: u"ä"
         self.assertEqual(git_commentchar(), u"ä")
 
+        git.return_value = ';\n'
+        self.assertEqual(git_commentchar(), ';')
+
     def test_commit_msg_custom_commentchar(self):
         with patch.object(GitCommitMessage, 'COMMENT_CHAR', new_callable=PropertyMock) as comment_char_mock:
             comment_char_mock.return_value = u"ä"


### PR DESCRIPTION
As soon as _git function returns string if it was executed (not sh.RunningCommand) **get_commentchar**
functions fails with AttributeError (could not get exit_code).