### PR TITLE
Local commit lazy evaluation

### DIFF
--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -219,9 +219,10 @@ def lint(ctx):
     # where users are using --commits in a check job to check the commit messages inside a CI job. By returning 0, we
     # ensure that these jobs don't fail if for whatever reason the specified commit range is empty.
     if number_of_commits == 0:
-        LOG.debug(u'No commits in range "%s"', ctx.obj[2])
+        LOG.debug(u'No commits in range "%s"', refspec)
         ctx.exit(0)
 
+    LOG.debug(u'Linting %d commit(s)', number_of_commits)
     general_config_builder = ctx.obj[1]
     last_commit = gitcontext.commits[-1]
 

--- a/gitlint/tests/expected/test_cli/test_debug_1
+++ b/gitlint/tests/expected/test_cli/test_debug_1
@@ -50,6 +50,7 @@ target: {target}
      regex=[^@ ]+@[^@ ]+\.[^@ ]+
 
 DEBUG: gitlint.cli No --msg-filename flag, no or empty data passed to stdin. Attempting to read from the local repo.
+DEBUG: gitlint.cli Linting 3 commit(s)
 DEBUG: gitlint.lint Linting commit 6f29bf81a8322a04071bb794666e48c443a90360
 DEBUG: gitlint.lint Commit Object
 --- Commit Message ----

--- a/gitlint/tests/test_cli.py
+++ b/gitlint/tests/test_cli.py
@@ -93,13 +93,10 @@ class CLITests(BaseTestCase):
             # git log --pretty <FORMAT> <SHA>
             u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01 :00\x00åbc\n"
             u"commït-title1\n\ncommït-body1",
-            u"file1.txt\npåth/to/file2.txt\n",  # git diff-tree <SHA>
             u"test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 01:00\x00åbc\n"
             u"commït-title2\n\ncommït-body2",
-            u"file4.txt\npåth/to/file5.txt\n",
             u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00åbc\n"
             u"commït-title3\n\ncommït-body3",
-            u"file6.txt\npåth/to/file7.txt\n"
         ]
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
@@ -120,13 +117,10 @@ class CLITests(BaseTestCase):
             # git log --pretty <FORMAT> <SHA>
             u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01:00\x00åbc\n"
             u"commït-title1\n\ncommït-body1",
-            u"file1.txt\npåth/to/file2.txt\n",  # git diff-tree <SHA>
             u"test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 01:00\x00åbc\n"
             u"commït-title2.\n\ncommït-body2\ngitlint-ignore: T3\n",
-            u"file4.txt\npåth/to/file5.txt\n",
             u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00åbc\n"
             u"commït-title3.\n\ncommït-body3",
-            u"file6.txt\npåth/to/file7.txt\n"
         ]
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
@@ -149,16 +143,13 @@ class CLITests(BaseTestCase):
             # git log --pretty <FORMAT> <SHA>
             u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01:00\x00åbc\n"
             u"commït-title1\n\ncommït-body1",
-            u"file1.txt\npåth/to/file2.txt\n",  # git diff-tree <SHA>
             u"test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 01:00\x00åbc\n"
             # Normally T3 violation (trailing punctuation), but this commit is ignored because of
             # config below
             u"commït-title2.\n\ncommït-body2\n",
-            u"file4.txt\npåth/to/file5.txt\n",
             u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00åbc\n"
             # Normally T1 and B5 violations, now only T1 because we're ignoring B5 in config below
             u"commït-title3.\n\ncommït-body3 foo",
-            u"file6.txt\npåth/to/file7.txt\n"
         ]
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
@@ -264,15 +255,13 @@ class CLITests(BaseTestCase):
             "6f29bf81a8322a04071bb794666e48c443a90360\n"  # git rev-list <SHA>
             "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n"
             "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
+            # git log --pretty <FORMAT> <SHA>
             u"test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 01:00\x00abc\n"
             u"commït-title1\n\ncommït-body1",
-            u"file1.txt\npåth/to/file2.txt\n",
             u"test åuthor2\x00test-email2@föo.com\x002016-12-04 15:28:15 01:00\x00abc\n"
             u"commït-title2.\n\ncommït-body2",
-            u"file4.txt\npåth/to/file5.txt\n",
             u"test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 01:00\x00abc\n"
             u"föo\nbar",
-            u"file6.txt\npåth/to/file7.txt\n"
         ]
 
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:

--- a/qa/expected/test_config/test_config_from_file_debug_1
+++ b/qa/expected/test_config/test_config_from_file_debug_1
@@ -50,6 +50,7 @@ target: {target}
      regex=[^@ ]+@[^@ ]+\.[^@ ]+
 
 DEBUG: gitlint.cli No --msg-filename flag, no or empty data passed to stdin. Attempting to read from the local repo.
+DEBUG: gitlint.cli Linting 1 commit(s)
 DEBUG: gitlint.lint Linting commit {commit_sha}
 DEBUG: gitlint.lint Commit Object
 --- Commit Message ----


### PR DESCRIPTION
Gitlint now defers reading information from a local git repository until a
certain git property is accessed for the first time.

This will allow us to expose more git repository properties for
rules to consume without incurring a performance penalty when those properties
are not used.

In addition, reading the required info when it's needed rather
than up front avoids adding delay during gitlint startup time and reduces
gitlint's memory footprint.