### PR TITLE
Enforce English in test_target

### DIFF
--- a/gitlint/tests/test_cli.py
+++ b/gitlint/tests/test_cli.py
@@ -283,6 +283,7 @@ class CLITests(BaseTestCase):
     @patch('gitlint.cli.stdin_has_data', return_value=False)
     def test_target(self, _):
         """ Test for the --target option """
+        os.environ["LANGUAGE"] = "C"
         result = self.cli.invoke(cli.cli, ["--target", "/tmp"])
         # We expect gitlint to tell us that /tmp is not a git repo (this proves that it takes the target parameter
         # into account).


### PR DESCRIPTION
The test_target test case calls git and expect a certain error message in English. If a different languages is use, git might produce a translated error message that does not match the expected error message. Therefore set the environment variable `LANGUAGE=C`.