### PR TITLE
New Rule: body-match-regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 - [User-defined Configuration Rules](TODO) allow users to dynamically change gitlint's configuration and/or the commit *before* any other rules are applied.
 - Users can now use `self.log.debug("my message")` for debugging purposes in their user-defined rules
 - Breaking: User-defined rule id's can no longer start with 'I', as those are reserved for built-in gitlint ignore rules.
-- **New Rule**: `ignore-body-lines` allows users to
+- **New Rule**: [ignore-body-lines](TODO) allows users to
 [ignore parts of a commit](http://jorisroovers.github.io/gitlint/#ignoring-commits) by matching a regex against
 the lines in a commit message body. ([#126](https://github.com/jorisroovers/gitlint/issues/126)).
+- **New Rule**: [body-match-regex](TODO) allows users to enforce that the commit-msg body matches a given regex.
 - Bugfixes:
-  -  Options can now actually be set to None (from code) to make them optional.
+  -  Options can now actually be set to `None` (from code) to make them optional.
   -  Ignore rules no longer have "None" as default regex, but an empty regex - effectively disabling them by default (as intended).
 
 -  New `RegexOption` rule option type for use in user-defined rules. By using the `RegexOption`, regular expressions are pre-validated at gitlint startup and compiled only once which is much more efficient compared when linting multiple commits.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -161,6 +161,31 @@ Name                  | gitlint version | Default      | Description
 files                 | >= 0.4          | (empty)      |  Comma-separated list of files that need to an explicit mention in the commit message in case they are changed.
 
 
+## B8: body-match-regex   ##
+
+ID    | Name                        | gitlint version | Description
+------|-----------------------------|-----------------|-------------------------------------------
+B8    | body-match-regex            | >= 0.14         | Body must match a given regex
+
+### Options ###
+
+Name                  | gitlint version | Default      | Description
+----------------------|-----------------|--------------|----------------------------------
+regex                 | >= 0.14         | None         |  [Python regex](https://docs.python.org/library/re.html) that the title should match.
+
+### Examples
+
+#### .gitlint
+
+```ini
+# Ensure the body ends with Reviewed-By: <some value>
+[body-match-regex]
+regex=Reviewed-By:(.*)$
+
+# Ensure body contains the word "Foo" somewhere
+[body-match-regex]
+regex=(*.)Foo(.*)
+```
 
 ## M1: author-valid-email   ##
 

--- a/gitlint/config.py
+++ b/gitlint/config.py
@@ -59,6 +59,7 @@ class LintConfig(object):
                             rules.BodyHardTab,
                             rules.BodyFirstLineEmpty,
                             rules.BodyChangedFileMention,
+                            rules.BodyRegexMatches,
                             rules.AuthorValidEmail)
 
     def __init__(self):

--- a/gitlint/files/gitlint
+++ b/gitlint/files/gitlint
@@ -50,8 +50,7 @@
 # words=wip
 
 # [title-match-regex]
-# python like regex (https://docs.python.org/2/library/re.html) that the
-# commit-msg title must be matched to.
+# python-style regex that the commit-msg title must match
 # Note that the regex can contradict with other rules if not used correctly
 # (e.g. title-must-not-contain-word).
 # regex=^US[0-9]*
@@ -74,9 +73,13 @@
 # it in the commit message.
 # files=gitlint/rules.py,README.md
 
+# [body-match-regex]
+# python-style regex that the commit-msg body must match.
+# E.g. body must end in My-Commit-Tag: foo
+# regex=My-Commit-Tag: foo$
+
 # [author-valid-email]
-# python like regex (https://docs.python.org/2/library/re.html) that the
-# commit author email address should be matched to
+# python-style regex that the commit author email address must match.
 # For example, use the following regex if you only want to allow email addresses from foo.com
 # regex=[^@]+@foo.com
 
@@ -97,6 +100,11 @@
 # Ignore certain rules, you can reference them by their id or by their full name
 # Use 'all' to ignore all rules
 # ignore=T1,body-min-length
+
+# [ignore-body-lines]
+# Ignore certain lines in a commit body that match a regex.
+# E.g. Ignore all lines that start with 'Co-Authored-By'
+# regex=^Co-Authored-By
 
 # This is a contrib rule - a community contributed rule. These are disabled by default.
 # You need to explicitly enable them one-by-one by adding them to the "contrib" option

--- a/gitlint/tests/expected/test_cli/test_debug_1
+++ b/gitlint/tests/expected/test_cli/test_debug_1
@@ -50,6 +50,8 @@ target: {target}
   B4: body-first-line-empty
   B7: body-changed-file-mention
      files=
+  B8: body-match-regex
+     regex=None
   M1: author-valid-email
      regex=[^@ ]+@[^@ ]+\.[^@ ]+
 

--- a/gitlint/tests/expected/test_cli/test_input_stream_debug_2
+++ b/gitlint/tests/expected/test_cli/test_input_stream_debug_2
@@ -50,6 +50,8 @@ target: {target}
   B4: body-first-line-empty
   B7: body-changed-file-mention
      files=
+  B8: body-match-regex
+     regex=None
   M1: author-valid-email
      regex=[^@ ]+@[^@ ]+\.[^@ ]+
 

--- a/gitlint/tests/expected/test_cli/test_lint_staged_msg_filename_2
+++ b/gitlint/tests/expected/test_cli/test_lint_staged_msg_filename_2
@@ -50,6 +50,8 @@ target: {target}
   B4: body-first-line-empty
   B7: body-changed-file-mention
      files=
+  B8: body-match-regex
+     regex=None
   M1: author-valid-email
      regex=[^@ ]+@[^@ ]+\.[^@ ]+
 

--- a/gitlint/tests/expected/test_cli/test_lint_staged_stdin_2
+++ b/gitlint/tests/expected/test_cli/test_lint_staged_stdin_2
@@ -50,6 +50,8 @@ target: {target}
   B4: body-first-line-empty
   B7: body-changed-file-mention
      files=
+  B8: body-match-regex
+     regex=None
   M1: author-valid-email
      regex=[^@ ]+@[^@ ]+\.[^@ ]+
 

--- a/gitlint/tests/rules/test_body_rules.py
+++ b/gitlint/tests/rules/test_body_rules.py
@@ -178,3 +178,47 @@ class BodyRuleTests(BaseTestCase):
         violations = rule.validate(commit)
         expected_violation_2 = rules.RuleViolation("B7", "Body does not mention changed file 'bar.txt'", None, 4)
         self.assertEqual([expected_violation_2, expected_violation], violations)
+
+    def test_body_match_regex(self):
+        commit = self.gitcommit(u"US1234: åbc\nIgnored\nBödy\nFöo\nMy-Commit-Tag: föo")
+
+        # assert no violation on default regex (=everything allowed)
+        rule = rules.BodyRegexMatches()
+        violations = rule.validate(commit)
+        self.assertIsNone(violations)
+
+        # assert no violation on matching regex
+        # (also note that first body line - in between title and rest of body - is ignored)
+        rule = rules.BodyRegexMatches({'regex': u"^Bödy(.*)"})
+        violations = rule.validate(commit)
+        self.assertIsNone(violations)
+
+        # assert we can do end matching (and last empty line is ignored)
+        # (also note that first body line - in between title and rest of body - is ignored)
+        rule = rules.BodyRegexMatches({'regex': u"My-Commit-Tag: föo$"})
+        violations = rule.validate(commit)
+        self.assertIsNone(violations)
+
+        # common use-case: matching that a given line is present
+        rule = rules.BodyRegexMatches({'regex': u"(.*)Föo(.*)"})
+        violations = rule.validate(commit)
+        self.assertIsNone(violations)
+
+        # assert violation on non-matching body
+        rule = rules.BodyRegexMatches({'regex': u"^Tëst(.*)Foo"})
+        violations = rule.validate(commit)
+        expected_violation = rules.RuleViolation("B8", u"Body does not match regex (^Tëst(.*)Foo)", None, 5)
+        self.assertListEqual(violations, [expected_violation])
+
+        # assert no violation on None regex
+        rule = rules.BodyRegexMatches({'regex': None})
+        violations = rule.validate(commit)
+        self.assertIsNone(violations)
+
+        # Assert no issues when there's no body or a weird body variation
+        bodies = [u"åbc", u"åbc\n", u"åbc\nföo\n", u"åbc\n\n", u"åbc\nföo\nblå", u"åbc\nföo\nblå\n"]
+        for body in bodies:
+            commit = self.gitcommit(body)
+            rule = rules.BodyRegexMatches({'regex': ".*"})
+            violations = rule.validate(commit)
+            self.assertIsNone(violations)

--- a/gitlint/tests/samples/commit_message/no-violations
+++ b/gitlint/tests/samples/commit_message/no-violations
@@ -1,0 +1,6 @@
+Normal Commit Tïtle
+
+Nörmal body that contains a few lines of text describing the changes in the
+commit without violating any of gitlint's rules.
+
+Sïgned-Off-By: foo@bar.com

--- a/qa/expected/test_commits/test_lint_staged_msg_filename_1
+++ b/qa/expected/test_commits/test_lint_staged_msg_filename_1
@@ -51,6 +51,8 @@ target: {target}
   B4: body-first-line-empty
   B7: body-changed-file-mention
      files=
+  B8: body-match-regex
+     regex=None
   M1: author-valid-email
      regex=[^@ ]+@[^@ ]+\.[^@ ]+
 

--- a/qa/expected/test_commits/test_lint_staged_stdin_1
+++ b/qa/expected/test_commits/test_lint_staged_stdin_1
@@ -51,6 +51,8 @@ target: {target}
   B4: body-first-line-empty
   B7: body-changed-file-mention
      files=
+  B8: body-match-regex
+     regex=None
   M1: author-valid-email
      regex=[^@ ]+@[^@ ]+\.[^@ ]+
 

--- a/qa/expected/test_config/test_config_from_file_debug_1
+++ b/qa/expected/test_config/test_config_from_file_debug_1
@@ -51,6 +51,8 @@ target: {target}
   B4: body-first-line-empty
   B7: body-changed-file-mention
      files=
+  B8: body-match-regex
+     regex=None
   M1: author-valid-email
      regex=[^@ ]+@[^@ ]+\.[^@ ]+
 


### PR DESCRIPTION
The body-match-regex rule allows users to enforce that the commit-msg
body matches a given regex.

Closes #130 