### PR TITLE
Run on windows

### DIFF
--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -14,13 +14,6 @@ USAGE_ERROR_CODE = 253  # noqa
 GIT_CONTEXT_ERROR_CODE = 254  # noqa
 CONFIG_ERROR_CODE = 255  # noqa
 
-# We need to make sure we're not on Windows before importing other gitlint modules, as some of these modules use sh
-# which will raise an exception when imported on Windows.
-if "windows" in platform.system().lower():  # noqa
-    click.echo("Gitlint currently does not support Windows. Check out "  # noqa
-               "https://github.com/jorisroovers/gitlint/issues/20 for details.", err=True)  # noqa
-    exit(USAGE_ERROR_CODE)  # noqa
-
 import gitlint
 from gitlint.lint import GitLinter
 from gitlint.config import LintConfigBuilder, LintConfigError, LintConfigGenerator

--- a/gitlint/config.py
+++ b/gitlint/config.py
@@ -9,6 +9,7 @@ import copy
 import re
 import os
 import shutil
+import codecs
 
 try:
     # python >= 2.7
@@ -313,7 +314,8 @@ class LintConfigBuilder(object):
         self._config_path = os.path.abspath(filename)
         try:
             parser = ConfigParser()
-            parser.read(filename)
+            with codecs.open(filename, encoding="UTF-8") as config_file:
+                parser.readfp(config_file, filename)  # pylint: disable=bad-option-value,deprecated-method
 
             for section_name in parser.sections():
                 for option_name, option_value in parser.items(section_name):

--- a/gitlint/git.py
+++ b/gitlint/git.py
@@ -1,5 +1,6 @@
 import sys
 from locale import getpreferredencoding
+import arrow
 from gitlint.utils import ustr, sstr
 from gitlint import sh
 DEFAULT_ENCODING = getpreferredencoding() or "UTF-8"

--- a/gitlint/hooks.py
+++ b/gitlint/hooks.py
@@ -3,8 +3,8 @@ import os
 import stat
 
 COMMIT_MSG_HOOK_SRC_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "files/commit-msg")
-COMMIT_MSG_HOOK_DST_PATH = ".git/hooks/commit-msg"
-HOOKS_DIR_PATH = ".git/hooks"
+COMMIT_MSG_HOOK_DST_PATH = os.path.join(".git", "hooks", "commit-msg")
+HOOKS_DIR_PATH = os.path.join(".git", "hooks")
 GITLINT_HOOK_IDENTIFIER = "### gitlint commit-msg hook start ###\n"
 
 

--- a/gitlint/sh.py
+++ b/gitlint/sh.py
@@ -1,0 +1,40 @@
+import subprocess
+from locale import getpreferredencoding
+DEFAULT_ENCODING = getpreferredencoding() or "UTF-8"
+
+
+class ShResult(object):
+
+    exit_code = None
+    stdout = None
+    stderr = None
+    full_cmd = None
+
+    def __init__(self, stdout, stderr='', exitcode=0, args=None):
+        self.exit_code = exitcode
+        self.stdout = stdout
+        self.stderr = stderr
+        self.full_cmd = '' if args is None else ' '.join(args)
+
+    def __str__(self):
+        return self.stdout
+
+
+def git(*command_parts, **kwargs):
+    args = ['git'] + list(command_parts)
+    return _exec(*args, **kwargs)
+
+
+def _exec(*args, **kwargs):
+    pipe = subprocess.PIPE
+    popen_kwargs = {'stdout': pipe, 'stderr': pipe, 'shell': False}
+    if '_cwd' in kwargs:
+        popen_kwargs['cwd'] = kwargs['_cwd']
+    p = subprocess.Popen(args, **popen_kwargs)
+    result = p.communicate()
+    exit_code = p.returncode
+    if exit_code == 0:
+        return result[0].decode(DEFAULT_ENCODING)
+    stdout = result[0].decode(DEFAULT_ENCODING)
+    stderr = result[1].decode(DEFAULT_ENCODING)
+    return ShResult(stdout, stderr, p.returncode, args)

--- a/gitlint/tests/base.py
+++ b/gitlint/tests/base.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import codecs
 
 try:
     # python 2.x
@@ -53,7 +54,7 @@ class BaseTestCase(unittest.TestCase):
     def get_sample(filename=""):
         """ Read and return the contents of a file in gitlint/tests/samples """
         sample_path = BaseTestCase.get_sample_path(filename)
-        with open(sample_path) as content:
+        with codecs.open(sample_path, encoding="UTF-8") as content:
             sample = ustr(content.read())
         return sample
 
@@ -63,7 +64,7 @@ class BaseTestCase(unittest.TestCase):
         Optionally replace template variables specified by variable_dict. """
         expected_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "expected")
         expected_path = os.path.join(expected_dir, filename)
-        with open(expected_path) as content:
+        with codecs.open(expected_path, encoding="UTF-8") as content:
             expected = ustr(content.read())
 
         if variable_dict:

--- a/gitlint/tests/test_cli.py
+++ b/gitlint/tests/test_cli.py
@@ -259,7 +259,7 @@ class CLITests(BaseTestCase):
                               u"file6.txt\npåth/to/file7.txt\n"]
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
-            config_path = self.get_sample_path("config/gitlintconfig")
+            config_path = self.get_sample_path(os.path.join("config", "gitlintconfig"))
             result = self.cli.invoke(cli.cli, ["--config", config_path, "--debug", "--commits",
                                                "foo...bar"])
 
@@ -388,11 +388,11 @@ class CLITests(BaseTestCase):
         result = self.cli.invoke(cli.cli, ["generate-config"], input=u"/föo/bar")
         self.assertEqual(result.exit_code, self.USAGE_ERROR_CODE)
         expected_msg = u"Please specify a location for the sample gitlint config file [.gitlint]: /föo/bar\n" + \
-                       u"Error: Directory '/föo' does not exist.\n"
+                       u"Error: Directory '{0}' does not exist.\n".format(os.path.abspath(u'/föo'))
         self.assertEqual(result.output, expected_msg)
 
         # Existing file
-        sample_path = self.get_sample_path("config/gitlintconfig")
+        sample_path = self.get_sample_path(os.path.join("config", "gitlintconfig"))
         result = self.cli.invoke(cli.cli, ["generate-config"], input=sample_path)
         self.assertEqual(result.exit_code, self.USAGE_ERROR_CODE)
         expected_msg = "Please specify a location for the sample gitlint " + \

--- a/gitlint/tests/test_cli.py
+++ b/gitlint/tests/test_cli.py
@@ -23,13 +23,12 @@ except ImportError:
     # python 3.x
     from unittest.mock import patch  # pylint: disable=no-name-in-module, import-error
 
-from sh import CommandNotFound
-
 from gitlint.tests.base import BaseTestCase
 from gitlint import cli
 from gitlint import hooks
 from gitlint import __version__
 from gitlint import config
+from gitlint import git
 
 
 @contextlib.contextmanager
@@ -402,10 +401,10 @@ class CLITests(BaseTestCase):
         self.assertEqual(result.output, expected_msg)
 
     @patch('gitlint.cli.get_stdin_data', return_value=False)
-    @patch('gitlint.git.sh')
-    def test_git_error(self, sh, _):
+    @patch('gitlint.git._git')
+    def test_git_error(self, _git, _):
         """ Tests that the cli handles git errors properly """
-        sh.git.side_effect = CommandNotFound("git")
+        _git.side_effect = git.GitNotInstalledError()
         result = self.cli.invoke(cli.cli)
         self.assertEqual(result.exit_code, self.GIT_CONTEXT_ERROR_CODE)
 

--- a/gitlint/tests/test_hooks.py
+++ b/gitlint/tests/test_hooks.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
 
 try:
     # python 2.x
@@ -31,10 +32,10 @@ class HookTests(BaseTestCase):
     @patch('os.path.isdir', return_value=True)
     def test_install_commit_msg_hook(isdir, path_exists, copy, stat, chmod):
         lint_config = LintConfig()
-        lint_config.target = u"/foo/bår"
-        expected_dst = os.path.join(u"/foo/bår", COMMIT_MSG_HOOK_DST_PATH)
+        lint_config.target = os.path.join(u"/foo", u"bår")
+        expected_dst = os.path.join(lint_config.target, COMMIT_MSG_HOOK_DST_PATH)
         GitHookInstaller.install_commit_msg_hook(lint_config)
-        isdir.assert_called_with(u"/foo/bår" + '/.git/hooks')
+        isdir.assert_called_with(os.path.join(lint_config.target, ".git", "hooks"))
         path_exists.assert_called_once_with(expected_dst)
         copy.assert_called_once_with(COMMIT_MSG_HOOK_SRC_PATH, expected_dst)
         stat.assert_called_once_with(expected_dst)
@@ -45,23 +46,24 @@ class HookTests(BaseTestCase):
     @patch('os.path.isdir', return_value=True)
     def test_install_commit_msg_hook_negative(self, isdir, path_exists, copy):
         lint_config = LintConfig()
-        lint_config.target = u"/foo/bår"
+        lint_config.target = os.path.join(u"/foo", u"bår")
         # mock that current dir is not a git repo
         isdir.return_value = False
-        expected_msg = u"{0} is not a git repository".format(u"/foo/bår")
+        # note: full stop at the end of error is windows
+        expected_msg = u"{0} is not a git repository.".format(re.escape(os.path.abspath(lint_config.target)))
         with self.assertRaisesRegex(GitHookInstallerError, expected_msg):
             GitHookInstaller.install_commit_msg_hook(lint_config)
-            isdir.assert_called_with(os.path.join(u"/foo/bår", '.git/hooks'))
+            isdir.assert_called_with(os.path.join(lint_config.target, '.git', 'hooks'))
             path_exists.assert_not_called()
             copy.assert_not_called()
 
         # mock that there is already a commit hook present
         isdir.return_value = True
         path_exists.return_value = True
-        expected_dst = os.path.join(u"/foo/bår", COMMIT_MSG_HOOK_DST_PATH)
+        expected_dst = os.path.join(lint_config.target, COMMIT_MSG_HOOK_DST_PATH)
         expected_msg = u"There is already a commit-msg hook file present in {0}.\n".format(expected_dst) + \
                        "gitlint currently does not support appending to an existing commit-msg file."
-        with self.assertRaisesRegex(GitHookInstallerError, expected_msg):
+        with self.assertRaisesRegex(GitHookInstallerError, re.escape(expected_msg)):
             GitHookInstaller.install_commit_msg_hook(lint_config)
 
     @staticmethod
@@ -70,13 +72,13 @@ class HookTests(BaseTestCase):
     @patch('os.path.isdir', return_value=True)
     def test_uninstall_commit_msg_hook(isdir, path_exists, remove):
         lint_config = LintConfig()
-        lint_config.target = u"/foo/bår"
+        lint_config.target = os.path.join(u"/foo", u"bår")
         read_data = "#!/bin/sh\n" + GITLINT_HOOK_IDENTIFIER
         with patch('gitlint.hooks.open', mock_open(read_data=read_data), create=True):
             GitHookInstaller.uninstall_commit_msg_hook(lint_config)
 
-        expected_dst = os.path.join(u"/foo/bår", COMMIT_MSG_HOOK_DST_PATH)
-        isdir.assert_called_with(os.path.join(u"/foo/bår", '.git/hooks'))
+        expected_dst = os.path.join(lint_config.target, COMMIT_MSG_HOOK_DST_PATH)
+        isdir.assert_called_with(os.path.abspath(os.path.join(lint_config.target, '.git', 'hooks')))
         path_exists.assert_called_once_with(expected_dst)
         remove.assert_called_with(expected_dst)
 
@@ -85,24 +87,24 @@ class HookTests(BaseTestCase):
     @patch('os.path.isdir', return_value=True)
     def test_uninstall_commit_msg_hook_negative(self, isdir, path_exists, remove):
         lint_config = LintConfig()
-        lint_config.target = u"/foo/bår"
+        lint_config.target = os.path.join(u"/foo", u"bår")
         # mock that the current directory is not a git repo
         isdir.return_value = False
-        expected_msg = u"{0} is not a git repository".format(u"/foo/bår")
-        with self.assertRaisesRegex(GitHookInstallerError, expected_msg):
+        expected_msg = u"{0} is not a git repository.".format(lint_config.target)
+        with self.assertRaisesRegex(GitHookInstallerError, re.escape(expected_msg)):
             GitHookInstaller.uninstall_commit_msg_hook(lint_config)
-            isdir.assert_called_with(os.path.join(u"/foo/bår", '.git/hooks'))
+            isdir.assert_called_with(os.path.abspath(os.path.join(lint_config.target, '.git', 'hooks')))
             path_exists.assert_not_called()
             remove.assert_not_called()
 
         # mock that there is no commit hook present
         isdir.return_value = True
         path_exists.return_value = False
-        expected_dst = os.path.join(u"/foo/bår", COMMIT_MSG_HOOK_DST_PATH)
+        expected_dst = os.path.join(lint_config.target, COMMIT_MSG_HOOK_DST_PATH)
         expected_msg = u"There is no commit-msg hook present in {0}.".format(expected_dst)
-        with self.assertRaisesRegex(GitHookInstallerError, expected_msg):
+        with self.assertRaisesRegex(GitHookInstallerError, re.escape(expected_msg)):
             GitHookInstaller.uninstall_commit_msg_hook(lint_config)
-            isdir.assert_called_with(os.path.join(u"/foo/bår", '.git/hooks'))
+            isdir.assert_called_with(os.path.join(lint_config.target, '.git/hooks'))
             path_exists.assert_called_once_with(expected_dst)
             remove.assert_not_called()
 
@@ -110,8 +112,8 @@ class HookTests(BaseTestCase):
         isdir.return_value = True
         path_exists.return_value = True
         read_data = "#!/bin/sh\nfoo"
-        expected_dst = os.path.join(u"/foo/bår", COMMIT_MSG_HOOK_DST_PATH)
-        expected_msg = u"The commit-msg hook in {0} was not installed by gitlint ".format(expected_dst) + \
+        expected_dst = os.path.join(lint_config.target, COMMIT_MSG_HOOK_DST_PATH)
+        expected_msg = u"The commit-msg hook in {0} was not installed by gitlint ".format(re.escape(expected_dst)) + \
                        r"\(or it was modified\).\nUninstallation of 3th party or modified gitlint hooks " + \
                        "is not supported."
         with patch('gitlint.hooks.open', mock_open(read_data=read_data), create=True):

--- a/gitlint/tests/test_options.py
+++ b/gitlint/tests/test_options.py
@@ -139,7 +139,7 @@ class RuleOptionTests(BaseTestCase):
             option.set(u"/föo/bar")
 
         # set to a file, should raise exception since option.type = dir
-        sample_path = self.get_sample_path("commit_message/sample1")
+        sample_path = self.get_sample_path(os.path.join("commit_message", "sample1"))
         expected = u"Option test-directory must be an existing directory \(current value: '{0}'\)".format(
             re.escape(sample_path))
         with self.assertRaisesRegex(RuleOptionError, expected):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 setuptools
 wheel==0.24.0
 Click==6.6
-sh==1.11; sys_platform != 'win32' # sh is not supported on windows
 arrow==0.10.0
 ordereddict==1.1; python_version < '2.7'
 importlib==1.0.3; python_version < '2.7'

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -217,7 +217,9 @@ run_stats(){
 }
 
 clean(){
-    echo -n "Cleaning the site, build, dist and all __pycache__directories..."
+    echo -n "Cleaning the site, build, dist, *.pyc and all __pycache__directories..."
+    find gitlint -type d  -name "*.pyc" -exec rm -rf {} \; 2> /dev/null
+    find qa -type d  -name "*.pyc" -exec rm -rf {} \; 2> /dev/null
     find gitlint -type d  -name "__pycache__" -exec rm -rf {} \; 2> /dev/null
     find qa -type d  -name "__pycache__" -exec rm -rf {} \; 2> /dev/null
     rm -rf "site" "dist" "build"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,7 @@ flake8==3.2.1; python_version >= '2.7'
 coverage==3.7.1
 python-coveralls==2.9.0
 radon==1.4.2
+sh==1.11; sys_platform != 'win32' # sh is not supported on windows
 mock==2.0.0
 pytest==3.0.4
 pylint<1.4; python_version < '2.7'


### PR DESCRIPTION
This MR updates gitlint to run on windows. The unit tests also run on windows but the qa tests don't.

* Replace use of sh with a (very) cut-down version in gitlint/sh.py (gitlint + unit tests)
* Update gitlint and unit tests to run on windows

The amount of sh functionality used by gitlint is quite small and neatly encapsulated inside the _git method. Originally I thought I could drop in a replacement for _git but nearly all the tests mock out sh so that would have required modifying almost all of them. Replacing sh meant I could keep the unit tests largely unchanged to support the shift to windows.

The changes for windows are straight-forward, mostly in the unit tests, slashes need to be `path.join` and the encoding when reading sample files needs to be explicity specified (the commit has more details). 

The QA tests use much more of the sh functionality (particularly fake ttys) so I left those as is for now. Some are easy enough to adapt (see this wip commit for examples: https://github.com/byrney/gitlint/commit/50bc2c93757b08f63ade2329f9a7af8a3b48756e) but others require significant effort or may never be runnable on windows.

If there is appetite I can do another PR to make the majority of QA run on both platforms and mark the rest to skip on windows.

Caveats

* I didn't update the docs. They say "windows is not supported" which may continue to be true. 
* Gitlint does not work in mintty (the git bash windows terminal) unless run under `winpty` (due to the way it detects terminal vs pipe)
* Calling it `sh.py` may be confusing since `sh` is still used in qa. The alternative is a big search/replace on the tests to use a new name for `gitlint/sh.py`
* I tested on py2.7 and py3.6 I'm hoping travis will tell me if there are problems with other versions when this PR gets CI'd.
* We are running this fork in our linux and CI envs now and will start rolling out to windows desktops this week/next

Related Issues: #20 
