### PR TITLE
Add author-from-file rule

### DIFF
--- a/gitlint/config.py
+++ b/gitlint/config.py
@@ -62,7 +62,8 @@ class LintConfig(object):
                             rules.BodyHardTab,
                             rules.BodyFirstLineEmpty,
                             rules.BodyChangedFileMention,
-                            rules.AuthorValidEmail)
+                            rules.AuthorValidEmail,
+                            rules.AuthorFromFile)
 
     def __init__(self):
         # Use an ordered dict so that the order in which rules are applied is always the same

--- a/gitlint/rules.py
+++ b/gitlint/rules.py
@@ -334,11 +334,18 @@ class AuthorFromFile(CommitRule):
         return False
 
     def validate(self, commit):
+        violations = []
         if self.options['validate-authors'].value and \
            not self.is_author_in_file(commit.author_name, commit.author_email):
+            context = u"Author information does not match"
+            error = u"{name} <{email}>".format(name=commit.author_name, email=commit.author_email)
+            violations.append(RuleViolation(self.id, context, error))
+        if self.options['validate-committers'].value and \
+           not self.is_author_in_file(commit.committer_name, commit.committer_email):
             context = u"Committer information does not match"
             error = u"{name} <{email}>".format(name=commit.author_name, email=commit.author_email)
-            return [RuleViolation(self.id, context, error)]
+            violations.append(RuleViolation(self.id, context, error))
+        return violations or None
 
     def __str__(self):
         return self.name

--- a/gitlint/tests/expected/debug_configuration_output1
+++ b/gitlint/tests/expected/debug_configuration_output1
@@ -39,3 +39,8 @@ target: {target}
      files=
   M1: author-valid-email
      regex=[^@ ]+@[^@ ]+\.[^@ ]+
+  M2: author-from-file
+     file=AUTHORS
+     regex=\A{{name}}\s+<{{email}}>\Z
+     validate-authors=False
+     validate-committers=False

--- a/gitlint/tests/test_cli.py
+++ b/gitlint/tests/test_cli.py
@@ -68,7 +68,8 @@ class CLITests(BaseTestCase):
     def test_lint(self, sh, _):
         """ Test for basic simple linting functionality """
         sh.git.side_effect = ["6f29bf81a8322a04071bb794666e48c443a90360",
-                              u"test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 01:00\x00åbc\n"
+                              u"1test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 01:00\x00"
+                              u"test committer\x00test-email@foo.bar\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               u"commït-title\n\ncommït-body",
                               u"file1.txt\npåth/to/file2.txt\n"]
 
@@ -86,13 +87,16 @@ class CLITests(BaseTestCase):
                               "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n" +
                               "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
                               # git log --pretty <FORMAT> <SHA>
-                              u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01 :00\x00åbc\n"
+                              u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01 :00\x00"
+                              u"test committer\x00test-email@foo.bar\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               u"commït-title1\n\ncommït-body1",
                               u"file1.txt\npåth/to/file2.txt\n",  # git diff-tree <SHA>
-                              u"test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 01:00\x00åbc\n"
+                              u"test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 01:00\x00"
+                              u"test committer\x00test-email@foo.bar\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               u"commït-title2\n\ncommït-body2",
                               u"file4.txt\npåth/to/file5.txt\n",
-                              u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00åbc\n"
+                              u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00"
+                              u"test committer\x00test-email@foo.bar\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               u"commït-title3\n\ncommït-body3",
                               u"file6.txt\npåth/to/file7.txt\n"]
 
@@ -117,13 +121,16 @@ class CLITests(BaseTestCase):
                               "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n" +
                               "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
                               # git log --pretty <FORMAT> <SHA>
-                              u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01:00\x00åbc\n"
+                              u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01:00\x00"
+                              u"test committer\x00test-email@foo.bar\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               u"commït-title1\n\ncommït-body1",
                               u"file1.txt\npåth/to/file2.txt\n",  # git diff-tree <SHA>
-                              u"test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 01:00\x00åbc\n"
+                              u"test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 01:00\x00"
+                              u"test committer\x00test-email@foo.bar\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               u"commït-title2.\n\ncommït-body2\ngitlint-ignore: T3\n",
                               u"file4.txt\npåth/to/file5.txt\n",
-                              u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00åbc\n"
+                              u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00"
+                              u"test committer\x00test-email@foo.bar\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               u"commït-title3.\n\ncommït-body3",
                               u"file6.txt\npåth/to/file7.txt\n"]
 
@@ -149,15 +156,18 @@ class CLITests(BaseTestCase):
                               "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n" +
                               "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
                               # git log --pretty <FORMAT> <SHA>
-                              u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01:00\x00åbc\n"
+                              u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01:00\x00"
+                              u"test committer\x00test-email@foo.bar\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               u"commït-title1\n\ncommït-body1",
                               u"file1.txt\npåth/to/file2.txt\n",  # git diff-tree <SHA>
-                              u"test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 01:00\x00åbc\n"
+                              u"test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 01:00\x00"
+                              u"test committer\x00test-email@foo.bar\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               # Normally T3 violation (trailing punctuation), but this commit is ignored because of
                               # config below
                               u"commït-title2.\n\ncommït-body2\n",
                               u"file4.txt\npåth/to/file5.txt\n",
-                              u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00åbc\n"
+                              u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00"
+                              u"test committer\x00test-email@foo.bar\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               # Normally T1 and B5 violations, now only T1 because we're ignoring B5 in config below
                               u"commït-title3.\n\ncommït-body3 foo",
                               u"file6.txt\npåth/to/file7.txt\n"]
@@ -249,13 +259,16 @@ class CLITests(BaseTestCase):
         sh.git.side_effect = ["6f29bf81a8322a04071bb794666e48c443a90360\n"  # git rev-list <SHA>
                               "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n"
                               "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
-                              u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01:00\x00abc\n"
+                              u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01:00\x00"
+                              u"test committer\x00test-email@foo.bar\x002016-12-03 15:28:15 01:00\x00abc\n"
                               u"commït-title1\n\ncommït-body1",
                               u"file1.txt\npåth/to/file2.txt\n",
-                              u"test åuthor2\x00test-email2@föo.com\x002016-12-04 15:28:15 01:00\x00abc\n"
+                              u"test åuthor2\x00test-email2@föo.com\x002016-12-04 15:28:15 01:00\x00"
+                              u"test committer\x00test-email@foo.bar\x002016-12-03 15:28:15 01:00\x00abc\n"
                               u"commït-title2.\n\ncommït-body2",
                               u"file4.txt\npåth/to/file5.txt\n",
-                              u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00abc\n"
+                              u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00"
+                              u"test committer\x00test-email@foo.bar\x002016-12-03 15:28:15 01:00\x00abc\n"
                               u"föo\nbar",
                               u"file6.txt\npåth/to/file7.txt\n"]
 

--- a/gitlint/tests/test_git.py
+++ b/gitlint/tests/test_git.py
@@ -27,7 +27,8 @@ class GitTests(BaseTestCase):
         sample_sha = "d8ac47e9f2923c7f22d8668e3a1ed04eb4cdbca9"
 
         sh.git.side_effect = [sample_sha,
-                              u"test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 01:00\x00åbc\n"
+                              u"test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 01:00\x00"
+                              u"test ćommitter\x00test-ćommitter@foo.bar\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               u"cömmit-title\n\ncömmit-body",
                               u"file1.txt\npåth/to/file2.txt\n"]
 
@@ -35,7 +36,8 @@ class GitTests(BaseTestCase):
         # assert that commit info was read using git command
         expected_calls = [
             call("log", "-1", "--pretty=%H", **self.expected_sh_special_args),
-            call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
+            call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%cN%x00%cE%x00%ci%x00%P%n%B",
+                 **self.expected_sh_special_args),
             call('diff-tree', '--no-commit-id', '--name-only', '-r', sample_sha, **self.expected_sh_special_args)
         ]
         self.assertListEqual(sh.git.mock_calls, expected_calls)
@@ -45,6 +47,8 @@ class GitTests(BaseTestCase):
         self.assertEqual(last_commit.message.body, ["", u"cömmit-body"])
         self.assertEqual(last_commit.author_name, u"test åuthor")
         self.assertEqual(last_commit.author_email, u"test-emåil@foo.com")
+        self.assertEqual(last_commit.committer_name, u"test ćommitter")
+        self.assertEqual(last_commit.committer_email, u"test-ćommitter@foo.bar")
         self.assertEqual(last_commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15,
                                                              tzinfo=dateutil.tz.tzoffset("+0100", 3600)))
         self.assertListEqual(last_commit.parents, [u"åbc"])
@@ -58,7 +62,8 @@ class GitTests(BaseTestCase):
         sample_sha = "myspecialref"
 
         sh.git.side_effect = [sample_sha,
-                              u"test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 01:00\x00åbc\n"
+                              u"test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 01:00\x00"
+                              u"test ćommitter\x00test-ćommitter@foo.bar\x002016-12-03 15:28:15 01:00\x00åbc\n"
                               u"cömmit-title\n\ncömmit-body",
                               u"file1.txt\npåth/to/file2.txt\n"]
 
@@ -66,7 +71,8 @@ class GitTests(BaseTestCase):
         # assert that commit info was read using git command
         expected_calls = [
             call("rev-list", sample_sha, **self.expected_sh_special_args),
-            call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
+            call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%cN%x00%cE%x00%ci%x00%P%n%B",
+                 **self.expected_sh_special_args),
             call('diff-tree', '--no-commit-id', '--name-only', '-r', sample_sha, **self.expected_sh_special_args)
         ]
         self.assertListEqual(sh.git.mock_calls, expected_calls)
@@ -76,6 +82,8 @@ class GitTests(BaseTestCase):
         self.assertEqual(last_commit.message.body, ["", u"cömmit-body"])
         self.assertEqual(last_commit.author_name, u"test åuthor")
         self.assertEqual(last_commit.author_email, u"test-emåil@foo.com")
+        self.assertEqual(last_commit.committer_name, u"test ćommitter")
+        self.assertEqual(last_commit.committer_email, u"test-ćommitter@foo.bar")
         self.assertEqual(last_commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15,
                                                              tzinfo=dateutil.tz.tzoffset("+0100", 3600)))
         self.assertListEqual(last_commit.parents, [u"åbc"])
@@ -89,7 +97,8 @@ class GitTests(BaseTestCase):
         sample_sha = "d8ac47e9f2923c7f22d8668e3a1ed04eb4cdbca9"
 
         sh.git.side_effect = [sample_sha,
-                              u"test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 01:00\x00åbc def\n"
+                              u"test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 01:00\x00"
+                              u"test ćommitter\x00test-ćommitter@foo.bar\x002016-12-03 15:28:15 01:00\x00åbc def\n"
                               u"Merge \"foo bår commit\"",
                               u"file1.txt\npåth/to/file2.txt\n"]
 
@@ -97,7 +106,8 @@ class GitTests(BaseTestCase):
         # assert that commit info was read using git command
         expected_calls = [
             call("log", "-1", "--pretty=%H", **self.expected_sh_special_args),
-            call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
+            call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%cN%x00%cE%x00%ci%x00%P%n%B",
+                 **self.expected_sh_special_args),
             call('diff-tree', '--no-commit-id', '--name-only', '-r', sample_sha, **self.expected_sh_special_args)
         ]
 
@@ -108,6 +118,8 @@ class GitTests(BaseTestCase):
         self.assertEqual(last_commit.message.body, [])
         self.assertEqual(last_commit.author_name, u"test åuthor")
         self.assertEqual(last_commit.author_email, u"test-emåil@foo.com")
+        self.assertEqual(last_commit.committer_name, u"test ćommitter")
+        self.assertEqual(last_commit.committer_email, u"test-ćommitter@foo.bar")
         self.assertEqual(last_commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15,
                                                              tzinfo=dateutil.tz.tzoffset("+0100", 3600)))
         self.assertListEqual(last_commit.parents, [u"åbc", "def"])
@@ -121,7 +133,8 @@ class GitTests(BaseTestCase):
             sample_sha = "d8ac47e9f2923c7f22d8668e3a1ed04eb4cdbca9"
 
             sh.git.side_effect = [sample_sha,
-                                  u"test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 01:00\x00åbc\n"
+                                  u"test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 01:00\x00"
+                                  u"test ćommitter\x00test-ćommitter@foo.bar\x002016-12-03 15:28:15 01:00\x00åbc\n"
                                   u"{0}! \"foo bår commit\"".format(commit_type),
                                   u"file1.txt\npåth/to/file2.txt\n"]
 
@@ -129,7 +142,8 @@ class GitTests(BaseTestCase):
             # assert that commit info was read using git command
             expected_calls = [
                 call("log", "-1", "--pretty=%H", **self.expected_sh_special_args),
-                call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
+                call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%cN%x00%cE%x00%ci%x00%P%n%B",
+                     **self.expected_sh_special_args),
                 call('diff-tree', '--no-commit-id', '--name-only', '-r', sample_sha, **self.expected_sh_special_args)
             ]
 
@@ -140,6 +154,8 @@ class GitTests(BaseTestCase):
             self.assertEqual(last_commit.message.body, [])
             self.assertEqual(last_commit.author_name, u"test åuthor")
             self.assertEqual(last_commit.author_email, u"test-emåil@foo.com")
+            self.assertEqual(last_commit.committer_name, u"test ćommitter")
+            self.assertEqual(last_commit.committer_email, u"test-ćommitter@foo.bar")
             self.assertEqual(last_commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15,
                                                                  tzinfo=dateutil.tz.tzoffset("+0100", 3600)))
             self.assertListEqual(last_commit.parents, [u"åbc"])
@@ -217,6 +233,8 @@ class GitTests(BaseTestCase):
         self.assertEqual(commit.message.original, expected_original)
         self.assertEqual(commit.author_name, None)
         self.assertEqual(commit.author_email, None)
+        self.assertEqual(commit.committer_name, None)
+        self.assertEqual(commit.committer_email, None)
         self.assertEqual(commit.date, None)
         self.assertListEqual(commit.parents, [])
         self.assertFalse(commit.is_merge_commit)
@@ -234,6 +252,8 @@ class GitTests(BaseTestCase):
         self.assertEqual(commit.message.original, u"Just a title contåining WIP")
         self.assertEqual(commit.author_name, None)
         self.assertEqual(commit.author_email, None)
+        self.assertEqual(commit.committer_name, None)
+        self.assertEqual(commit.committer_email, None)
         self.assertListEqual(commit.parents, [])
         self.assertFalse(commit.is_merge_commit)
         self.assertFalse(commit.is_fixup_commit)
@@ -250,6 +270,8 @@ class GitTests(BaseTestCase):
         self.assertEqual(commit.message.original, "")
         self.assertEqual(commit.author_name, None)
         self.assertEqual(commit.author_email, None)
+        self.assertEqual(commit.committer_name, None)
+        self.assertEqual(commit.committer_email, None)
         self.assertEqual(commit.date, None)
         self.assertListEqual(commit.parents, [])
         self.assertFalse(commit.is_merge_commit)
@@ -267,6 +289,8 @@ class GitTests(BaseTestCase):
         self.assertEqual(commit.message.original, u"Tïtle\n\nBödy 1\n#Cömment\nBody 2")
         self.assertEqual(commit.author_name, None)
         self.assertEqual(commit.author_email, None)
+        self.assertEqual(commit.committer_name, None)
+        self.assertEqual(commit.committer_email, None)
         self.assertEqual(commit.date, None)
         self.assertListEqual(commit.parents, [])
         self.assertFalse(commit.is_merge_commit)
@@ -285,6 +309,8 @@ class GitTests(BaseTestCase):
         self.assertEqual(commit.message.original, commit_msg)
         self.assertEqual(commit.author_name, None)
         self.assertEqual(commit.author_email, None)
+        self.assertEqual(commit.committer_name, None)
+        self.assertEqual(commit.committer_email, None)
         self.assertEqual(commit.date, None)
         self.assertListEqual(commit.parents, [])
         self.assertTrue(commit.is_merge_commit)
@@ -305,6 +331,8 @@ class GitTests(BaseTestCase):
             self.assertEqual(commit.message.original, commit_msg)
             self.assertEqual(commit.author_name, None)
             self.assertEqual(commit.author_email, None)
+            self.assertEqual(commit.committer_name, None)
+            self.assertEqual(commit.committer_email, None)
             self.assertEqual(commit.date, None)
             self.assertListEqual(commit.parents, [])
             self.assertEqual(len(gitcontext.commits), 1)
@@ -334,8 +362,8 @@ class GitTests(BaseTestCase):
         self.assertEqual(commit1, commit2)
 
         # Check that objects are inequal when changing a single attribute
-        for attr in ['message', 'author_name', 'author_email', 'parents', 'is_merge_commit', 'is_fixup_commit',
-                     'is_squash_commit', 'changed_files']:
+        for attr in ['message', 'author_name', 'author_email', 'committer_name', 'committer_email', 'parents',
+                     'is_merge_commit', 'is_fixup_commit', 'is_squash_commit', 'changed_files']:
             prev_val = getattr(commit1, attr)
             setattr(commit1, attr, u"föo")
             self.assertNotEqual(commit1, commit2)

--- a/qa/expected/debug_output1
+++ b/qa/expected/debug_output1
@@ -43,6 +43,11 @@ target: {target}
      files=
   M1: author-valid-email
      regex=[^@ ]+@[^@ ]+\.[^@ ]+
+  M2: author-from-file
+     file=AUTHORS
+     regex=\A{{name}}\s+<{{email}}>\Z
+     validate-authors=False
+     validate-committers=False
 
 DEBUG: gitlint.cli No --msg-filename flag, no or empty data passed to stdin. Attempting to read from the local repo.
 DEBUG: gitlint.lint Linting commit {commit_sha}


### PR DESCRIPTION
The rule expects a file with a list of valid author names and emails. It checks the names and email addresses of all commit authors and committers.

The format of the file is configurable, by default it expects files of the format
```
Peter Foo <foo@bar.com>
Jöhn Doe Jr. <doe@foo.bar>
```