### PR TITLE
Change formatting

### DIFF
--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -172,10 +172,8 @@ def lint(ctx):
         ctx.exit(0)
 
     general_config_builder = ctx.obj[1]
-    last_commit = gitcontext.commits[-1]
 
     # Let's get linting!
-    first_violation = True
     exit_code = 0
     for commit in gitcontext.commits:
         # Build a config_builder and linter taking into account the commit specific config (if any)
@@ -189,14 +187,7 @@ def lint(ctx):
         # exit code equals the total number of violations in all commits
         exit_code += len(violations)
         if violations:
-            # Display the commit hash & new lines intelligently
-            if number_of_commits > 1 and commit.sha:
-                linter.display.e(u"{0}Commit {1}:".format(
-                    "\n" if not first_violation or commit is last_commit else "",
-                    commit.sha[:10]
-                ))
-            linter.print_violations(violations)
-            first_violation = False
+            linter.print_violations(commit.sha if commit else None, violations)
 
     # cap actual max exit code because bash doesn't like exit codes larger than 255:
     # http://tldp.org/LDP/abs/html/exitcodes.html

--- a/gitlint/lint.py
+++ b/gitlint/lint.py
@@ -84,14 +84,15 @@ class GitLinter(object):
         violations.sort(key=lambda v: (-1 if v.line_nr is None else v.line_nr, v.rule_id))
         return violations
 
-    def print_violations(self, violations):
+    def print_violations(self, commit_sha, violations):
         """ Print a given set of violations to the standard error output """
+        commit = "Commit {0}: ".format(commit_sha[:10]) if commit_sha else ""
         for v in violations:
             line_nr = v.line_nr if v.line_nr else "-"
-            self.display.e(u"{0}: {1}".format(line_nr, v.rule_id), exact=True)
-            self.display.ee(u"{0}: {1} {2}".format(line_nr, v.rule_id, v.message), exact=True)
+            self.display.e(u"{0}{1}: {2}".format(commit, line_nr, v.rule_id), exact=True)
+            self.display.ee(u"{0}{1}: {2} {3}".format(commit, line_nr, v.rule_id, v.message), exact=True)
             if v.content:
-                self.display.eee(u"{0}: {1} {2}: \"{3}\"".format(line_nr, v.rule_id, v.message, v.content),
+                self.display.eee(u"{0}{1}: {2} {3}: \"{4}\"".format(commit, line_nr, v.rule_id, v.message, v.content),
                                  exact=True)
             else:
-                self.display.eee(u"{0}: {1} {2}".format(line_nr, v.rule_id, v.message), exact=True)
+                self.display.eee(u"{0}{1}: {2} {3}".format(commit, line_nr, v.rule_id, v.message), exact=True)

--- a/gitlint/lint.py
+++ b/gitlint/lint.py
@@ -88,11 +88,11 @@ class GitLinter(object):
         """ Print a given set of violations to the standard error output """
         commit = "Commit {0}: ".format(commit_sha[:10]) if commit_sha else ""
         for v in violations:
-            line_nr = v.line_nr if v.line_nr else "-"
-            self.display.e(u"{0}{1}: {2}".format(commit, line_nr, v.rule_id), exact=True)
-            self.display.ee(u"{0}{1}: {2} {3}".format(commit, line_nr, v.rule_id, v.message), exact=True)
+            line_nr = "line {}: ".format(v.line_nr) if v.line_nr else ""
+            self.display.e(u"{0}{1}{2}".format(commit, line_nr, v.rule_id), exact=True)
+            self.display.ee(u"{0}{1}{2} {3}".format(commit, line_nr, v.rule_id, v.message), exact=True)
             if v.content:
-                self.display.eee(u"{0}{1}: {2} {3}: \"{4}\"".format(commit, line_nr, v.rule_id, v.message, v.content),
+                self.display.eee(u"{0}{1}{2} {3}: \"{4}\"".format(commit, line_nr, v.rule_id, v.message, v.content),
                                  exact=True)
             else:
-                self.display.eee(u"{0}{1}: {2} {3}".format(commit, line_nr, v.rule_id, v.message), exact=True)
+                self.display.eee(u"{0}{1}{2} {3}".format(commit, line_nr, v.rule_id, v.message), exact=True)

--- a/gitlint/tests/test_cli.py
+++ b/gitlint/tests/test_cli.py
@@ -63,7 +63,7 @@ class CLITests(BaseTestCase):
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli)
             self.assertEqual(stderr.getvalue(),
-                             u'Commit 6f29bf81a8: 3: B5 Body message is too short (11<20): "commït-body"\n')
+                             u'Commit 6f29bf81a8: line 3: B5 Body message is too short (11<20): "commït-body"\n')
             self.assertEqual(result.exit_code, 1)
 
     @patch('gitlint.cli.stdin_has_data', return_value=False)
@@ -87,9 +87,9 @@ class CLITests(BaseTestCase):
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--commits", "foo...bar"])
-            expected = (u'Commit 6f29bf81a8: 3: B5 Body message is too short (12<20): "commït-body1"\n'
-                        u'Commit 25053ccec5: 3: B5 Body message is too short (12<20): "commït-body2"\n'
-                        u'Commit 4da2656b0d: 3: B5 Body message is too short (12<20): "commït-body3"\n')
+            expected = (u'Commit 6f29bf81a8: line 3: B5 Body message is too short (12<20): "commït-body1"\n'
+                        u'Commit 25053ccec5: line 3: B5 Body message is too short (12<20): "commït-body2"\n'
+                        u'Commit 4da2656b0d: line 3: B5 Body message is too short (12<20): "commït-body3"\n')
             self.assertEqual(stderr.getvalue(), expected)
             self.assertEqual(result.exit_code, 3)
 
@@ -116,17 +116,17 @@ class CLITests(BaseTestCase):
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--commits", "foo...bar"])
             # We expect that the second commit has no failures because of 'gitlint-ignore: T3' in its commit msg body
-            expected = (u'Commit 6f29bf81a8: 3: B5 Body message is too short (12<20): "commït-body1"\n'
-                        u'Commit 4da2656b0d: 3: B5 Body message is too short (12<20): "commït-body3"\n')
+            expected = (u'Commit 6f29bf81a8: line 3: B5 Body message is too short (12<20): "commït-body1"\n'
+                        u'Commit 4da2656b0d: line 3: B5 Body message is too short (12<20): "commït-body3"\n')
             self.assertEqual(stderr.getvalue(), expected)
             self.assertEqual(result.exit_code, 2)
 
     @patch('gitlint.cli.stdin_has_data', return_value=True)
     def test_input_stream(self, _):
         """ Test for linting when a message is passed via stdin """
-        expected_output = u"1: T2 Title has trailing whitespace: \"WIP: tïtle \"\n" + \
-                          u"1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP: tïtle \"\n" + \
-                          u"3: B6 Body message is missing\n"
+        expected_output = u"line 1: T2 Title has trailing whitespace: \"WIP: tïtle \"\n" + \
+                          u"line 1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP: tïtle \"\n" + \
+                          u"line 3: B6 Body message is missing\n"
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, input=u'WIP: tïtle \n')
@@ -150,14 +150,14 @@ class CLITests(BaseTestCase):
         # -v
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["-v"], input=u"WIP: tïtle \n")
-            self.assertEqual(stderr.getvalue(), "1: T2\n1: T5\n3: B6\n")
+            self.assertEqual(stderr.getvalue(), "line 1: T2\nline 1: T5\nline 3: B6\n")
             self.assertEqual(result.exit_code, 3)
             self.assertEqual(result.output, "")
 
         # -vv
-        expected_output = "1: T2 Title has trailing whitespace\n" + \
-                          "1: T5 Title contains the word 'WIP' (case-insensitive)\n" + \
-                          "3: B6 Body message is missing\n"
+        expected_output = "line 1: T2 Title has trailing whitespace\n" + \
+                          "line 1: T5 Title contains the word 'WIP' (case-insensitive)\n" + \
+                          "line 3: B6 Body message is missing\n"
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["-vv"], input=u"WIP: tïtle \n")
@@ -195,12 +195,12 @@ class CLITests(BaseTestCase):
             result = self.cli.invoke(cli.cli, ["--config", config_path, "--debug", "--commits",
                                                "foo...bar"])
 
-            expected = ("Commit 6f29bf81a8: 3: B5\n"
-                        "Commit 25053ccec5: 1: T3\n"
-                        "Commit 25053ccec5: 3: B5\n"
-                        "Commit 4da2656b0d: 2: B4\n"
-                        "Commit 4da2656b0d: 3: B5\n"
-                        "Commit 4da2656b0d: 3: B6\n")
+            expected = ("Commit 6f29bf81a8: line 3: B5\n"
+                        "Commit 25053ccec5: line 1: T3\n"
+                        "Commit 25053ccec5: line 3: B5\n"
+                        "Commit 4da2656b0d: line 2: B4\n"
+                        "Commit 4da2656b0d: line 3: B5\n"
+                        "Commit 4da2656b0d: line 3: B6\n")
 
             self.assertEqual(stderr.getvalue(), expected)
             self.assertEqual(result.exit_code, 6)
@@ -232,8 +232,8 @@ class CLITests(BaseTestCase):
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             extra_path = self.get_sample_path("user_rules")
             result = self.cli.invoke(cli.cli, ["--extra-path", extra_path, "--debug"], input=u"Test tïtle\n")
-            expected_output = u"1: UC1 Commit violåtion 1: \"Contënt 1\"\n" + \
-                              "3: B6 Body message is missing\n"
+            expected_output = u"line 1: UC1 Commit violåtion 1: \"Contënt 1\"\n" + \
+                              "line 3: B6 Body message is missing\n"
             self.assertEqual(stderr.getvalue(), expected_output)
             self.assertEqual(result.exit_code, 2)
 
@@ -241,8 +241,8 @@ class CLITests(BaseTestCase):
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             extra_path = self.get_sample_path("user_rules/my_commit_rules.py")
             result = self.cli.invoke(cli.cli, ["--extra-path", extra_path, "--debug"], input=u"Test tïtle\n")
-            expected_output = u"1: UC1 Commit violåtion 1: \"Contënt 1\"\n" + \
-                              "3: B6 Body message is missing\n"
+            expected_output = u"line 1: UC1 Commit violåtion 1: \"Contënt 1\"\n" + \
+                              "line 3: B6 Body message is missing\n"
             self.assertEqual(stderr.getvalue(), expected_output)
             self.assertEqual(result.exit_code, 2)
 
@@ -253,7 +253,7 @@ class CLITests(BaseTestCase):
             config_path = self.get_sample_path("config/gitlintconfig")
             result = self.cli.invoke(cli.cli, ["--config", config_path], input=u"WIP: tëst")
             self.assertEqual(result.output, "")
-            self.assertEqual(stderr.getvalue(), "1: T5\n3: B6\n")
+            self.assertEqual(stderr.getvalue(), "line 1: T5\nline 3: B6\n")
             self.assertEqual(result.exit_code, 2)
 
     def test_config_file_negative(self):

--- a/gitlint/tests/test_cli.py
+++ b/gitlint/tests/test_cli.py
@@ -62,7 +62,8 @@ class CLITests(BaseTestCase):
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli)
-            self.assertEqual(stderr.getvalue(), u'3: B5 Body message is too short (11<20): "commït-body"\n')
+            self.assertEqual(stderr.getvalue(),
+                             u'Commit 6f29bf81a8: 3: B5 Body message is too short (11<20): "commït-body"\n')
             self.assertEqual(result.exit_code, 1)
 
     @patch('gitlint.cli.stdin_has_data', return_value=False)
@@ -86,12 +87,9 @@ class CLITests(BaseTestCase):
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--commits", "foo...bar"])
-            expected = (u"Commit 6f29bf81a8:\n"
-                        u'3: B5 Body message is too short (12<20): "commït-body1"\n\n'
-                        u"Commit 25053ccec5:\n"
-                        u'3: B5 Body message is too short (12<20): "commït-body2"\n\n'
-                        u"Commit 4da2656b0d:\n"
-                        u'3: B5 Body message is too short (12<20): "commït-body3"\n')
+            expected = (u'Commit 6f29bf81a8: 3: B5 Body message is too short (12<20): "commït-body1"\n'
+                        u'Commit 25053ccec5: 3: B5 Body message is too short (12<20): "commït-body2"\n'
+                        u'Commit 4da2656b0d: 3: B5 Body message is too short (12<20): "commït-body3"\n')
             self.assertEqual(stderr.getvalue(), expected)
             self.assertEqual(result.exit_code, 3)
 
@@ -118,10 +116,8 @@ class CLITests(BaseTestCase):
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--commits", "foo...bar"])
             # We expect that the second commit has no failures because of 'gitlint-ignore: T3' in its commit msg body
-            expected = (u"Commit 6f29bf81a8:\n"
-                        u'3: B5 Body message is too short (12<20): "commït-body1"\n\n'
-                        u"Commit 4da2656b0d:\n"
-                        u'3: B5 Body message is too short (12<20): "commït-body3"\n')
+            expected = (u'Commit 6f29bf81a8: 3: B5 Body message is too short (12<20): "commït-body1"\n'
+                        u'Commit 4da2656b0d: 3: B5 Body message is too short (12<20): "commït-body3"\n')
             self.assertEqual(stderr.getvalue(), expected)
             self.assertEqual(result.exit_code, 2)
 
@@ -199,9 +195,12 @@ class CLITests(BaseTestCase):
             result = self.cli.invoke(cli.cli, ["--config", config_path, "--debug", "--commits",
                                                "foo...bar"])
 
-            expected = "Commit 6f29bf81a8:\n3: B5\n\n" + \
-                       "Commit 25053ccec5:\n1: T3\n3: B5\n\n" + \
-                       "Commit 4da2656b0d:\n2: B4\n3: B5\n3: B6\n"
+            expected = ("Commit 6f29bf81a8: 3: B5\n"
+                        "Commit 25053ccec5: 1: T3\n"
+                        "Commit 25053ccec5: 3: B5\n"
+                        "Commit 4da2656b0d: 2: B4\n"
+                        "Commit 4da2656b0d: 3: B5\n"
+                        "Commit 4da2656b0d: 3: B6\n")
 
             self.assertEqual(stderr.getvalue(), expected)
             self.assertEqual(result.exit_code, 6)

--- a/gitlint/tests/test_config_precedence.py
+++ b/gitlint/tests/test_config_precedence.py
@@ -42,25 +42,27 @@ class LintConfigPrecedenceTests(BaseTestCase):
             result = self.cli.invoke(cli.cli, ["-vvv", "-c", "general.verbosity=2", "--config", config_path],
                                      input=input_text)
             self.assertEqual(result.output, "")
-            self.assertEqual(stderr.getvalue(), "1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP\"\n")
+            self.assertEqual(stderr.getvalue(),
+                             "line 1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP\"\n")
 
         # 2. commandline -c flags
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["-c", "general.verbosity=2", "--config", config_path], input=input_text)
             self.assertEqual(result.output, "")
-            self.assertEqual(stderr.getvalue(), "1: T5 Title contains the word 'WIP' (case-insensitive)\n")
+            self.assertEqual(stderr.getvalue(), "line 1: T5 Title contains the word 'WIP' (case-insensitive)\n")
 
         # 3. config file
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--config", config_path], input=input_text)
             self.assertEqual(result.output, "")
-            self.assertEqual(stderr.getvalue(), "1: T5\n")
+            self.assertEqual(stderr.getvalue(), "line 1: T5\n")
 
         # 4. default config
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, input=input_text)
             self.assertEqual(result.output, "")
-            self.assertEqual(stderr.getvalue(), "1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP\"\n")
+            self.assertEqual(stderr.getvalue(),
+                             "line 1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP\"\n")
 
     @patch('gitlint.cli.stdin_has_data', return_value=True)
     def test_ignore_precedence(self, _):
@@ -72,7 +74,7 @@ class LintConfigPrecedenceTests(BaseTestCase):
             self.assertEqual(result.exit_code, 1)
             # We still expect the T5 violation, but no B6 violation as --ignore overwrites -c general.ignore
             self.assertEqual(stderr.getvalue(),
-                             u"1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP: This is å test\"\n")
+                             u"line 1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP: This is å test\"\n")
 
         # test that we can also still configure a rule that is first ignored but then not
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
@@ -85,7 +87,7 @@ class LintConfigPrecedenceTests(BaseTestCase):
 
             # We still expect the T1 violation with custom config,
             # but no B6 violation as --ignore overwrites -c general.ignore
-            self.assertEqual(stderr.getvalue(), u"1: T1 Title exceeds max length (14>5): \"This is å test\"\n")
+            self.assertEqual(stderr.getvalue(), u"line 1: T1 Title exceeds max length (14>5): \"This is å test\"\n")
 
     def test_general_option_after_rule_option(self):
         # We used to have a bug where we didn't process general options before setting specific options, this would

--- a/gitlint/tests/test_lint.py
+++ b/gitlint/tests/test_lint.py
@@ -157,18 +157,18 @@ class LintTests(BaseTestCase):
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             linter.config.verbosity = 1
             linter.print_violations("1234", violations)
-            expected = u"Commit 1234: -: RULE_ID_1\nCommit 1234: 2: RULE_ID_2\n"
+            expected = u"Commit 1234: RULE_ID_1\nCommit 1234: line 2: RULE_ID_2\n"
             self.assertEqual(expected, stderr.getvalue())
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             linter.config.verbosity = 2
             linter.print_violations("1234", violations)
-            expected = u"Commit 1234: -: RULE_ID_1 Error Messåge 1\nCommit 1234: 2: RULE_ID_2 Error Message 2\n"
+            expected = u"Commit 1234: RULE_ID_1 Error Messåge 1\nCommit 1234: line 2: RULE_ID_2 Error Message 2\n"
             self.assertEqual(expected, stderr.getvalue())
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             linter.config.verbosity = 3
             linter.print_violations("1234", violations)
-            expected = (u"Commit 1234: -: RULE_ID_1 Error Messåge 1: \"Violating Content 1\"\n"
-                        u"Commit 1234: 2: RULE_ID_2 Error Message 2: \"Violåting Content 2\"\n")
+            expected = (u"Commit 1234: RULE_ID_1 Error Messåge 1: \"Violating Content 1\"\n"
+                        u"Commit 1234: line 2: RULE_ID_2 Error Message 2: \"Violåting Content 2\"\n")
             self.assertEqual(expected, stderr.getvalue())

--- a/gitlint/tests/test_lint.py
+++ b/gitlint/tests/test_lint.py
@@ -151,24 +151,24 @@ class LintTests(BaseTestCase):
         # test output with increasing verbosity
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             linter.config.verbosity = 0
-            linter.print_violations(violations)
+            linter.print_violations("1234", violations)
             self.assertEqual("", stderr.getvalue())
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             linter.config.verbosity = 1
-            linter.print_violations(violations)
-            expected = u"-: RULE_ID_1\n2: RULE_ID_2\n"
+            linter.print_violations("1234", violations)
+            expected = u"Commit 1234: -: RULE_ID_1\nCommit 1234: 2: RULE_ID_2\n"
             self.assertEqual(expected, stderr.getvalue())
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             linter.config.verbosity = 2
-            linter.print_violations(violations)
-            expected = u"-: RULE_ID_1 Error Messåge 1\n2: RULE_ID_2 Error Message 2\n"
+            linter.print_violations("1234", violations)
+            expected = u"Commit 1234: -: RULE_ID_1 Error Messåge 1\nCommit 1234: 2: RULE_ID_2 Error Message 2\n"
             self.assertEqual(expected, stderr.getvalue())
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             linter.config.verbosity = 3
-            linter.print_violations(violations)
-            expected = u"-: RULE_ID_1 Error Messåge 1: \"Violating Content 1\"\n" + \
-                       u"2: RULE_ID_2 Error Message 2: \"Violåting Content 2\"\n"
+            linter.print_violations("1234", violations)
+            expected = (u"Commit 1234: -: RULE_ID_1 Error Messåge 1: \"Violating Content 1\"\n"
+                        u"Commit 1234: 2: RULE_ID_2 Error Message 2: \"Violåting Content 2\"\n")
             self.assertEqual(expected, stderr.getvalue())


### PR DESCRIPTION
We want to use gitlint in our company and therefore the error output should be self explaining. The first commit prints the commit hash on every line (to make the output shorter) and the second adds 'line' to the line number, because that is not intuitive.