### PR TITLE
replace readfp with Python2 read_file function, to fix a test failure:

### DIFF
--- a/gitlint/config.py
+++ b/gitlint/config.py
@@ -374,8 +374,7 @@ class LintConfigBuilder(object):
             parser = ConfigParser()
 
             with io.open(filename, encoding=DEFAULT_ENCODING) as config_file:
-                # readfp() is deprecated in python 3.2+, but compatible with 2.7
-                parser.readfp(config_file, filename)  # pylint: disable=deprecated-method
+                parser.read_file(config_file)
 
             for section_name in parser.sections():
                 for option_name, option_value in parser.items(section_name):


### PR DESCRIPTION
```
======================================================================
FAIL: test_config_file (test_cli.CLITests)
Test for --config option
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.7/unittest/mock.py", line 1248, in patched
    return func(*args, **keywargs)
  File "/<<PKGBUILDDIR>>/gitlint/tests/test_cli.py", line 372, in test_config_file
    self.assertEqual(result.output, "")
AssertionError: "/<<PKGBUILDDIR>>/git[197 chars]od\n" != ''
- /<<PKGBUILDDIR>>/gitlint/config.py:366: DeprecationWarning: This method will be removed in future versions.  Use 'parser.read_file()' instead.
-   parser.readfp(config_file, filename)  # pylint: disable=deprecated-method
```