### PR TITLE
Revert "Removed erroneous 'stages' line from .pre-commit-hooks.yaml (#64)"

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,4 +1,5 @@
 -   id: gitlint
     name: gitlint
-    entry: gitlint --msg-filename
     language: python
+    entry: gitlint --msg-filename
+    stages: [commit-msg]


### PR DESCRIPTION
This reverts commit f3906027abb1fd434e9c92b1c7050bf146b3121a.

See https://github.com/jorisroovers/gitlint/pull/64#issuecomment-381410128