### PR TITLE
RegexOption option type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ the lines in a commit message body. ([#126](https://github.com/jorisroovers/gitl
   -  Options can now actually be set to None (from code) to make them optional.
   -  Ignore rules no longer have "None" as default regex, but an empty regex - effectively disabling them by default (as intended).
 
+-  New `RegexOption` rule option type for use in user-defined rules. By using the `RegexOption`, regular expressions are pre-validated at gitlint startup and compiled only once which is much more efficient compared when linting multiple commits.
+
+
 ## v0.13.1 (2020-02-26)
 
 - Patch to enable `--staged` flag for pre-commit.

--- a/docs/user_defined_rules.md
+++ b/docs/user_defined_rules.md
@@ -276,13 +276,14 @@ As `options_spec` is a list, you can obviously have multiple options per rule. T
 
 Gitlint supports a variety of different option types, all can be imported from `gitlint.options`:
 
-Option Class    | Use for
-----------------|--------------
-StrOption       | Strings
-IntOption       | Integers. `IntOption` takes an optional `allow_negative` parameter if you want to allow negative integers.
-BoolOption      | Booleans. Valid values: `true`, `false`. Case-insensitive.
-ListOption      | List of strings. Comma separated.
-PathOption      | Directory or file path. Takes an optional `type` parameter for specifying path type (`file`, `dir` (=default) or `both`).
+Option Class      | Use for
+------------------|--------------
+`StrOption `      | Strings
+`IntOption`       | Integers. `IntOption` takes an optional `allow_negative` parameter if you want to allow negative integers.
+`BoolOption`      | Booleans. Valid values: `true`, `false`. Case-insensitive.
+`ListOption`      | List of strings. Comma separated.
+`PathOption`      | Directory or file path. Takes an optional `type` parameter for specifying path type (`file`, `dir` (=default) or `both`).
+`RegexOption`     | String representing a [Python-style regex](https://docs.python.org/library/re.html) - compiled and validated before rules are applied.
 
 !!! note
     Gitlint currently does not support options for all possible types (e.g. float, list of int, etc).

--- a/gitlint/config.py
+++ b/gitlint/config.py
@@ -371,8 +371,12 @@ class RuleCollection(object):
         for rule in self._rules.values():
             return_str += u"  {0}: {1}\n".format(rule.id, rule.name)
             for option_name, option_value in sorted(rule.options.items()):
-                if isinstance(option_value.value, list):
+                if option_value.value is None:
+                    option_val_repr = None
+                elif isinstance(option_value.value, list):
                     option_val_repr = ",".join(option_value.value)
+                elif isinstance(option_value, options.RegexOption):
+                    option_val_repr = option_value.value.pattern
                 else:
                     option_val_repr = option_value.value
                 return_str += u"     {0}={1}\n".format(option_name, option_val_repr)

--- a/gitlint/tests/base.py
+++ b/gitlint/tests/base.py
@@ -158,12 +158,12 @@ class BaseTestCase(unittest.TestCase):
         except expected_exception as exc:
             exception_msg = ustr(exc)
             if exception_msg != expected_msg:
-                error = "Right exception, wrong message:\n      got: {0}\n expected: {1}"
+                error = u"Right exception, wrong message:\n      got: {0}\n expected: {1}"
                 raise self.fail(error.format(exception_msg, expected_msg))
             # else: everything is fine, just return
             return
         except Exception as exc:
-            raise self.fail("Expected '{0}' got '{1}'".format(expected_exception.__name__, exc.__class__.__name__))
+            raise self.fail(u"Expected '{0}' got '{1}'".format(expected_exception.__name__, exc.__class__.__name__))
 
         # No exception raised while we expected one
         raise self.fail("Expected to raise {0}, didn't get an exception at all".format(expected_exception.__name__))

--- a/gitlint/tests/test_options.py
+++ b/gitlint/tests/test_options.py
@@ -1,29 +1,34 @@
 # -*- coding: utf-8 -*-
 import os
+import re
 
 from gitlint.tests.base import BaseTestCase
 
-from gitlint.options import IntOption, BoolOption, StrOption, ListOption, PathOption, RuleOptionError
+from gitlint.options import IntOption, BoolOption, StrOption, ListOption, PathOption, RegexOption, RuleOptionError
 
 
 class RuleOptionTests(BaseTestCase):
     def test_option_equality(self):
-        # 2 options are equal if their name, value and description match
-        option1 = IntOption("test-option", 123, u"Test Dëscription")
-        option2 = IntOption("test-option", 123, u"Test Dëscription")
-        self.assertEqual(option1, option2)
+        options = {IntOption: 123, StrOption: u"foöbar", BoolOption: False, ListOption: ["a", "b"],
+                   PathOption: ".", RegexOption: u"^foöbar(.*)"}
+        for clazz, val in options.items():
+            # 2 options are equal if their name, value and description match
+            option1 = clazz(u"test-öption", val, u"Test Dëscription")
+            option2 = clazz(u"test-öption", val, u"Test Dëscription")
+            self.assertEqual(option1, option2)
 
-        # Not equal: name, description, value are different
-        self.assertNotEqual(option1, IntOption("test-option1", 123, u"Test Dëscription"))
-        self.assertNotEqual(option1, IntOption("test-option", 1234, u"Test Dëscription"))
-        self.assertNotEqual(option1, IntOption("test-option", 123, u"Test Dëscription2"))
+        # Not equal: class, name, description, value are different
+        self.assertNotEqual(option1, IntOption(u"tëst-option1", 123, u"Test Dëscription"))
+        self.assertNotEqual(option1, StrOption(u"tëst-option1", u"åbc", u"Test Dëscription"))
+        self.assertNotEqual(option1, StrOption(u"tëst-option", u"åbcd", u"Test Dëscription"))
+        self.assertNotEqual(option1, StrOption(u"tëst-option", u"åbc", u"Test Dëscription2"))
 
     def test_int_option(self):
         # normal behavior
-        option = IntOption("test-name", 123, "Test Description")
+        option = IntOption(u"tëst-name", 123, u"Tëst Description")
+        self.assertEqual(option.name, u"tëst-name")
+        self.assertEqual(option.description, u"Tëst Description")
         self.assertEqual(option.value, 123)
-        self.assertEqual(option.name, "test-name")
-        self.assertEqual(option.description, "Test Description")
 
         # re-set value
         option.set(456)
@@ -34,12 +39,12 @@ class RuleOptionTests(BaseTestCase):
         self.assertEqual(option.value, None)
 
         # error on negative int when not allowed
-        expected_error = u"Option 'test-name' must be a positive integer (current value: '-123')"
+        expected_error = u"Option 'tëst-name' must be a positive integer (current value: '-123')"
         with self.assertRaisesMessage(RuleOptionError, expected_error):
             option.set(-123)
 
         # error on non-int value
-        expected_error = u"Option 'test-name' must be a positive integer (current value: 'foo')"
+        expected_error = u"Option 'tëst-name' must be a positive integer (current value: 'foo')"
         with self.assertRaisesMessage(RuleOptionError, expected_error):
             option.set("foo")
 
@@ -55,10 +60,10 @@ class RuleOptionTests(BaseTestCase):
 
     def test_str_option(self):
         # normal behavior
-        option = StrOption("test-name", u"föo", "Test Description")
+        option = StrOption(u"tëst-name", u"föo", u"Tëst Description")
+        self.assertEqual(option.name, u"tëst-name")
+        self.assertEqual(option.description, u"Tëst Description")
         self.assertEqual(option.value, u"föo")
-        self.assertEqual(option.name, "test-name")
-        self.assertEqual(option.description, "Test Description")
 
         # re-set value
         option.set(u"bår")
@@ -78,7 +83,9 @@ class RuleOptionTests(BaseTestCase):
 
     def test_boolean_option(self):
         # normal behavior
-        option = BoolOption("test-name", "true", "Test Description")
+        option = BoolOption(u"tëst-name", "true", u"Tëst Description")
+        self.assertEqual(option.name, u"tëst-name")
+        self.assertEqual(option.description, u"Tëst Description")
         self.assertEqual(option.value, True)
 
         # re-set value
@@ -92,12 +99,14 @@ class RuleOptionTests(BaseTestCase):
         # error on incorrect value
         incorrect_values = [1, -1, "foo", u"bår", ["foo"], {'foo': "bar"}, None]
         for value in incorrect_values:
-            with self.assertRaisesMessage(RuleOptionError, "Option 'test-name' must be either 'true' or 'false'"):
+            with self.assertRaisesMessage(RuleOptionError, u"Option 'tëst-name' must be either 'true' or 'false'"):
                 option.set(value)
 
     def test_list_option(self):
         # normal behavior
-        option = ListOption("test-name", u"å,b,c,d", "Test Description")
+        option = ListOption(u"tëst-name", u"å,b,c,d", u"Tëst Description")
+        self.assertEqual(option.name, u"tëst-name")
+        self.assertEqual(option.description, u"Tëst Description")
         self.assertListEqual(option.value, [u"å", u"b", u"c", u"d"])
 
         # re-set value
@@ -141,10 +150,10 @@ class RuleOptionTests(BaseTestCase):
         self.assertListEqual(option.value, ["123"])
 
     def test_path_option(self):
-        option = PathOption("test-directory", ".", u"Test Description", type=u"dir")
+        option = PathOption(u"tëst-directory", ".", u"Tëst Description", type=u"dir")
+        self.assertEqual(option.name, u"tëst-directory")
+        self.assertEqual(option.description, u"Tëst Description")
         self.assertEqual(option.value, os.getcwd())
-        self.assertEqual(option.name, "test-directory")
-        self.assertEqual(option.description, u"Test Description")
         self.assertEqual(option.type, u"dir")
 
         # re-set value
@@ -156,19 +165,19 @@ class RuleOptionTests(BaseTestCase):
         self.assertIsNone(option.value)
 
         # set to int
-        expected = u"Option test-directory must be an existing directory (current value: '1234')"
+        expected = u"Option tëst-directory must be an existing directory (current value: '1234')"
         with self.assertRaisesMessage(RuleOptionError, expected):
             option.set(1234)
 
         # set to non-existing directory
         non_existing_path = os.path.join(u"/föo", u"bar")
-        expected = u"Option test-directory must be an existing directory (current value: '{0}')"
+        expected = u"Option tëst-directory must be an existing directory (current value: '{0}')"
         with self.assertRaisesMessage(RuleOptionError, expected.format(non_existing_path)):
             option.set(non_existing_path)
 
         # set to a file, should raise exception since option.type = dir
         sample_path = self.get_sample_path(os.path.join("commit_message", "sample1"))
-        expected = u"Option test-directory must be an existing directory (current value: '{0}')".format(sample_path)
+        expected = u"Option tëst-directory must be an existing directory (current value: '{0}')".format(sample_path)
         with self.assertRaisesMessage(RuleOptionError, expected):
             option.set(sample_path)
 
@@ -176,7 +185,7 @@ class RuleOptionTests(BaseTestCase):
         option.type = u"file"
         option.set(sample_path)
         self.assertEqual(option.value, sample_path)
-        expected = u"Option test-directory must be an existing file (current value: '{0}')".format(
+        expected = u"Option tëst-directory must be an existing file (current value: '{0}')".format(
             self.get_sample_path())
         with self.assertRaisesMessage(RuleOptionError, expected):
             option.set(self.get_sample_path())
@@ -190,6 +199,27 @@ class RuleOptionTests(BaseTestCase):
 
         # Expect exception if path type is invalid
         option.type = u'föo'
-        expected = u"Option test-directory type must be one of: 'file', 'dir', 'both' (current: 'föo')"
+        expected = u"Option tëst-directory type must be one of: 'file', 'dir', 'both' (current: 'föo')"
         with self.assertRaisesMessage(RuleOptionError, expected):
             option.set("haha")
+
+    def test_regex_option(self):
+        # normal behavior
+        option = RegexOption(u"tëst-regex", u"^myrëgex(.*)foo$", u"Tëst Regex Description")
+        self.assertEqual(option.name, u"tëst-regex")
+        self.assertEqual(option.description, u"Tëst Regex Description")
+        self.assertEqual(option.value, re.compile(u"^myrëgex(.*)foo$", re.UNICODE))
+
+        # re-set value
+        option.set(u"[0-9]föbar.*")
+        self.assertEqual(option.value, re.compile(u"[0-9]föbar.*", re.UNICODE))
+
+        # set None
+        option.set(None)
+        self.assertIsNone(option.value)
+
+        # error on invalid regex
+        incorrect_values = [u"foo(", 123, -1]
+        for value in incorrect_values:
+            with self.assertRaisesRegex(RuleOptionError, u"Invalid regular expression"):
+                option.set(value)


### PR DESCRIPTION
The RegexOption allows regular expressions to be pre-validated at gitlint
startup and compiled only once which is much more efficient when re-using the
regex (e.g. linting multiple commits).

Replaced StrOption with RegexOption in all rules using regular expressions.

Also made some minor improvements to other Options tests.

<!--- THIS IS A COMMENT BLOCK, REMOVE IT BEFORE SUBMITTING YOUR PR

Thank you for your interest in gitlint and putting in the effort to create a PR!

A few quick notes:

- It's really just me (https://github.com/jorisroovers) maintaining gitlint, and I do so in a hobby capacity. More recently it has become harder for me to find time to maintain gitlint on a regular basis, which in practice means that it might take me a while (sometimes months) to get back to you. Rest assured though, I absolutely look at all PRs as soon as they come in - I just tend to only "work" on gitlint a few times a year.
- Similarly, after your code is merged, it typically still takes months before I do another release that contains your code. Please don't let that deter you from contributing - I appreciate your patience and understanding!
- Please review: http://jorisroovers.github.io/gitlint/contributing/

-->