### PR TITLE
Improve handling of piped data in CI environment

### DIFF
--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -122,7 +122,7 @@ def get_stdin_data():
         # i.e. don't consider empty piped data
         if input_data:
             stdin_data = ustr(input_data)
-            LOG.debug("stdin data:\n%s", stdin_data)
+            LOG.debug("stdin data:\n%r", stdin_data)
             return stdin_data
     return False
 

--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -121,7 +121,9 @@ def get_stdin_data():
         # Only return the input data if there's actually something passed
         # i.e. don't consider empty piped data
         if input_data:
-            return ustr(input_data)
+            stdin_data = ustr(input_data)
+            LOG.debug("stdin data:\n%s", stdin_data)
+            return stdin_data
     return False
 
 

--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -119,11 +119,12 @@ def get_stdin_data():
     if stdin_is_pipe_or_file:
         input_data = sys.stdin.read()
         # Only return the input data if there's actually something passed
-        # i.e. don't consider empty piped data
+        # i.e. don't consider empty (or whitespace-only) piped data
         if input_data:
-            stdin_data = ustr(input_data)
-            LOG.debug("stdin data:\n%r", stdin_data)
-            return stdin_data
+            LOG.debug("input data:\n%r", input_data)
+            if not input_data.isspace():
+                stdin_data = ustr(input_data)
+                return stdin_data
     return False
 
 


### PR DESCRIPTION
Basically, gitlint failed to work successfully on internally-hosted QuickBuild instance.

Apparently "\n" string was piped to gitlint process, which was enough to early exit from "local repository" case. This patch attempts to avoid such case by rejecting whitespace-only piped content. Also, additional debug log is added to improve available debug info when -d switch is used.
