### PR TITLE
Unpin requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools
-wheel==0.33.4
-Click==7.0
-sh==1.12.14; sys_platform != 'win32' # sh is not supported on windows
-arrow==0.15.5;
+wheel>=0.33.4
+Click>=7.0
+sh>=1.12.14; sys_platform != 'win32' # sh is not supported on windows
+arrow>=0.15.5;


### PR DESCRIPTION
Pinning requirements for no specific reasons creates installation conflicts and also create extra maintenance requests.

As a linter it is expected to be installed with other similar tools.

Closes: #69