### PR TITLE
Added 'ci' and 'build' to conventional commit types

### DIFF
--- a/docs/contrib_rules.md
+++ b/docs/contrib_rules.md
@@ -53,7 +53,7 @@ CT1   | contrib-title-conventional-commits    | >= 0.12.0          | Enforces [C
 
 Name           | gitlint version    | Default      | Description
 ---------------|--------------------|--------------|----------------------------------
-types          | >= 0.12.0          | `fix,feat,chore,docs,style,refactor,perf,test,revert` | Comma separated list of allowed commit types.
+types          | >= 0.12.0          | `fix,feat,chore,docs,style,refactor,perf,test,revert,ci,build` | Comma separated list of allowed commit types.
 
 
 ## CC1: contrib-requires-signed-off-by ##

--- a/gitlint/contrib/rules/conventional_commit.py
+++ b/gitlint/contrib/rules/conventional_commit.py
@@ -17,7 +17,7 @@ class ConventionalCommit(LineRule):
     options_spec = [
         ListOption(
             "types",
-            ["fix", "feat", "chore", "docs", "style", "refactor", "perf", "test", "revert"],
+            ["fix", "feat", "chore", "docs", "style", "refactor", "perf", "test", "revert", "ci", "build"],
             "Comma separated list of allowed commit types.",
         )
     ]

--- a/gitlint/tests/config/test_config.py
+++ b/gitlint/tests/config/test_config.py
@@ -124,7 +124,7 @@ class LintConfigTests(BaseTestCase):
 
         expected_rule_option = options.ListOption(
             "types",
-            ["fix", "feat", "chore", "docs", "style", "refactor", "perf", "test", "revert"],
+            ["fix", "feat", "chore", "docs", "style", "refactor", "perf", "test", "revert", "ci", "build"],
             "Comma separated list of allowed commit types.",
         )
 

--- a/gitlint/tests/contrib/test_conventional_commit.py
+++ b/gitlint/tests/contrib/test_conventional_commit.py
@@ -19,13 +19,13 @@ class ContribConventionalCommitTests(BaseTestCase):
         rule = ConventionalCommit()
 
         # No violations when using a correct type and format
-        for type in ["fix", "feat", "chore", "docs", "style", "refactor", "perf", "test", "revert"]:
+        for type in ["fix", "feat", "chore", "docs", "style", "refactor", "perf", "test", "revert", "ci", "build"]:
             violations = rule.validate(type + u": föo", None)
             self.assertListEqual([], violations)
 
         # assert violation on wrong type
         expected_violation = RuleViolation("CT1", "Title does not start with one of fix, feat, chore, docs,"
-                                                  " style, refactor, perf, test, revert", u"bår: foo")
+                                                  " style, refactor, perf, test, revert, ci, build", u"bår: foo")
         violations = rule.validate(u"bår: foo", None)
         self.assertListEqual([expected_violation], violations)
 

--- a/gitlint/tests/expected/test_cli/test_contrib_1
+++ b/gitlint/tests/expected/test_cli/test_contrib_1
@@ -1,3 +1,3 @@
 1: CC1 Body does not contain a 'Signed-Off-By' line
-1: CT1 Title does not start with one of fix, feat, chore, docs, style, refactor, perf, test, revert: "Test tïtle"
+1: CT1 Title does not start with one of fix, feat, chore, docs, style, refactor, perf, test, revert, ci, build: "Test tïtle"
 1: CT1 Title does not follow ConventionalCommits.org format 'type(optional-scope): description': "Test tïtle"

--- a/qa/expected/test_contrib/test_contrib_rules_1
+++ b/qa/expected/test_contrib/test_contrib_rules_1
@@ -1,4 +1,4 @@
 1: CC1 Body does not contain a 'Signed-Off-By' line
-1: CT1 Title does not start with one of fix, feat, chore, docs, style, refactor, perf, test, revert: "WIP Thi$ is å title"
+1: CT1 Title does not start with one of fix, feat, chore, docs, style, refactor, perf, test, revert, ci, build: "WIP Thi$ is å title"
 1: CT1 Title does not follow ConventionalCommits.org format 'type(optional-scope): description': "WIP Thi$ is å title"
 1: T5 Title contains the word 'WIP' (case-insensitive): "WIP Thi$ is å title"


### PR DESCRIPTION
This adds "ci" and "build" to the list of allowed conventional commit types.

This completes the list of possible commit message types listed under bullet point 4 in https://www.conventionalcommits.org/en/v1.0.0/#summary.