### PR TITLE
Add regex for commit title that skips body checks, if matches

### DIFF
--- a/gitlint/config.py
+++ b/gitlint/config.py
@@ -254,7 +254,7 @@ class LintConfig(object):
         return_str += u"[RULES]\n"
         for rule in self.rules:
             return_str += u"  {0}: {1}\n".format(rule.id, rule.name)
-            for option_name, option_value in rule.options.items():
+            for option_name, option_value in sorted(rule.options.items()):
                 if isinstance(option_value.value, list):
                     option_val_repr = ",".join(option_value.value)
                 else:

--- a/gitlint/files/gitlint
+++ b/gitlint/files/gitlint
@@ -44,6 +44,7 @@
 
 # [body-min-length]
 # min-length=5
+# ignore-body-checks-regex=''
 
 # [body-is-missing]
 # Whether to ignore this rule on merge commits (which typically only have a title)

--- a/gitlint/rules.py
+++ b/gitlint/rules.py
@@ -81,14 +81,14 @@ class RuleViolation(object):
         return equal
 
     def __str__(self):
-        return sstr(self)  # pragma: no cover
+        return self.__unicode__()  # pragma: no cover
 
     def __unicode__(self):
         return u"{0}: {1} {2}: \"{3}\"".format(self.line_nr, self.rule_id, self.message,
                                                self.content)  # pragma: no cover
 
     def __repr__(self):
-        return self.__str__()  # pragma: no cover
+        return self.__unicode__()  # pragma: no cover
 
 
 class MaxLineLength(LineRule):

--- a/gitlint/tests/expected/debug_configuration_output1
+++ b/gitlint/tests/expected/debug_configuration_output1
@@ -23,8 +23,10 @@ target: {target}
   B1: body-max-line-length
      line-length=30
   B5: body-min-length
+     ignore-body-checks-regex=
      min-length=20
   B6: body-is-missing
+     ignore-body-checks-regex=
      ignore-merge-commits=True
   B2: body-trailing-whitespace
   B3: body-hard-tab

--- a/gitlint/tests/test_body_rules.py
+++ b/gitlint/tests/test_body_rules.py
@@ -178,3 +178,20 @@ class BodyRuleTests(BaseTestCase):
         violations = rule.validate(commit)
         expected_violation_2 = rules.RuleViolation("B7", "Body does not mention changed file 'bar.txt'", None, 4)
         self.assertEqual([expected_violation_2, expected_violation], violations)
+
+    def test_skip_body_checks_regex(self):
+
+        # Skip body checks, if regex matches
+        rule = rules.BodyMinLength()
+        rules.BodyMinLength({'ignore-body-checks-regex': 'Release\s([a-z\-])*\s(\d+\.)?(\d+\.)?(\*|\d+)'})
+        commit = self.gitcommit(u"Release foo-bar-baz 0.12.3")
+        violations = rule.validate(commit)
+        self.assertIsNone(violations)
+
+        # Skip body checks, if regex matches
+        rule = rules.BodyFirstLineEmpty()
+        rules.BodyMinLength({'ignore-body-checks-regex': 'Release\s([a-z\-])*\s(\d+\.)?(\d+\.)?(\*|\d+)'})
+        commit = self.gitcommit(u"Release foo-bar-baz 0.12.3")
+        violations = rule.validate(commit)
+        self.assertIsNone(violations)
+


### PR DESCRIPTION
We needed a possibility to exclude release commits from our rigorous gitlint-checks.

This pull requests has the following to offer

* An option to specify a regular expression and, if it matches on the commit messages title, skip further body checks for the given commit.
* An option to set the loglevel from commandline. This behavior was splitted between `-d` and `-v[vvv]`