### PR TITLE
Initial implementation of 'ignore-stdin' flag

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,4 +161,4 @@ debug                 | false         | >= 0.7.1         |  ```--debug```       
 target                | (empty)       | >= 0.8.0         |  ```--target=/home/joe/myrepo/   ```                   | Target git repository gitlint should be linting against.
 extra-path            | (empty)       | >= 0.8.0         |  ```--extra-path=/home/joe/rules/```                   | Path where gitlint looks for [user-defined rules](user_defined_rules.md).
 contrib               | (empty)       | >= 0.12.0        | ```--contrib=contrib-title-conventional-commits,CC1``` | [Contrib rules](contrib_rules) to enable.
-force-target-repo     | false         | >= 0.12.0        | ```--force-target-repo``` or ```-f```                  | Ignore stdin and always select target repo.
+ignore-stdin          | false         | >= 0.12.0        | ```--ignore-stdin```                                   | Ignore any stdin data. Useful for running in CI server.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,3 +161,4 @@ debug                 | false         | >= 0.7.1         |  ```--debug```       
 target                | (empty)       | >= 0.8.0         |  ```--target=/home/joe/myrepo/   ```                   | Target git repository gitlint should be linting against.
 extra-path            | (empty)       | >= 0.8.0         |  ```--extra-path=/home/joe/rules/```                   | Path where gitlint looks for [user-defined rules](user_defined_rules.md).
 contrib               | (empty)       | >= 0.12.0        | ```--contrib=contrib-title-conventional-commits,CC1``` | [Contrib rules](contrib_rules) to enable.
+force-target-repo     | false         | >= 0.12.0        | ```--force-target-repo``` or ```-f```                  | Ignore stdin and always select target repo.

--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -149,7 +149,7 @@ def get_stdin_data():
 @click.option('--ignore', default="", help="Ignore rules (comma-separated by id or name).")
 @click.option('--contrib', default="", help="Contrib rules to enable (comma-separated by id or name).")
 @click.option('--msg-filename', type=click.File(), help="Path to a file containing a commit-msg.")
-@click.option('--ignore-stdin', is_flag=True, help="Ignore stdin and always select target repo.")
+@click.option('--ignore-stdin', is_flag=True, help="Ignore any stdin data. Useful for running in CI server.")
 @click.option('-v', '--verbose', count=True, default=0,
               help="Verbosity, more v's for more verbose output (e.g.: -v, -vv, -vvv). [default: -vvv]", )
 @click.option('-s', '--silent', help="Silent mode (no output). Takes precedence over -v, -vv, -vvv.", is_flag=True)

--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -54,7 +54,9 @@ def log_system_info():
     LOG.debug("Gitlint version: %s", gitlint.__version__)
 
 
-def build_config(ctx, target, config_path, c, extra_path, ignore, contrib, verbose, silent, debug):
+def build_config(  # pylint: disable=too-many-arguments
+        ctx, target, config_path, c, extra_path, ignore, contrib, force_target_repo, verbose, silent, debug
+):
     """ Creates a LintConfig object based on a set of commandline parameters. """
     config_builder = LintConfigBuilder()
     try:
@@ -74,6 +76,9 @@ def build_config(ctx, target, config_path, c, extra_path, ignore, contrib, verbo
 
         if contrib:
             config_builder.set_option('general', 'contrib', contrib)
+
+        if force_target_repo:
+            config_builder.set_option('general', 'force-target-repo', force_target_repo)
 
         if silent:
             config_builder.set_option('general', 'verbosity', 0)
@@ -144,6 +149,7 @@ def get_stdin_data():
 @click.option('--ignore', default="", help="Ignore rules (comma-separated by id or name).")
 @click.option('--contrib', default="", help="Contrib rules to enable (comma-separated by id or name).")
 @click.option('--msg-filename', type=click.File(), help="Path to a file containing a commit-msg.")
+@click.option('-f', "--force-target-repo", is_flag=True, help="Ignore stdin and always select target repo.")
 @click.option('-v', '--verbose', count=True, default=0,
               help="Verbosity, more v's for more verbose output (e.g.: -v, -vv, -vvv). [default: -vvv]", )
 @click.option('-s', '--silent', help="Silent mode (no output). Takes precedence over -v, -vv, -vvv.", is_flag=True)
@@ -152,7 +158,7 @@ def get_stdin_data():
 @click.pass_context
 def cli(  # pylint: disable=too-many-arguments
         ctx, target, config, c, commits, extra_path, ignore, contrib,
-        msg_filename, verbose, silent, debug,
+        msg_filename, force_target_repo, verbose, silent, debug,
 ):
     """ Git lint tool, checks your git commit messages for styling issues """
 
@@ -165,7 +171,7 @@ def cli(  # pylint: disable=too-many-arguments
         # Get the lint config from the commandline parameters and
         # store it in the context (click allows storing an arbitrary object in ctx.obj).
         config, config_builder = build_config(ctx, target, config, c, extra_path,
-                                              ignore, contrib, verbose, silent, debug)
+                                              ignore, contrib, force_target_repo, verbose, silent, debug)
 
         LOG.debug(u"Configuration\n%s", ustr(config))
 
@@ -193,11 +199,14 @@ def lint(ctx):
     # 2. Any data sent to stdin
     # 3. Fallback to reading from local repository
     stdin_input = get_stdin_data()
+    if stdin_input:
+        LOG.debug("Stdin data: %r", stdin_input)
+
     if msg_filename:
         LOG.debug("Attempting to read from --msg-filename.")
         gitcontext = GitContext.from_commit_msg(ustr(msg_filename.read()))
-    elif stdin_input:
-        LOG.debug("No --msg-filename flag. Attempting to read from stdin.")
+    elif stdin_input and not lint_config.force_target_repo:
+        LOG.debug("No --msg-filename nor --force-target-repo flag. Using data passed via stdin.")
         gitcontext = GitContext.from_commit_msg(stdin_input)
     else:
         LOG.debug("No --msg-filename flag, no or empty data passed to stdin. Attempting to read from the local repo.")

--- a/gitlint/config.py
+++ b/gitlint/config.py
@@ -74,8 +74,8 @@ class LintConfig(object):
         self._ignore = options.ListOption('ignore', [], 'List of rule-ids to ignore')
         self._contrib = options.ListOption('contrib', [], 'List of contrib-rules to enable')
         self._config_path = None
-        force_target_repo_description = "Ignore stdin and always select target repo."
-        self._force_target_repo = options.BoolOption('force-target-repo', False, force_target_repo_description)
+        ignore_stdin_description = "Ignore any stdin data. Useful for running in CI server."
+        self._ignore_stdin = options.BoolOption('ignore-stdin', False, ignore_stdin_description)
 
     @property
     def target(self):
@@ -211,13 +211,13 @@ class LintConfig(object):
             raise LintConfigError(ustr(e))
 
     @property
-    def force_target_repo(self):
-        return self._force_target_repo.value
+    def ignore_stdin(self):
+        return self._ignore_stdin.value
 
-    @force_target_repo.setter
+    @ignore_stdin.setter
     @handle_option_error
-    def force_target_repo(self, value):
-        return self._force_target_repo.set(value)
+    def ignore_stdin(self, value):
+        return self._ignore_stdin.set(value)
 
     @property
     def rules(self):

--- a/gitlint/config.py
+++ b/gitlint/config.py
@@ -74,6 +74,8 @@ class LintConfig(object):
         self._ignore = options.ListOption('ignore', [], 'List of rule-ids to ignore')
         self._contrib = options.ListOption('contrib', [], 'List of contrib-rules to enable')
         self._config_path = None
+        force_target_repo_description = "Ignore stdin and always select target repo."
+        self._force_target_repo = options.BoolOption('force-target-repo', False, force_target_repo_description)
 
     @property
     def target(self):
@@ -207,6 +209,15 @@ class LintConfig(object):
 
         except (options.RuleOptionError, rules.UserRuleError) as e:
             raise LintConfigError(ustr(e))
+
+    @property
+    def force_target_repo(self):
+        return self._force_target_repo.value
+
+    @force_target_repo.setter
+    @handle_option_error
+    def force_target_repo(self, value):
+        return self._force_target_repo.set(value)
 
     @property
     def rules(self):

--- a/gitlint/tests/test_cli.py
+++ b/gitlint/tests/test_cli.py
@@ -200,8 +200,8 @@ class CLITests(BaseTestCase):
 
     @patch('gitlint.cli.get_stdin_data', return_value="Should be ignored\n")
     @patch('gitlint.git.sh')
-    def test_lint_force_target_repo(self, sh, _):
-        """ Test for ignoring stdin when --force-target-repo flag is enabled"""
+    def test_lint_ignore_stdin(self, sh, _):
+        """ Test for ignoring stdin when --ignore-stdin flag is enabled"""
         sh.git.side_effect = self.GIT_CONFIG_SIDE_EFFECTS + [
             "6f29bf81a8322a04071bb794666e48c443a90360",
             u"test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 01:00\x00åbc\n"
@@ -210,7 +210,7 @@ class CLITests(BaseTestCase):
         ]
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
-            result = self.cli.invoke(cli.cli, ["--force-target-repo"])
+            result = self.cli.invoke(cli.cli, ["--ignore-stdin"])
             self.assertEqual(stderr.getvalue(), u'3: B5 Body message is too short (11<20): "commït-body"\n')
             self.assertEqual(result.exit_code, 1)
 

--- a/gitlint/tests/test_cli.py
+++ b/gitlint/tests/test_cli.py
@@ -198,6 +198,22 @@ class CLITests(BaseTestCase):
             self.assertEqual(result.exit_code, 3)
             self.assertEqual(result.output, "")
 
+    @patch('gitlint.cli.get_stdin_data', return_value="Should be ignored\n")
+    @patch('gitlint.git.sh')
+    def test_lint_force_target_repo(self, sh, _):
+        """ Test for ignoring stdin when --force-target-repo flag is enabled"""
+        sh.git.side_effect = self.GIT_CONFIG_SIDE_EFFECTS + [
+            "6f29bf81a8322a04071bb794666e48c443a90360",
+            u"test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 01:00\x00åbc\n"
+            u"commït-title\n\ncommït-body",
+            u"file1.txt\npåth/to/file2.txt\n"
+        ]
+
+        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+            result = self.cli.invoke(cli.cli, ["--force-target-repo"])
+            self.assertEqual(stderr.getvalue(), u'3: B5 Body message is too short (11<20): "commït-body"\n')
+            self.assertEqual(result.exit_code, 1)
+
     @patch('gitlint.cli.get_stdin_data', return_value=False)
     def test_msg_filename(self, _):
         expected_output = u"3: B6 Body message is missing\n"


### PR DESCRIPTION
This feature is beneficial when running in automated environments
liek CI servers. Current heuristic fails in some conditions.
With this flag enabled we can simply always ignore stdin
and fall back to using target repo.

Closes #56

Needs further discussion, especially regarding actual naming of flag (maybe disregard_stdin would be better idea), test coverage and docs examples.

Feature itself is kind of "meh, boring" :) .