### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
   include:
     - python: "2.7"
       os: linux
-    - python: "3.4"
-      os: linux
     - python: "3.5"
       os: linux
     - python: "3.6"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.13.0 (next up)
 - Python 3.8 support
+- Python 3.4 no longer supported (it has [reached EOL](https://www.python.org/dev/peps/pep-0429/#id4) and an increasing
+  of gitlint's dependencies have dropped support which makes it hard to maintain).
 
 ## v0.12.0 (2019-07-15) ##
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ INSTALL_DEPS=<<EOF
 cd /vagrant
 sudo add-apt-repository -y ppa:deadsnakes/ppa
 sudo apt-get update
-sudo apt-get install -y --allow-unauthenticated python2.7-dev python3.4-dev python3.5-dev python3.6-dev python3.7-dev python3.8-dev
+sudo apt-get install -y --allow-unauthenticated python2.7-dev python3.5-dev python3.6-dev python3.7-dev python3.8-dev
 sudo apt-get install -y --allow-unauthenticated python3.8-distutils # Needed to work around python3.8+virtualenv issue
 sudo apt-get install -y python-virtualenv git ipython python-pip python3-pip silversearcher-ag jq
 sudo apt-get purge -y python3-virtualenv

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -55,7 +55,7 @@ To run tests:
 ./run_tests.sh --all                 # Run unit, integration, pep8 and gitlint checks
 ```
 
-The ```Vagrantfile``` comes with ```virtualenv```s for python 2.7, 3.4, 3.5, 3.6, 3.7 and pypy2.
+The ```Vagrantfile``` comes with ```virtualenv```s for python 2.7, 3.5, 3.6, 3.7 and pypy2.
 You can easily run tests against specific python environments by using the following commands *inside* of the Vagrant VM:
 ```
 ./run_tests.sh --envs 27               # Run the unit tests against Python 2.7

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ useful throughout the years.
  - **Easily configurable:** Gitlint has sane defaults, but [you can also easily customize it to your own liking](configuration.md).
  - **Community contributed rules**: Conventions that are common but not universal [can be selectively enabled](contrib_rules).
  - **User-defined rules:** Want to do more then what gitlint offers out of the box? Write your own [user defined rules](user_defined_rules.md).
- - **Broad python version support:** Gitlint supports python versions 2.7, 3.4+, PyPy2 and PyPy3.5.
+ - **Broad python version support:** Gitlint supports python versions 2.7, 3.5+, PyPy2 and PyPy3.5.
  - **Full unicode support:** Lint your Russian, Chinese or Emoji commit messages with ease!
  - **Production-ready:** Gitlint checks a lot of the boxes you're looking for: high unit test coverage, integration tests,
    python code standards (pep8, pylint), good documentation, proven track record.

--- a/qa/requirements.txt
+++ b/qa/requirements.txt
@@ -1,5 +1,4 @@
 sh==1.12.14
 pytest==4.6.3;
-arrow==0.14.2; python_version != '3.4'
-arrow==0.13.2; python_version == '3.4'
+arrow==0.14.2;
 gitlint # no version as you want to test the currently installed version

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ setuptools
 wheel==0.33.4
 Click==7.0
 sh==1.12.14; sys_platform != 'win32' # sh is not supported on windows
-arrow==0.14.2; python_version != '3.4'
-arrow==0.13.2; python_version == '3.4'
+arrow==0.14.2;

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -13,7 +13,7 @@ help(){
     echo "  -b, --build              Run build tests"
     echo "  -a, --all                Run all tests and checks (unit, integration, pep8, git)"
     echo "  -e, --envs [ENV1],[ENV2] Run tests against specified python environments"
-    echo "                           (envs: 27,34,35,36,37,pypy2,pypy35)."
+    echo "                           (envs: 27,35,36,37,pypy2,pypy35)."
     echo "                           Also works for integration, pep8 and lint tests."
     echo "  -C, --container          Run the specified command in the container for the --envs specified"
     echo "  --all-env                Run all tests against all python environments"
@@ -366,7 +366,7 @@ uninstall_container(){
 
 assert_specific_env(){
     if [ -z "$1" ] || [ "$1" == "default" ]; then
-        fatal "ERROR: Please specify one or more valid python environments using --envs: 27,34,35,36,37,pypy2,pypy35"
+        fatal "ERROR: Please specify one or more valid python environments using --envs: 27,35,36,37,pypy2,pypy35"
         exit 1
     fi
 }
@@ -452,7 +452,7 @@ exit_code=0
 
 # If the users specified 'all', then just replace $envs with the list of all envs
 if [ "$envs" == "all" ]; then
-    envs="27,34,35,36,37,38,pypy2,pypy35"
+    envs="27,35,36,37,38,pypy2,pypy35"
 fi
 original_envs="$envs"
 envs=$(echo "$envs" | tr ',' '\n') # Split the env list on comma so we can loop through it

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -72,9 +71,6 @@ setup(
     extras_require={
         ':python_version != "3.4"': [
             'arrow==0.14.2',
-        ],
-        ':python_version == "3.4"': [
-            'arrow==0.13.2',
         ],
         ':sys_platform != "win32"': [
             'sh==1.12.14',


### PR DESCRIPTION
Python 3.4 has reached EOL and an increasing number of gitlint's
dependencies have dropped support which makes it hard to maintain.