### PR TITLE
commit-msg hook in python

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -92,8 +92,8 @@ jobs:
       - name: Tests (sanity)
         run: tools\windows\run_tests.bat "gitlint\tests\cli\test_cli.py::CLITests::test_lint"
 
-      - name: Tests (ignore test_cli.py)
-        run: pytest --ignore gitlint\tests\cli\test_cli.py -rw -s gitlint
+      - name: Tests (ignore cli\*)
+        run: pytest --ignore gitlint\tests\cli -rw -s gitlint
 
       - name: Tests (test_cli.py only - continue-on-error:true)
         run: tools\windows\run_tests.bat "gitlint\tests\cli\test_cli.py"

--- a/gitlint/files/commit-msg
+++ b/gitlint/files/commit-msg
@@ -8,74 +8,21 @@ stdin_available=1
 (exec < /dev/tty) 2> /dev/null || stdin_available=0
 
 if [ $stdin_available -eq 1 ]; then
-    # Set bash color codes in case we have a tty
-    RED="\033[31m"
-    YELLOW="\033[33m"
-    GREEN="\033[32m"
-    END_COLOR="\033[0m"
-
     # Now that we know we have a functional tty, set stdin to it so we can ask the user questions :-)
     exec < /dev/tty
-else
-    # Unset bash colors if we don't have a tty
-    RED=""
-    YELLOW=""
-    GREEN=""
-    END_COLOR=""
 fi
 
-run_gitlint(){
-   echo "gitlint: checking commit message..."
-   python -m gitlint.cli --staged --msg-filename "$1"
-   gitlint_exit_code=$?
-}
+gitlint --staged --msg-filename "$1" run-hook
+exit_code=$?
 
-# Prompts a given yes/no question.
-# Returns 0 if user answers yes, 1 if no
-# Reprompts if different answer
-ask_yes_no_edit(){
-    ask_yes_no_edit_result="no"
-    # If we don't have a stdin available, then just return "No".
-    if [ $stdin_available -eq 0 ]; then
-        ask_yes_no_edit_result="no"
-        return;
-    fi
-    # Otherwise, ask the question until the user answers yes or no
-    question="$1"
-    while true; do
-        read -p "$question" yn
-        case $yn in
-             [Yy]* ) ask_yes_no_edit_result="yes"; return;;
-             [Nn]* ) ask_yes_no_edit_result="no"; return;;
-             [Ee]* ) ask_yes_no_edit_result="edit"; return;;
-        esac
-    done
-}
+# If we fail to find the gitlint binary (command not found), let's retry by executing as a python module.
+# This is the case for Atlassian SourceTree, where $PATH deviates from the user's shell $PATH.
+if [ $exit_code -eq 127 ]; then
+    echo "Fallback to python module execution"
+    python -m gitlint.cli --staged --msg-filename "$1" run-hook
+    exit_code=$?
+fi
 
-run_gitlint "$1"
-
-while [ $gitlint_exit_code -gt 0 ]; do
-    echo "-----------------------------------------------"
-    echo "gitlint: ${RED}Your commit message contains the above violations.${END_COLOR}"
-    ask_yes_no_edit "Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] "
-    if [ $ask_yes_no_edit_result = "yes" ]; then
-        exit 0
-    elif [ $ask_yes_no_edit_result = "edit" ]; then
-        EDITOR=${EDITOR:-vim}
-        $EDITOR "$1"
-        run_gitlint "$1"
-    else
-        echo "Commit aborted."
-        echo "Your commit message: "
-        echo "-----------------------------------------------"
-        cat "$1"
-        echo "-----------------------------------------------"
-
-        exit $gitlint_exit_code
-    fi
-done
-
-echo "gitlint: ${GREEN}OK${END_COLOR} (no violations in commit message)"
-exit 0
+exit $exit_code
 
 ### gitlint commit-msg hook end ###

--- a/gitlint/shell.py
+++ b/gitlint/shell.py
@@ -2,12 +2,19 @@
 """
 This module implements a shim for the 'sh' library, mainly for use on Windows (sh is not supported on Windows).
 We might consider removing the 'sh' dependency alltogether in the future, but 'sh' does provide a few
-capabilities wrt dealing with more edge-case environments on *nix systems that might be useful.
+capabilities wrt dealing with more edge-case environments on *nix systems that are useful.
 """
 
 import subprocess
 import sys
 from gitlint.utils import ustr, USE_SH_LIB
+
+
+def shell(cmd):
+    """ Convenience function that opens a given command in a shell. Does not use 'sh' library. """
+    p = subprocess.Popen(cmd, shell=True)
+    p.communicate()
+
 
 if USE_SH_LIB:
     from sh import git  # pylint: disable=unused-import,import-error
@@ -21,7 +28,7 @@ else:
 
     class ShResult(object):
         """ Result wrapper class. We use this to more easily migrate from using https://amoffat.github.io/sh/ to using
-        the builtin subprocess. module """
+        the builtin subprocess module """
 
         def __init__(self, full_cmd, stdout, stderr='', exitcode=0):
             self.full_cmd = full_cmd
@@ -51,7 +58,7 @@ else:
             no_command_error = FileNotFoundError  # noqa pylint: disable=undefined-variable
 
         pipe = subprocess.PIPE
-        popen_kwargs = {'stdout': pipe, 'stderr': pipe, 'shell': kwargs['_tty_out']}
+        popen_kwargs = {'stdout': pipe, 'stderr': pipe, 'shell': kwargs.get('_tty_out', False)}
         if '_cwd' in kwargs:
             popen_kwargs['cwd'] = kwargs['_cwd']
 

--- a/gitlint/tests/cli/test_cli.py
+++ b/gitlint/tests/cli/test_cli.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import contextlib
+
 import io
 import os
 import sys
 import platform
-import shutil
-import tempfile
 
 import arrow
 
@@ -32,15 +30,6 @@ from gitlint.tests.base import BaseTestCase
 from gitlint import cli
 from gitlint import __version__
 from gitlint.utils import DEFAULT_ENCODING
-
-
-@contextlib.contextmanager
-def tempdir():
-    tmpdir = tempfile.mkdtemp()
-    try:
-        yield tmpdir
-    finally:
-        shutil.rmtree(tmpdir)
 
 
 class CLITests(BaseTestCase):
@@ -281,7 +270,7 @@ class CLITests(BaseTestCase):
             u"commit-1/file-1\ncommit-1/file-2\n",        # git diff-tree
         ]
 
-        with tempdir() as tmpdir:
+        with self.tempdir() as tmpdir:
             msg_filename = os.path.join(tmpdir, "msg")
             with io.open(msg_filename, 'w', encoding=DEFAULT_ENCODING) as f:
                 f.write(u"WIP: msg-filename tïtle\n")
@@ -307,7 +296,7 @@ class CLITests(BaseTestCase):
     def test_msg_filename(self, _):
         expected_output = u"3: B6 Body message is missing\n"
 
-        with tempdir() as tmpdir:
+        with self.tempdir() as tmpdir:
             msg_filename = os.path.join(tmpdir, "msg")
             with io.open(msg_filename, 'w', encoding=DEFAULT_ENCODING) as f:
                 f.write(u"Commït title\n")

--- a/gitlint/tests/cli/test_cli_hooks.py
+++ b/gitlint/tests/cli/test_cli_hooks.py
@@ -1,8 +1,16 @@
 # -*- coding: utf-8 -*-
 
+import io
 import os
 
 from click.testing import CliRunner
+
+try:
+    # python 2.x
+    from StringIO import StringIO
+except ImportError:
+    # python 3.x
+    from io import StringIO  # pylint: disable=ungrouped-imports
 
 try:
     # python 2.x
@@ -15,6 +23,8 @@ from gitlint.tests.base import BaseTestCase
 from gitlint import cli
 from gitlint import hooks
 from gitlint import config
+
+from gitlint.utils import DEFAULT_ENCODING
 
 
 class CLIHookTests(BaseTestCase):
@@ -94,3 +104,149 @@ class CLIHookTests(BaseTestCase):
         expected_config = config.LintConfig()
         expected_config.target = os.path.realpath(os.getcwd())
         uninstall_hook.assert_called_once_with(expected_config)
+
+    def test_hook_no_tty(self):
+        """ Test for run-hook subcommand.
+            When no TTY is available (like is the case for this test), the hook will abort after the first check.
+        """
+
+        # No need to patch git as we're passing a msg-filename to run-hook, so no git calls are made.
+        # Note that this is the case when passing --staged as well, but that's tested as part of the integration tests
+        # (=end-to-end scenario).
+
+        # Ideally we'd be able to assert that run-hook internally calls the lint cli command, but couldn't make
+        # that work. Have tried many different variatons of mocking and patching without avail. For now, we just
+        # check the output which indirectly proves the same thing.
+
+        with self.tempdir() as tmpdir:
+            msg_filename = os.path.join(tmpdir, u"hür")
+            with io.open(msg_filename, 'w', encoding=DEFAULT_ENCODING) as f:
+                f.write(u"WIP: tïtle\n")
+
+            with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+                result = self.cli.invoke(cli.cli, ["--msg-filename", msg_filename, "run-hook"])
+                self.assertEqual(result.output, self.get_expected('test_cli_hooks/test_hook_no_tty_1_stdout'))
+                self.assertEqual(stderr.getvalue(), self.get_expected("test_cli_hooks/test_hook_no_tty_1_stderr"))
+
+                # exit code is 1 because aborted (no stdin available)
+                self.assertEqual(result.exit_code, 1)
+
+    @patch('gitlint.cli.shell')
+    def test_hook_edit(self, shell):
+        """ Test for run-hook subcommand, answering 'e(dit)' after commit-hook """
+
+        set_editors = [None, u"myeditor"]
+        expected_editors = [u"vim", u"myeditor"]
+        commit_messages = [u"WIP: höok edit 1", u"WIP: höok edit 2"]
+
+        for i in range(0, len(set_editors)):
+            if set_editors[i]:
+                os.environ['EDITOR'] = set_editors[i]
+
+            with self.patch_input(['e', 'e', 'n']):
+                with self.tempdir() as tmpdir:
+                    msg_filename = os.path.realpath(os.path.join(tmpdir, u"hür"))
+                    with io.open(msg_filename, 'w', encoding=DEFAULT_ENCODING) as f:
+                        f.write(commit_messages[i] + "\n")
+
+                    with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+                        result = self.cli.invoke(cli.cli, ["--msg-filename", msg_filename, "run-hook"])
+                        self.assertEqual(result.output, self.get_expected('test_cli_hooks/test_hook_edit_1_stdout',
+                                                                          {"commit_msg": commit_messages[i]}))
+                        self.assertEqual(stderr.getvalue(), self.get_expected("test_cli_hooks/test_hook_edit_1_stderr",
+                                                                              {"commit_msg": commit_messages[i]}))
+
+                        # exit code = number of violations
+                        self.assertEqual(result.exit_code, 2)
+
+                        shell.assert_called_with([expected_editors[i], msg_filename])
+                        self.assert_log_contains(u"DEBUG: gitlint.cli run-hook: editing commit message")
+                        self.assert_log_contains(u"DEBUG: gitlint.cli run-hook: {0} {1}".format(expected_editors[i],
+                                                                                                msg_filename))
+
+    def test_hook_no(self):
+        """ Test for run-hook subcommand, answering 'n(o)' after commit-hook """
+
+        with self.patch_input(['n']):
+            with self.tempdir() as tmpdir:
+                msg_filename = os.path.join(tmpdir, u"hür")
+                with io.open(msg_filename, 'w', encoding=DEFAULT_ENCODING) as f:
+                    f.write(u"WIP: höok no\n")
+
+                with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+                    result = self.cli.invoke(cli.cli, ["--msg-filename", msg_filename, "run-hook"])
+                    self.assertEqual(result.output, self.get_expected('test_cli_hooks/test_hook_no_1_stdout'))
+                    self.assertEqual(stderr.getvalue(), self.get_expected("test_cli_hooks/test_hook_no_1_stderr"))
+
+                    # We decided not to keep the commit message: hook returns number of violations (>0)
+                    # This will cause git to abort the commit
+                    self.assertEqual(result.exit_code, 2)
+                    self.assert_log_contains("DEBUG: gitlint.cli run-hook: commit message declined")
+
+    def test_hook_yes(self):
+        """ Test for run-hook subcommand, answering 'y(es)' after commit-hook """
+        with self.patch_input(['y']):
+            with self.tempdir() as tmpdir:
+                msg_filename = os.path.join(tmpdir, u"hür")
+                with io.open(msg_filename, 'w', encoding=DEFAULT_ENCODING) as f:
+                    f.write(u"WIP: höok yes\n")
+
+                with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+                    result = self.cli.invoke(cli.cli, ["--msg-filename", msg_filename, "run-hook"])
+                    self.assertEqual(result.output, self.get_expected('test_cli_hooks/test_hook_yes_1_stdout'))
+                    self.assertEqual(stderr.getvalue(), self.get_expected("test_cli_hooks/test_hook_yes_1_stderr"))
+
+                    # Exit code is 0 because we decide to keep the commit message
+                    # This will cause git to keep the commit
+                    self.assertEqual(result.exit_code, 0)
+                    self.assert_log_contains("DEBUG: gitlint.cli run-hook: commit message accepted")
+
+    @patch('gitlint.cli.get_stdin_data', return_value=u"WIP: Test hook stdin tïtle\n")
+    def test_hook_stdin(self, _):
+        """ Test for passing stdin data to run-hook, equivalent of:
+            $ echo "Test hook stdin tïtle" | gitlint run-hook
+        """
+
+        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+            result = self.cli.invoke(cli.cli, ["run-hook"])
+            self.assertEqual(stderr.getvalue(), self.get_expected('test_cli_hooks/test_hook_stdin_1_stderr'))
+            self.assertEqual(result.output, self.get_expected('test_cli_hooks/test_hook_stdin_1_stdout'))
+            # Hook will auto-abort because we're using stdin. Abort = exit code 1
+            self.assertEqual(result.exit_code, 1)
+
+    @patch('gitlint.cli.get_stdin_data', return_value=u"WIP: Test hook config tïtle\n")
+    def test_hook_config(self, _):
+        """ Test that gitlint still respects config when running run-hook, equivalent of:
+            $ echo "Test hook stdin tïtle" | gitlint -c title-max-length.line-length=5 --ignore B6 run-hook
+        """
+
+        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+            result = self.cli.invoke(cli.cli, ["-c", "title-max-length.line-length=5", "--ignore", "B6", "run-hook"])
+            self.assertEqual(stderr.getvalue(), self.get_expected('test_cli_hooks/test_hook_config_1_stderr'))
+            self.assertEqual(result.output, self.get_expected('test_cli_hooks/test_hook_config_1_stdout'))
+            # Hook will auto-abort because we're using stdin. Abort = exit code 1
+            self.assertEqual(result.exit_code, 1)
+
+    @patch('gitlint.cli.get_stdin_data', return_value=False)
+    @patch('gitlint.git.sh')
+    def test_hook_local_commit(self, sh, _):
+        """ Test running the hook on the last commit-msg from the local repo, equivalent of:
+            $ gitlint run-hook
+            and then choosing 'e'
+        """
+        sh.git.side_effect = [
+            "6f29bf81a8322a04071bb794666e48c443a90360",
+            u"test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
+            u"WIP: commït-title\n\ncommït-body",
+            u"#",  # git config --get core.commentchar
+            u"commit-1-branch-1\ncommit-1-branch-2\n",
+            u"file1.txt\npåth/to/file2.txt\n"
+        ]
+
+        with self.patch_input(['e']):
+            with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+                result = self.cli.invoke(cli.cli, ["run-hook"])
+                self.assertEqual(stderr.getvalue(), self.get_expected('test_cli_hooks/test_hook_local_commit_1_stderr'))
+                self.assertEqual(result.output, self.get_expected('test_cli_hooks/test_hook_local_commit_1_stdout'))
+                # If we can't edit the message, run-hook follows regular gitlint behavior and exit code = # violations
+                self.assertEqual(result.exit_code, 2)

--- a/gitlint/tests/expected/test_cli_hooks/test_hook_config_1_stderr
+++ b/gitlint/tests/expected/test_cli_hooks/test_hook_config_1_stderr
@@ -1,0 +1,2 @@
+1: T1 Title exceeds max length (27>5): "WIP: Test hook config tïtle"
+1: T5 Title contains the word 'WIP' (case-insensitive): "WIP: Test hook config tïtle"

--- a/gitlint/tests/expected/test_cli_hooks/test_hook_config_1_stdout
+++ b/gitlint/tests/expected/test_cli_hooks/test_hook_config_1_stdout
@@ -1,0 +1,5 @@
+gitlint: checking commit message...
+-----------------------------------------------
+gitlint: Your commit message contains the above violations.
+Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] 
+Aborted!

--- a/gitlint/tests/expected/test_cli_hooks/test_hook_edit_1_stderr
+++ b/gitlint/tests/expected/test_cli_hooks/test_hook_edit_1_stderr
@@ -1,0 +1,6 @@
+1: T5 Title contains the word 'WIP' (case-insensitive): "{commit_msg}"
+3: B6 Body message is missing
+1: T5 Title contains the word 'WIP' (case-insensitive): "{commit_msg}"
+3: B6 Body message is missing
+1: T5 Title contains the word 'WIP' (case-insensitive): "{commit_msg}"
+3: B6 Body message is missing

--- a/gitlint/tests/expected/test_cli_hooks/test_hook_edit_1_stdout
+++ b/gitlint/tests/expected/test_cli_hooks/test_hook_edit_1_stdout
@@ -1,0 +1,14 @@
+gitlint: checking commit message...
+-----------------------------------------------
+gitlint: Your commit message contains the above violations.
+Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] gitlint: checking commit message...
+-----------------------------------------------
+gitlint: Your commit message contains the above violations.
+Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] gitlint: checking commit message...
+-----------------------------------------------
+gitlint: Your commit message contains the above violations.
+Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] Commit aborted.
+Your commit message: 
+-----------------------------------------------
+{commit_msg}
+-----------------------------------------------

--- a/gitlint/tests/expected/test_cli_hooks/test_hook_local_commit_1_stderr
+++ b/gitlint/tests/expected/test_cli_hooks/test_hook_local_commit_1_stderr
@@ -1,0 +1,2 @@
+1: T5 Title contains the word 'WIP' (case-insensitive): "WIP: commït-title"
+3: B5 Body message is too short (11<20): "commït-body"

--- a/gitlint/tests/expected/test_cli_hooks/test_hook_local_commit_1_stdout
+++ b/gitlint/tests/expected/test_cli_hooks/test_hook_local_commit_1_stdout
@@ -1,0 +1,4 @@
+gitlint: checking commit message...
+-----------------------------------------------
+gitlint: Your commit message contains the above violations.
+Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] Editing only possible when --msg-filename is specified.

--- a/gitlint/tests/expected/test_cli_hooks/test_hook_no_1_stderr
+++ b/gitlint/tests/expected/test_cli_hooks/test_hook_no_1_stderr
@@ -1,0 +1,2 @@
+1: T5 Title contains the word 'WIP' (case-insensitive): "WIP: höok no"
+3: B6 Body message is missing

--- a/gitlint/tests/expected/test_cli_hooks/test_hook_no_1_stdout
+++ b/gitlint/tests/expected/test_cli_hooks/test_hook_no_1_stdout
@@ -1,0 +1,8 @@
+gitlint: checking commit message...
+-----------------------------------------------
+gitlint: Your commit message contains the above violations.
+Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] Commit aborted.
+Your commit message: 
+-----------------------------------------------
+WIP: höok no
+-----------------------------------------------

--- a/gitlint/tests/expected/test_cli_hooks/test_hook_no_tty_1_stderr
+++ b/gitlint/tests/expected/test_cli_hooks/test_hook_no_tty_1_stderr
@@ -1,0 +1,2 @@
+1: T5 Title contains the word 'WIP' (case-insensitive): "WIP: tïtle"
+3: B6 Body message is missing

--- a/gitlint/tests/expected/test_cli_hooks/test_hook_no_tty_1_stdout
+++ b/gitlint/tests/expected/test_cli_hooks/test_hook_no_tty_1_stdout
@@ -1,0 +1,5 @@
+gitlint: checking commit message...
+-----------------------------------------------
+gitlint: Your commit message contains the above violations.
+Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] 
+Aborted!

--- a/gitlint/tests/expected/test_cli_hooks/test_hook_stdin_1_stderr
+++ b/gitlint/tests/expected/test_cli_hooks/test_hook_stdin_1_stderr
@@ -1,0 +1,2 @@
+1: T5 Title contains the word 'WIP' (case-insensitive): "WIP: Test hook stdin tïtle"
+3: B6 Body message is missing

--- a/gitlint/tests/expected/test_cli_hooks/test_hook_stdin_1_stdout
+++ b/gitlint/tests/expected/test_cli_hooks/test_hook_stdin_1_stdout
@@ -1,0 +1,5 @@
+gitlint: checking commit message...
+-----------------------------------------------
+gitlint: Your commit message contains the above violations.
+Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] 
+Aborted!

--- a/gitlint/tests/expected/test_cli_hooks/test_hook_yes_1_stderr
+++ b/gitlint/tests/expected/test_cli_hooks/test_hook_yes_1_stderr
@@ -1,0 +1,2 @@
+1: T5 Title contains the word 'WIP' (case-insensitive): "WIP: höok yes"
+3: B6 Body message is missing

--- a/gitlint/tests/expected/test_cli_hooks/test_hook_yes_1_stdout
+++ b/gitlint/tests/expected/test_cli_hooks/test_hook_yes_1_stdout
@@ -1,0 +1,4 @@
+gitlint: checking commit message...
+-----------------------------------------------
+gitlint: Your commit message contains the above violations.
+Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] 


### PR DESCRIPTION
This moves the business logic of the commit-msg hook from the hook
script to python. This makes the commit-msg hook much more portable
across shells and OSes, as well as easier to unit test.

This should fix #127 