### PR TITLE
Make `test_target` less strict with `git`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,7 @@
 # R0801: Similar lines in files
 # I0011: Informational: locally disabled pylint
 # I0013: Informational: Ignoring entire file
-disable=C0111,W0511,W0142,W0622,W0223,W0212,R0901,R0801,I0011,I0013,anomalous-backslash-in-string
+disable=bad-option-value,C0111,W0511,W0142,W0622,W0223,W0212,R0901,R0801,I0011,I0013,anomalous-backslash-in-string,useless-object-inheritance
 
 [Format]
 max-line-length=120

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,43 +9,17 @@ matrix:
       os: linux
     - python: "3.3"
       os: linux
-      script:
-      # Skip integration tests in Travis for Python 3.3, need to look into this
-      # Error example: https://travis-ci.org/jorisroovers/gitlint/jobs/310861373
-        - "./run_tests.sh"
-        - "./run_tests.sh --build"
-        - "./run_tests.sh --pep8"
-        - "./run_tests.sh --lint"
-        - "./run_tests.sh --git"
     - python: "3.4"
       os: linux
-      script:
-      # Skip integration tests in Travis for Python 3.4, need to look into this
-      # Error example: https://travis-ci.org/jorisroovers/gitlint/jobs/310861374
-        - "./run_tests.sh"
-        - "./run_tests.sh --build"
-        - "./run_tests.sh --pep8"
-        - "./run_tests.sh --lint"
-        - "./run_tests.sh --git"
     - python: "3.5"
       os: linux
-      script:
-      # Skip integration tests in Travis for Python 3.5, need to look into this
-      # Error example: https://travis-ci.org/jorisroovers/gitlint/jobs/310861375
-        - "./run_tests.sh"
-        - "./run_tests.sh --build"
-        - "./run_tests.sh --pep8"
-        - "./run_tests.sh --lint"
-        - "./run_tests.sh --git"
     - python: "3.6"
       os: linux
-      script:
-      # Skip lint tests for python 3.6 (see https://github.com/PyCQA/pylint/issues/1072)
-        - "./run_tests.sh"
-        - "./run_tests.sh --integration"
-        - "./run_tests.sh --build"
-        - "./run_tests.sh --pep8"
-        - "./run_tests.sh --git"
+    - python: "3.7"
+      os: linux
+      # See https://github.com/travis-ci/travis-ci/issues/9815
+      dist: xenial
+      sudo: true
     - python: "pypy"
       os: linux
 install:

--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -120,7 +120,7 @@ def get_stdin_data():
         input_data = sys.stdin.read()
         # Only return the input data if there's actually something passed
         # i.e. don't consider empty piped data
-        if len(input_data) != 0:
+        if input_data:
             return ustr(input_data)
     return False
 
@@ -295,4 +295,5 @@ def generate_config(ctx):
 # Let's Party!
 setup_logging()
 if __name__ == "__main__":
-    cli()  # pragma: no cover, # pylint: disable=no-value-for-parameter
+    # pylint: disable=no-value-for-parameter
+    cli()  # pragma: no cover

--- a/gitlint/git.py
+++ b/gitlint/git.py
@@ -24,7 +24,7 @@ def _git(*command_parts, **kwargs):
     git_kwargs = {'_tty_out': False}
     git_kwargs.update(kwargs)
     try:
-        result = sh.git(*command_parts, **git_kwargs)
+        result = sh.git(*command_parts, **git_kwargs)  # pylint: disable=unexpected-keyword-arg
         # If we reach this point and the result has an exit_code that is larger than 0, this means that we didn't
         # get an exception (which is the default sh behavior for non-zero exit codes) and so the user is expecting
         # a non-zero exit code -> just return the entire result
@@ -82,7 +82,7 @@ class GitCommitMessage(object):
             cutline_index = None
         lines = [line for line in all_lines[:cutline_index] if not line.startswith(GitCommitMessage.COMMENT_CHAR)]
         full = "\n".join(lines)
-        title = lines[0] if len(lines) > 0 else ""
+        title = lines[0] if lines else ""
         body = lines[1:] if len(lines) > 1 else []
         return GitCommitMessage(original=commit_msg_str, full=full, title=title, body=body)
 

--- a/gitlint/lint.py
+++ b/gitlint/lint.py
@@ -1,3 +1,4 @@
+# pylint: disable=logging-not-lazy
 import logging
 from gitlint import rules as gitlint_rules
 from gitlint import display

--- a/gitlint/rules.py
+++ b/gitlint/rules.py
@@ -1,3 +1,4 @@
+# pylint: disable=inconsistent-return-statements
 import copy
 import logging
 import re
@@ -262,7 +263,7 @@ class BodyMinLength(CommitRule):
         min_length = self.options['min-length'].value
         body_message_no_newline = "".join([line for line in commit.message.body if line is not None])
         actual_length = len(body_message_no_newline)
-        if actual_length > 0 and actual_length < min_length:
+        if 0 < actual_length < min_length:
             violation_message = "Body message is too short ({0}<{1})".format(actual_length, min_length)
             return [RuleViolation(self.id, violation_message, body_message_no_newline, 3)]
 

--- a/gitlint/tests/test_cli.py
+++ b/gitlint/tests/test_cli.py
@@ -355,8 +355,7 @@ class CLITests(BaseTestCase):
         # We expect gitlint to tell us that /tmp is not a git repo (this proves that it takes the target parameter
         # into account).
         self.assertEqual(result.exit_code, self.GIT_CONTEXT_ERROR_CODE)
-        expected_path = os.path.realpath("/tmp")
-        self.assertEqual(result.output, "%s is not a git repository.\n" % expected_path)
+        self.assertTrue("not a git repository" in result.output)
 
     def test_target_negative(self):
         """ Negative test for the --target option """

--- a/gitlint/user_rules.py
+++ b/gitlint/user_rules.py
@@ -41,7 +41,7 @@ def find_rule_classes(extra_path):
             modules.append(os.path.splitext(filename)[0])
 
     # No need to continue if there are no modules specified
-    if len(modules) == 0:
+    if not modules:
         return []
 
     # Append the extra rules path to python path so that we can import them
@@ -93,7 +93,7 @@ def assert_valid_rule_class(clazz):
                                        rules.LineRule.__name__, rules.CommitRule.__name__))
 
     # Rules must have an id attribute
-    if not hasattr(clazz, 'id') or clazz.id is None or len(clazz.id) == 0:
+    if not hasattr(clazz, 'id') or clazz.id is None or not clazz.id:
         raise UserRuleError(u"User-defined rule class '{0}' must have an 'id' attribute".format(clazz.__name__))
 
     # Rule id's cannot start with gitlint reserved letters
@@ -102,7 +102,7 @@ def assert_valid_rule_class(clazz):
         raise UserRuleError(msg.format(clazz.__name__, clazz.id[0]))
 
     # Rules must have a name attribute
-    if not hasattr(clazz, 'name') or clazz.name is None or len(clazz.name) == 0:
+    if not hasattr(clazz, 'name') or clazz.name is None or not clazz.name:
         raise UserRuleError(u"User-defined rule class '{0}' must have a 'name' attribute".format(clazz.__name__))
 
     # if set, options_spec must be a list of RuleOption

--- a/gitlint/utils.py
+++ b/gitlint/utils.py
@@ -1,4 +1,4 @@
-# pylint: disable=bad-option-value,unidiomatic-typecheck,undefined-variable
+# pylint: disable=bad-option-value,unidiomatic-typecheck,undefined-variable,no-else-return
 import sys
 
 from locale import getpreferredencoding

--- a/qa/requirements.txt
+++ b/qa/requirements.txt
@@ -1,5 +1,6 @@
-unittest2==1.1.0 # support for python 2.6
-sh==1.11
-pytest==3.0.4
+unittest2==1.1.0; python_version <= '2.7'
+sh==1.12.14
+pytest==3.2.5; python_version == '2.6' or python_version == '3.3'
+pytest==3.10.0; python_version != '2.6' and python_version != '3.3'
 arrow==0.10.0
 gitlint # no version as you want to test the currently installed version

--- a/qa/test_commits.py
+++ b/qa/test_commits.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+# pylint: disable=too-many-function-args,unexpected-keyword-arg
 from sh import git, gitlint  # pylint: disable=no-name-in-module
 from qa.base import BaseTestCase
 
@@ -17,7 +17,7 @@ class CommitsTests(BaseTestCase):
         self._create_simple_commit(u"Sïmple title3\n\nSimple bödy describing the commit3")
         output = gitlint("--commits", "test-branch-commits-base...test-branch-commits",
                          _cwd=self.tmp_git_repo, _tty_in=True)
-        self.assertEqual(output, "")
+        self.assertEqualStdout(output, "")
 
     def test_violations(self):
         """ Test linting multiple commits with violations """
@@ -40,7 +40,7 @@ class CommitsTests(BaseTestCase):
                     u"3: B6 Body message is missing\n")
 
         self.assertEqual(output.exit_code, 4)
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)
 
     def test_lint_single_commit(self):
         self._create_simple_commit(u"Sïmple title.\n")
@@ -52,7 +52,7 @@ class CommitsTests(BaseTestCase):
         expected = (u"1: T3 Title has trailing punctuation (.): \"Sïmple title2.\"\n" +
                     u"3: B6 Body message is missing\n")
         self.assertEqual(output.exit_code, 2)
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)
 
     def test_lint_head(self):
         """ Testing whether we can also recognize special refs like 'HEAD' """
@@ -72,7 +72,7 @@ class CommitsTests(BaseTestCase):
             u"1: T3 Title has trailing punctuation (.): \"Sïmple title.\"\n"
         )
 
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)
 
     def test_ignore_commits(self):
         """ Tests multiple commits of which some rules get igonored because of ignore-* rules """
@@ -102,4 +102,4 @@ class CommitsTests(BaseTestCase):
             u"1: T3 Title has trailing punctuation (.): \"Sïmple title.\"\n"
         )
 
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)

--- a/qa/test_config.py
+++ b/qa/test_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+# pylint: disable=too-many-function-args,unexpected-keyword-arg
 import platform
 import sys
 
@@ -16,36 +16,36 @@ class ConfigTests(BaseTestCase):
         self._create_simple_commit(u"WIP: Thïs is a title.\nContënt on the second line")
         output = gitlint("--ignore", "T5,B4", _tty_in=True, _cwd=self.tmp_git_repo, _ok_code=[1])
         expected = u"1: T3 Title has trailing punctuation (.): \"WIP: Thïs is a title.\"\n"
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)
 
     def test_ignore_by_name(self):
         self._create_simple_commit(u"WIP: Thïs is a title.\nContënt on the second line")
         output = gitlint("--ignore", "title-must-not-contain-word,body-first-line-empty",
                          _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[1])
         expected = u"1: T3 Title has trailing punctuation (.): \"WIP: Thïs is a title.\"\n"
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)
 
     def test_verbosity(self):
         self._create_simple_commit(u"WIP: Thïs is a title.\nContënt on the second line")
         output = gitlint("-v", _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3])
         expected = u"1: T3\n1: T5\n2: B4\n"
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)
 
         output = gitlint("-vv", _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3])
         expected = u"1: T3 Title has trailing punctuation (.)\n" + \
                    u"1: T5 Title contains the word 'WIP' (case-insensitive)\n" + \
                    u"2: B4 Second line is not empty\n"
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)
 
         output = gitlint("-vvv", _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3])
         expected = u"1: T3 Title has trailing punctuation (.): \"WIP: Thïs is a title.\"\n" + \
                    u"1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP: Thïs is a title.\"\n" + \
                    u"2: B4 Second line is not empty: \"Contënt on the second line\"\n"
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)
 
         # test silent mode
         output = gitlint("--silent", _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3])
-        self.assertEqual(output, "")
+        self.assertEqualStdout(output, "")
 
     def test_set_rule_option(self):
         self._create_simple_commit(u"This ïs a title.")
@@ -53,7 +53,7 @@ class ConfigTests(BaseTestCase):
         expected = u"1: T1 Title exceeds max length (16>5): \"This ïs a title.\"\n" + \
                    u"1: T3 Title has trailing punctuation (.): \"This ïs a title.\"\n" + \
                    "3: B6 Body message is missing\n"
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)
 
     def test_config_from_file(self):
         commit_msg = u"WIP: Thïs is a title thåt is a bit longer.\nContent on the second line\n" + \
@@ -68,7 +68,7 @@ class ConfigTests(BaseTestCase):
                    "2: B4 Second line is not empty\n" + \
                    "3: B1 Line exceeds max length (48>30)\n"
 
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)
 
     def test_config_from_file_debug(self):
         commit_msg = u"WIP: Thïs is a title thåt is a bit longer.\nContent on the second line\n" + \
@@ -89,4 +89,4 @@ class ConfigTests(BaseTestCase):
                                                        'config_path': config_path, 'target': self.tmp_git_repo,
                                                        'commit_sha': commit_sha, 'commit_date': expected_date})
 
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)

--- a/qa/test_hooks.py
+++ b/qa/test_hooks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+# pylint: disable=too-many-function-args,unexpected-keyword-arg
 from sh import git, gitlint  # pylint: disable=no-name-in-module
 from qa.base import BaseTestCase
 
@@ -24,14 +24,14 @@ class HookTests(BaseTestCase):
         output_installed = gitlint("install-hook", _cwd=self.tmp_git_repo)
         expected_installed = u"Successfully installed gitlint commit-msg hook in %s/.git/hooks/commit-msg\n" % \
                              self.tmp_git_repo
-        self.assertEqual(output_installed, expected_installed)
+        self.assertEqualStdout(output_installed, expected_installed)
 
     def tearDown(self):
         # uninstall git commit-msg hook and assert output
         output_uninstalled = gitlint("uninstall-hook", _cwd=self.tmp_git_repo)
         expected_uninstalled = u"Successfully uninstalled gitlint commit-msg hook from %s/.git/hooks/commit-msg\n" % \
                                self.tmp_git_repo
-        self.assertEqual(output_uninstalled, expected_uninstalled)
+        self.assertEqualStdout(output_uninstalled, expected_uninstalled)
 
     def _violations(self):
         # Make a copy of the violations array so that we don't inadvertently edit it in the test (like I did :D)
@@ -63,7 +63,11 @@ class HookTests(BaseTestCase):
                             " 1 file changed, 0 insertions(+), 0 deletions(-)\n",
                             u" create mode 100644 %s\n" % test_filename]
 
-        self.assertListEqual(expected_output, self.githook_output)
+        assert len(self.githook_output) == len(expected_output)
+        for output, expected in zip(self.githook_output, expected_output):
+            self.assertMultiLineEqual(
+                output.replace('\r', ''),
+                expected.replace('\r', ''))
 
     def test_commit_hook_abort(self):
         self.responses = ["n"]
@@ -89,7 +93,7 @@ class HookTests(BaseTestCase):
         self.responses = ["e", "y"]
         env = {"EDITOR": ":"}
         test_filename = self._create_simple_commit(u"WIP: This ïs a title.\nContënt on the second line",
-                                                   out=self._interact, env=env, ok_code=1, tty_in=True)
+                                                   out=self._interact, env=env, tty_in=True)
         git("rm", "-f", test_filename, _cwd=self.tmp_git_repo)
 
         short_hash = git("rev-parse", "--short", "HEAD", _cwd=self.tmp_git_repo, _tty_in=True).replace("\n", "")
@@ -106,4 +110,8 @@ class HookTests(BaseTestCase):
                             " 1 file changed, 0 insertions(+), 0 deletions(-)\n",
                             u" create mode 100644 %s\n" % test_filename]
 
-        self.assertListEqual(expected_output, self.githook_output)
+        assert len(self.githook_output) == len(expected_output)
+        for output, expected in zip(self.githook_output, expected_output):
+            self.assertMultiLineEqual(
+                output.replace('\r', ''),
+                expected.replace('\r', ''))

--- a/qa/test_stdin.py
+++ b/qa/test_stdin.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=too-many-function-args,unexpected-keyword-arg
 import subprocess
 from sh import gitlint, echo  # pylint: disable=no-name-in-module
 from qa.base import BaseTestCase, ustr
@@ -21,7 +22,7 @@ class StdInTests(BaseTestCase):
                    u"1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP: Pïpe test.\"\n" + \
                    u"3: B6 Body message is missing\n"
 
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)
 
     def test_stdin_pipe_empty(self):
         """ Test the scenario where no TTY is attached an nothing is piped into gitlint. This occurs in
@@ -35,12 +36,12 @@ class StdInTests(BaseTestCase):
         # We need to set _err_to_out explicitly for sh to merge stdout and stderr output in case there's
         # no TTY attached to STDIN
         # http://amoffat.github.io/sh/sections/special_arguments.html?highlight=_tty_in#err-to-out
-        output = gitlint(_cwd=self.tmp_git_repo, _in=self.mock_stdin(), _tty_in=False, _err_to_out=True, _ok_code=[3])
+        output = gitlint(echo("-n", ""), _cwd=self.tmp_git_repo, _tty_in=False, _err_to_out=True, _ok_code=[3])
 
         expected = u"1: T3 Title has trailing punctuation (.): \"WIP: This ïs a title.\"\n" + \
             u"1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP: This ïs a title.\"\n" + \
             u"2: B4 Second line is not empty: \"Content on the sëcond line\"\n"
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)
 
     def test_stdin_file(self):
         """ Test the scenario where STDIN is a regular file (stat.S_ISREG = True)

--- a/qa/test_user_defined.py
+++ b/qa/test_user_defined.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+# pylint: disable=too-many-function-args,unexpected-keyword-arg
 from sh import gitlint  # pylint: disable=no-name-in-module
 from qa.base import BaseTestCase
 
@@ -16,7 +16,7 @@ class UserDefinedRuleTests(BaseTestCase):
                    "1: UC2 Body does not contain a 'Signed-Off-By' line\n" + \
                    u"1: UL1 Title contains the special character '$': \"WIP: Thi$ is å title\"\n" + \
                    "2: B4 Second line is not empty: \"Content on the second line\"\n"
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)
 
     def test_user_defined_rules_with_config(self):
         extra_path = self.get_example_path()
@@ -30,11 +30,11 @@ class UserDefinedRuleTests(BaseTestCase):
                    u"1: UL1 Title contains the special character '$': \"WIP: Thi$ is å title\"\n" + \
                    "2: B4 Second line is not empty: \"Content on the second line\"\n"
 
-        self.assertEqual(output, expected)
+        self.assertEqualStdout(output, expected)
 
     def test_invalid_user_defined_rules(self):
         extra_path = self.get_sample_path("user_rules/incorrect_linerule")
         self._create_simple_commit("WIP: test")
         output = gitlint("--extra-path", extra_path, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[255])
-        self.assertEqual(output,
-                         "Config Error: User-defined rule class 'MyUserLineRule' must have a 'validate' method\n")
+        self.assertEqualStdout(output,
+                               "Config Error: User-defined rule class 'MyUserLineRule' must have a 'validate' method\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 setuptools
-wheel==0.24.0
-Click==6.6
-sh==1.11; sys_platform != 'win32' # sh is not supported on windows
+wheel==0.29.0; python_version == '2.6' or python_version == '3.3'
+wheel==0.32.2; python_version != '2.6' and python_version != '3.3'
+Click==6.7
+sh==1.12.14; sys_platform != 'win32' # sh is not supported on windows
 arrow==0.10.0
 ordereddict==1.1; python_version < '2.7'
 importlib==1.0.3; python_version < '2.7'

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Environment :: Console",
@@ -65,7 +66,7 @@ setup(
         "License :: OSI Approved :: MIT License"
     ],
     install_requires=[
-        'Click==6.6',
+        'Click==6.7',
         'arrow==0.10.0'
     ],
     extras_require={
@@ -74,7 +75,7 @@ setup(
             'ordereddict==1.1',
         ],
         ':sys_platform != "win32"': [
-            'sh==1.11',
+            'sh==1.12.14',
         ],
     },
     keywords='gitlint git lint',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,13 +1,17 @@
-discover==0.4.0 # support for python 2.6
-unittest2==1.1.0 # support for python 2.6
+discover==0.4.0; python_version < '2.7'
+unittest2==1.1.0; python_version <= '2.7'
 flake8==2.6.2; python_version < '2.7'
 flake8==3.2.1; python_version >= '2.7'
-coverage==3.7.1
-python-coveralls==2.9.0
+coverage==4.0.3
+python-coveralls==2.9.1
 radon==1.4.2
 mock==2.0.0
-pytest==3.0.4
+pytest==3.2.5; python_version == '2.6' or python_version == '3.3'
+pytest==3.10.0; python_version != '2.6' and python_version != '3.3'
 pylint<1.4; python_version < '2.7'
 astroid<=1.3.2; python_version < '2.7' # astroid is a pylint dependency
-pylint==1.6.4; python_version >= '2.7'
+isort==4.2.15; python_version == '3.3' # specific version for pylint 1.7.6
+pylint==1.9.2; python_version == '2.7'
+pylint==1.7.6; python_version == '3.3'
+pylint==2.1.1; python_version >= '3.4'
 -e .


### PR DESCRIPTION
An expectation of the `test_target` is that `git` prints a specific
error message when run outside a workdir. This message was changed in
one of the last `git` releases, so the test fails.

Make the `test_target` less strict regarding the message content, just
looking for the 'not a git repository' ought to be enough.

Fixes #78 for me