### PR TITLE
Unpin dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools
 wheel==0.24.0
-Click==6.6
+Click==6.7
 sh==1.11; sys_platform != 'win32' # sh is not supported on windows
-arrow==0.10.0
+arrow==0.12.1
 ordereddict==1.1; python_version < '2.7'
 importlib==1.0.3; python_version < '2.7'

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ setup(
         "License :: OSI Approved :: MIT License"
     ],
     install_requires=[
-        'Click==6.6',
-        'arrow==0.10.0'
+        'Click>=6.6',
+        'arrow>=0.10.0'
     ],
     extras_require={
         ':python_version < "2.7"': [


### PR DESCRIPTION
Pinning `install_requires` to an exact version causes users of a library a lot of problems.

Why projects should never do this has been explained in the [Python Packaging User Guide][1] and in a [blog post][2] by Donald Stufft.

This pull request changes just `install_requires` from an exact version to lower bounds. It does not change `extras_require`.

It also updates Click and arrow to the latest version in `requirements.txt`.

[1]: https://packaging.python.org/discussions/install-requires-vs-requirements/
[2]: https://caremad.io/posts/2013/07/setup-vs-requirement/