### PR TITLE
Removed erroneous 'stages' line from .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,4 @@
 -   id: gitlint
     name: gitlint
-    language: python
     entry: gitlint --msg-filename
-    stages: [commit-msg]
+    language: python


### PR DESCRIPTION
Removed the `stages` line from `.pre-commit-hooks.yaml`, and made a slight re-ordering to conform to the `pre-commit` docs.  The `stages` line belongs in `.pre-commit-config.yaml` instead.