### PR TITLE
GitCommit branches property

### DIFF
--- a/docs/user_defined_rules.md
+++ b/docs/user_defined_rules.md
@@ -176,6 +176,7 @@ commit.is_fixup_commit  | boolean        | Boolean indicating whether the commit
 commit.is_squash_commit | boolean        | Boolean indicating whether the commit is a squash commit or not.
 commit.parents          | list of string | List of parent commit ```sha```s (only for merge commits).
 commit.changed_files    | list of string | List of files changed in the commit (relative paths).
+commit.branches         | list of string | List of branch names the commit is part of
 commit.context          | object         | Object pointing to the bigger git context that the commit is part of
 commit.context.commits  | list of commit | List of commits in the git context. Note that this might only be the subset of commits that gitlint is acting on, not all commits in the repo.
 

--- a/gitlint/utils.py
+++ b/gitlint/utils.py
@@ -95,6 +95,11 @@ def sstr(obj):
     and to unicode in python 3.
     Especially useful for implementing __str__ methods in python 2: http://stackoverflow.com/a/1307210/381010"""
     if sys.version_info[0] == 2:
+        # For lists in python2, remove unicode string representation characters.
+        # i.e. ensure lists are printed as ['a', 'b'] and not [u'a', u'b']
+        if type(obj) in [list]:
+            return [unicode(item).encode(DEFAULT_ENCODING) for item in obj] # pragma: no cover # noqa
+
         return unicode(obj).encode(DEFAULT_ENCODING)  # pragma: no cover # noqa
     else:
         return obj  # pragma: no cover

--- a/qa/expected/test_user_defined/test_user_defined_rules_1
+++ b/qa/expected/test_user_defined/test_user_defined_rules_1
@@ -1,4 +1,5 @@
 1: T5 Title contains the word 'WIP' (case-insensitive): "WIP: Thi$ is å title"
 1: UC2 Body does not contain a 'Signed-Off-By' line
+1: UC3 Branch name 'master' does not start with one of ['feature/', 'hotfix/', 'release/']
 1: UL1 Title contains the special character '$': "WIP: Thi$ is å title"
 2: B4 Second line is not empty: "Content on the second line"

--- a/qa/expected/test_user_defined/test_user_defined_rules_with_config_1
+++ b/qa/expected/test_user_defined/test_user_defined_rules_with_config_1
@@ -1,5 +1,6 @@
 1: T5 Title contains the word 'WIP' (case-insensitive): "WIP: Thi$ is å title"
 1: UC1 Body contains too many lines (2 > 1)
 1: UC2 Body does not contain a 'Signed-Off-By' line
+1: UC3 Branch name 'master' does not start with one of ['feature/', 'hotfix/', 'release/']
 1: UL1 Title contains the special character '$': "WIP: Thi$ is å title"
 2: B4 Second line is not empty: "Content on the second line"

--- a/qa/test_user_defined.py
+++ b/qa/test_user_defined.py
@@ -11,7 +11,7 @@ class UserDefinedRuleTests(BaseTestCase):
         extra_path = self.get_example_path()
         commit_msg = u"WIP: Thi$ is å title\nContent on the second line"
         self._create_simple_commit(commit_msg)
-        output = gitlint("--extra-path", extra_path, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[4])
+        output = gitlint("--extra-path", extra_path, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[5])
         self.assertEqualStdout(output, self.get_expected("test_user_defined/test_user_defined_rules_1"))
 
     def test_user_defined_rules_with_config(self):
@@ -19,7 +19,7 @@ class UserDefinedRuleTests(BaseTestCase):
         commit_msg = u"WIP: Thi$ is å title\nContent on the second line"
         self._create_simple_commit(commit_msg)
         output = gitlint("--extra-path", extra_path, "-c", "body-max-line-count.max-line-count=1",
-                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[5])
+                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[6])
         self.assertEqualStdout(output, self.get_expected("test_user_defined/test_user_defined_rules_with_config_1"))
 
     def test_invalid_user_defined_rules(self):


### PR DESCRIPTION
Each GitCommit object now contains a 'branches' property that can be
used as part of rules.

Also added an extra user-defined rule example that demonstrates this.

This implements #108