### PR TITLE
Fail nicer when username missing

### DIFF
--- a/gitlint/git.py
+++ b/gitlint/git.py
@@ -305,7 +305,10 @@ class StagedLocalGitCommit(GitCommit, PropertyCache):
     @property
     @cache
     def author_name(self):
-        return ustr(_git("config", "--get", "user.name", _cwd=self.context.repository_path)).strip()
+        try:
+            return ustr(_git("config", "--get", "user.name", _cwd=self.context.repository_path)).strip()
+        except GitExitCodeError:
+            raise GitContextError("Missing git configuration: please set user.name")
 
     @property
     @cache

--- a/gitlint/git.py
+++ b/gitlint/git.py
@@ -313,7 +313,10 @@ class StagedLocalGitCommit(GitCommit, PropertyCache):
     @property
     @cache
     def author_email(self):
-        return ustr(_git("config", "--get", "user.email", _cwd=self.context.repository_path)).strip()
+        try:
+            return ustr(_git("config", "--get", "user.email", _cwd=self.context.repository_path)).strip()
+        except GitExitCodeError:
+            raise GitContextError("Missing git configuration: please set user.email")
 
     @property
     @cache

--- a/gitlint/tests/git/test_git_commit.py
+++ b/gitlint/tests/git/test_git_commit.py
@@ -495,6 +495,21 @@ class GitCommitTests(BaseTestCase):
             ctx = GitContext.from_staged_commit(u"Foōbar 123\n\ncömmit-body\n", u"fåke/path")
             [ustr(commit) for commit in ctx.commits]
 
+    @patch('gitlint.git.sh')
+    def test_staged_commit_with_missing_email(self, sh):
+        # StagedLocalGitCommit()
+
+        sh.git.side_effect = [
+            u"#",                               # git config --get core.commentchar
+            u"test åuthor\n",                   # git config --get user.name
+            ErrorReturnCode('git config --get user.name', b"", b""),
+        ]
+
+        expected_msg = "Missing git configuration: please set user.email"
+        with self.assertRaisesMessage(GitContextError, expected_msg):
+            ctx = GitContext.from_staged_commit(u"Foōbar 123\n\ncömmit-body\n", u"fåke/path")
+            [ustr(commit) for commit in ctx.commits]
+
     def test_gitcommitmessage_equality(self):
         commit_message1 = GitCommitMessage(GitContext(), u"tëst\n\nfoo", u"tëst\n\nfoo", u"tēst", ["", u"föo"])
         attrs = ['original', 'full', 'title', 'body']

--- a/qa/base.py
+++ b/qa/base.py
@@ -93,6 +93,13 @@ class BaseTestCase(TestCase):
         io.open(os.path.join(parent_dir, test_filename), 'a', encoding=DEFAULT_ENCODING).close()
         return test_filename
 
+    def create_tmp_git_config(self, contents):
+        """ Creates an environment with the GIT_CONFIG variable set to a file with the given contents. """
+        tmp_config = self.create_tmpfile(contents)
+        env = os.environ.copy()
+        env["GIT_CONFIG"] = tmp_config
+        return env
+
     def create_simple_commit(self, message, out=None, ok_code=None, env=None, git_repo=None, tty_in=False):
         """ Creates a simple commit with an empty test file.
             :param message: Commit message for the commit. """

--- a/qa/shell.py
+++ b/qa/shell.py
@@ -67,6 +67,8 @@ else:
         popen_kwargs = {'stdout': pipe, 'stderr': pipe, 'shell': kwargs.get('_tty_out', False)}
         if '_cwd' in kwargs:
             popen_kwargs['cwd'] = kwargs['_cwd']
+        if '_env' in kwargs:
+            popen_kwargs['env'] = kwargs['_env']
 
         try:
             p = subprocess.Popen(args, **popen_kwargs)

--- a/qa/test_gitlint.py
+++ b/qa/test_gitlint.py
@@ -157,6 +157,28 @@ class IntegrationTests(BaseTestCase):
 
         self.assertEqualStdout(output, self.get_expected("test_gitlint/test_msg_filename_no_tty_1"))
 
+    def test_no_git_name_set(self):
+        """ Ensure we print out a helpful message if user.name is not set """
+        tmp_commit_msg_file = self.create_tmpfile(u"WIP: msg-fïlename NO name test.")
+        # Name is checked before email so this isn't strictly
+        # necessary but seems good for consistency.
+        env = self.create_tmp_git_config(u"[user]\n  email = test-emåil@foo.com\n")
+        output = gitlint("--staged", "--msg-filename", tmp_commit_msg_file,
+                         _ok_code=[self.GIT_CONTEXT_ERROR_CODE],
+                         _env=env)
+        expected = u"Missing git configuration: please set user.name\n"
+        self.assertEqualStdout(output, expected)
+
+    def test_no_git_email_set(self):
+        """ Ensure we print out a helpful message if user.email is not set """
+        tmp_commit_msg_file = self.create_tmpfile(u"WIP: msg-fïlename NO email test.")
+        env = self.create_tmp_git_config(u"[user]\n  name = test åuthor\n")
+        output = gitlint("--staged", "--msg-filename", tmp_commit_msg_file,
+                         _ok_code=[self.GIT_CONTEXT_ERROR_CODE],
+                         _env=env)
+        expected = u"Missing git configuration: please set user.email\n"
+        self.assertEqualStdout(output, expected)
+
     def test_git_errors(self):
         # Repo has no commits: caused by `git log`
         empty_git_repo = self.create_tmp_git_repo()


### PR DESCRIPTION
An attempt to make #148 a little less severe. `git` failing to retrieve these configuration variables is still fatal, but at least the error message is a little nicer.
