### PR TITLE
Fix stdin_has_data()

### DIFF
--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import platform
-import select
+import stat
 import sys
 
 import click
@@ -94,16 +94,12 @@ def build_config(ctx, target, config_path, c, extra_path, ignore, verbose, silen
 
 
 def stdin_has_data():
-    """ Helper function that indicates whether the stdin has data incoming or not """
-    # This code was taken from:
-    # https://stackoverflow.com/questions/3762881/how-do-i-check-if-stdin-has-some-data
+    """ Helper function that indicates whether the stdin has data incoming or not
 
-    # Caveat, this probably doesn't work on Windows because the code is dependent on the unix SELECT syscall.
-    # Details: https://docs.python.org/2/library/select.html#select.select
-    # This isn't a real problem now, because gitlint as a whole doesn't support Windows (see #20).
-    # If we ever do, we probably want to fall back to the old detection mechanism of reading from the local git repo
-    # in case there's no TTY connected to STDIN.
-    return select.select([sys.stdin, ], [], [], 0.0)[0]
+    Read from stdin if that device is a pipe or a redirect.
+    """
+    mode = os.fstat(sys.stdin.fileno()).st_mode
+    return stat.S_ISFIFO(mode) or stat.S_ISREG(mode)
 
 
 @click.group(invoke_without_command=True, epilog="When no COMMAND is specified, gitlint defaults to 'gitlint lint'.")


### PR DESCRIPTION
When calling gitlint in a custom git commit hook on a gitlab server, stdin_has_data() will always return True regardless whether gitlint is called directly or text is piped into it. To reproduce you can call this
script:

```python
#!/usr/bin/python3

import sys
import stat
import os

if sys.stdin.isatty():
    print("Input comes from tty.")
else:
    print("Input doesn't come from tty.")

mode = os.fstat(sys.stdin.fileno()).st_mode
if stat.S_ISFIFO(mode):
    print("stdin is piped")
elif stat.S_ISREG(mode):
    print("stdin is redirected")
else:
    print("stdin is terminal")
```

On my server it prints:

```
Input doesn't come from tty.
stdin is terminal
```

stdin should only be read if the user uses a pipe or a redirect to pass data in.