### PR TITLE
Configuration through environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Named Rules](TODO) allow users to have multiple instances of the same rule active at the same time. This is useful when you want to enforce the same rule multiple times but with different options.
 - [User-defined Configuration Rules](TODO) allow users to dynamically change gitlint's configuration and/or the commit *before* any other rules are applied.
 - Python 3.9 support
+- Most general options can now be set through environment variables (e.g. set the `general.ignore` option via `GITLINT_IGNORE=T1,T2`). The list of available environment variables can be found in the [configuration documentation](TODO).
 - Users can now use `self.log.debug("my message")` for debugging purposes in their user-defined rules
 - Breaking: User-defined rule id's can no longer start with 'I', as those are reserved for built-in gitlint ignore rules.
 - **New Rule**: [ignore-body-lines](TODO) allows users to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -182,9 +182,10 @@ gitlint configuration is applied in the following order of precedence:
 1. Commit specific config (e.g.: `gitlint-ignore: all` in the commit message)
 2. Configuration Rules (e.g.: [ignore-by-title](/rules/#i1-ignore-by-title))
 3. Commandline convenience flags (e.g.:  `-vv`, `--silent`, `--ignore`)
-4. Commandline configuration flags (e.g.: `-c title-max-length=123`)
-5. Configuration file (local `.gitlint` file, or file specified using `-C`/`--config`)
-6. Default gitlint config
+4. Environment variables (e.g.: `GITLINT_VERBOSITY=3`)
+5. Commandline configuration flags (e.g.: `-c title-max-length=123`)
+6. Configuration file (local `.gitlint` file, or file specified using `-C`/`--config`)
+7. Default gitlint config
 
 ## General Options
 Below we outline all configuration options that modify gitlint's overall behavior. These options can be specified
@@ -194,23 +195,24 @@ using commandline flags or in `[general]` section in a `.gitlint` configuration 
 
 Enable silent mode (no output). Use [exit](index.md#exit-codes) code to determine result.
 
-Default value  |  gitlint version | commandline flag  
----------------|------------------|-------------------
- false         | >= 0.1.0         | `--silent`
+Default value  |  gitlint version | commandline flag  | environment variable
+---------------|------------------|-------------------|-----------------------
+`False`        | >= 0.1.0         | `--silent`        | `GITLINT_SILENT`
 
 #### Examples
 ```sh
 # CLI
 gitlint --silent
+GITLINT_SILENT=1 gitlint  # using env variable
 ```
 
 ### verbosity
 
 Amount of output gitlint will show when printing errors.
 
-Default value  |  gitlint version | commandline flag  
----------------|------------------|-------------------
- 3             | >= 0.1.0         | `-v`
+Default value  |  gitlint version | commandline flag  | environment variable 
+---------------|------------------|-------------------|-----------------------
+3              | >= 0.1.0         | `-v`              | `GITLINT_VERBOSITY`
 
 
 #### Examples
@@ -222,6 +224,7 @@ gitlint -v                     # even less   (level 1)
 gitlint --silent               # no output   (level 0)
 gitlint -c general.verbosity=1 # Set specific level
 gitlint -c general.verbosity=0 # Same as --silent
+GITLINT_VERBOSITY=2 gitlint    # using env variable
 ```
 ```ini
 # .gitlint
@@ -233,9 +236,9 @@ verbosity=2
 
 Whether or not to ignore merge commits.
 
-Default value  |  gitlint version | commandline flag  
----------------|------------------|-------------------
- true          | >= 0.7.0         | Not Available
+Default value  |  gitlint version | commandline flag  | environment variable  
+---------------|------------------|-------------------|-----------------------
+ true          | >= 0.7.0         | Not Available     | Not Available  
 
 #### Examples
 ```sh
@@ -252,9 +255,9 @@ ignore-merge-commits=false
 
 Whether or not to ignore revert commits.
 
-Default value  |  gitlint version | commandline flag  
----------------|------------------|-------------------
- true          | >= 0.13.0        | Not Available
+Default value  |  gitlint version | commandline flag  | environment variable   
+---------------|------------------|-------------------|-----------------------
+ true          | >= 0.13.0        | Not Available     | Not Available  
 
 #### Examples
 ```sh
@@ -271,9 +274,9 @@ ignore-revert-commits=false
 
 Whether or not to ignore [fixup](https://git-scm.com/docs/git-commit#git-commit---fixupltcommitgt) commits.
 
-Default value  |  gitlint version | commandline flag  
----------------|------------------|-------------------
- true          | >= 0.9.0         | Not Available
+Default value  |  gitlint version | commandline flag  | environment variable  
+---------------|------------------|-------------------|-----------------------
+ true          | >= 0.9.0         | Not Available     | Not Available  
 
 #### Examples
 ```sh
@@ -290,9 +293,9 @@ ignore-fixup-commits=false
 
 Whether or not to ignore [squash](https://git-scm.com/docs/git-commit#git-commit---squashltcommitgt) commits.
 
-Default value  |  gitlint version | commandline flag  
----------------|------------------|-------------------
- true          | >= 0.9.0         | Not Available
+Default value  |  gitlint version | commandline flag  | environment variable 
+---------------|------------------|-------------------|-----------------------
+ true          | >= 0.9.0         | Not Available     | Not Available  
 
 #### Examples
 ```sh
@@ -309,9 +312,9 @@ ignore-squash-commits=false
 
 Comma separated list of rules to ignore (by name or id).
 
-Default value              |  gitlint version | commandline flag  
----------------------------|------------------|-------------------
- [] (=empty list)          | >= 0.1.0         | `--ignore`
+Default value              |  gitlint version | commandline flag  | environment variable   
+---------------------------|------------------|-------------------|-----------------------
+ [] (=empty list)          | >= 0.1.0         | `--ignore`        | `GITLINT_IGNORE`
 
 #### Examples
 ```sh
@@ -319,6 +322,7 @@ Default value              |  gitlint version | commandline flag
 gitlint --ignore=body-min-length              # ignore single rule
 gitlint --ignore=T1,body-min-length           # ignore multiple rule
 gitlint -c general.ignore=T1,body-min-length  # different way of doing the same
+GITLINT_IGNORE=T1,body-min-length gitlint     # using env variable
 ```
 ```ini
 #.gitlint
@@ -330,14 +334,15 @@ ignore=T1,body-min-length
 
 Enable debugging output.
 
-Default value  |  gitlint version | commandline flag  
----------------|------------------|-------------------
- false         | >= 0.7.1         | `--debug`
+Default value  |  gitlint version | commandline flag  | environment variable   
+---------------|------------------|-------------------|-----------------------
+ false         | >= 0.7.1         | `--debug`         | `GITLINT_DEBUG`
 
 #### Examples
 ```sh
 # CLI
 gitlint --debug
+GITLINT_DEBUG=1 gitlint # using env variable
 # --debug is special, the following does NOT work
 # gitlint -c general.debug=true
 ```
@@ -346,15 +351,16 @@ gitlint --debug
 
 Target git repository gitlint should be linting against.
 
-Default value              |  gitlint version | commandline flag  
----------------------------|------------------|-------------------
- (empty)                   | >= 0.8.0         | `--target`
+Default value              |  gitlint version | commandline flag  | environment variable   
+---------------------------|------------------|-------------------|-----------------------
+(empty)                    | >= 0.8.0         | `--target`        | `GITLINT_TARGET`
 
 #### Examples
 ```sh
 # CLI
 gitlint --target=/home/joe/myrepo/
 gitlint -c general.target=/home/joe/myrepo/  # different way of doing the same
+GITLINT_TARGET=/home/joe/myrepo/ gitlint     # using env variable
 ```
 ```ini
 #.gitlint
@@ -366,15 +372,16 @@ target=/home/joe/myrepo/
 
 Path where gitlint looks for [user-defined rules](user_defined_rules.md).
 
-Default value              |  gitlint version | commandline flag  
----------------------------|------------------|-------------------
- (empty)                   | >= 0.8.0         | `--extra-path`
+Default value              |  gitlint version | commandline flag  | environment variable   
+---------------------------|------------------|-------------------|-----------------------
+ (empty)                   | >= 0.8.0         | `--extra-path`    | `GITLINT_EXTRA_PATH`
 
 #### Examples
 ```sh
 # CLI
 gitlint --extra-path=/home/joe/rules/
 gitlint -c general.extra-path=/home/joe/rules/  # different way of doing the same
+GITLINT_EXTRA_PATH=/home/joe/rules/ gitlint     # using env variable
 ```
 ```ini
 #.gitlint
@@ -384,17 +391,18 @@ extra-path=/home/joe/rules/
 
 ### contrib
 
-[Contrib rules](contrib_rules) to enable.
+Comma-separated list of [Contrib rules](contrib_rules) to enable (by name or id).
 
-Default value              |  gitlint version | commandline flag  
----------------------------|------------------|-------------------
- (empty)                   | >= 0.12.0        | `--contrib`
+Default value              |  gitlint version | commandline flag  | environment variable   
+---------------------------|------------------|-------------------|-----------------------
+ (empty)                   | >= 0.12.0        | `--contrib`       | `GITLINT_CONTRIB`
 
 #### Examples
 ```sh
 # CLI
 gitlint --contrib=contrib-title-conventional-commits,CC1
 gitlint -c general.contrib=contrib-title-conventional-commits,CC1  # different way of doing the same
+GITLINT_CONTRIB=contrib-title-conventional-commits,CC1 gitlint     # using env variable
 ```
 ```ini
 #.gitlint
@@ -405,15 +413,16 @@ contrib=contrib-title-conventional-commits,CC1
 
 Ignore any stdin data. Sometimes useful when running gitlint in a CI server.
 
-Default value  |  gitlint version | commandline flag  
----------------|------------------|-------------------
- false         | >= 0.12.0        | `--ignore-stdin`
+Default value  |  gitlint version | commandline flag  | environment variable   
+---------------|------------------|-------------------|-----------------------
+ false         | >= 0.12.0        | `--ignore-stdin`  | `GITLINT_IGNORE_STDIN`
 
 #### Examples
 ```sh
 # CLI
 gitlint --ignore-stdin
 gitlint -c general.ignore-stdin=true # different way of doing the same
+GITLINT_IGNORE_STDIN=1 gitlint       # using env variable
 ```
 ```ini
 #.gitlint
@@ -425,15 +434,16 @@ ignore-stdin=true
 
 Fetch additional meta-data from the local `repository when manually passing a commit message to gitlint via stdin or `--commit-msg`.
 
-Default value  |  gitlint version | commandline flag  
----------------|------------------|-------------------
- false         | >= 0.13.0        | `--staged`
+Default value  |  gitlint version | commandline flag  | environment variable   
+---------------|------------------|-------------------|-----------------------
+ false         | >= 0.13.0        | `--staged`        | `GITLINT_STAGED`
 
 #### Examples
 ```sh
 # CLI
 gitlint --staged
 gitlint -c general.staged=true # different way of doing the same
+GITLINT_STAGED=1 gitlint       # using env variable
 ```
 ```ini
 #.gitlint

--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -182,25 +182,31 @@ class ContextObj(object):
 
 @click.group(invoke_without_command=True, context_settings={'max_content_width': 120},
              epilog="When no COMMAND is specified, gitlint defaults to 'gitlint lint'.")
-@click.option('--target', type=click.Path(exists=True, resolve_path=True, file_okay=False, readable=True),
+@click.option('--target', envvar='GITLINT_TARGET',
+              type=click.Path(exists=True, resolve_path=True, file_okay=False, readable=True),
               help="Path of the target git repository. [default: current working directory]")
 @click.option('-C', '--config', type=click.Path(exists=True, dir_okay=False, readable=True, resolve_path=True),
               help="Config file location [default: {0}]".format(DEFAULT_CONFIG_FILE))
 @click.option('-c', multiple=True,
               help="Config flags in format <rule>.<option>=<value> (e.g.: -c T1.line-length=80). " +
                    "Flag can be used multiple times to set multiple config values.")  # pylint: disable=bad-continuation
-@click.option('--commits', default=None, help="The range of commits to lint. [default: HEAD]")
-@click.option('-e', '--extra-path', help="Path to a directory or python module with extra user-defined rules",
+@click.option('--commits', envvar='GITLINT_COMMITS', default=None, help="The range of commits to lint. [default: HEAD]")
+@click.option('-e', '--extra-path', envvar='GITLINT_EXTRA_PATH',
+              help="Path to a directory or python module with extra user-defined rules",
               type=click.Path(exists=True, resolve_path=True, readable=True))
-@click.option('--ignore', default="", help="Ignore rules (comma-separated by id or name).")
-@click.option('--contrib', default="", help="Contrib rules to enable (comma-separated by id or name).")
+@click.option('--ignore', envvar='GITLINT_IGNORE', default="", help="Ignore rules (comma-separated by id or name).")
+@click.option('--contrib', envvar='GITLINT_CONTRIB', default="",
+              help="Contrib rules to enable (comma-separated by id or name).")
 @click.option('--msg-filename', type=click.File(), help="Path to a file containing a commit-msg.")
-@click.option('--ignore-stdin', is_flag=True, help="Ignore any stdin data. Useful for running in CI server.")
-@click.option('--staged', is_flag=True, help="Read staged commit meta-info from the local repository.")
-@click.option('-v', '--verbose', count=True, default=0,
+@click.option('--ignore-stdin', envvar='GITLINT_IGNORE_STDIN', is_flag=True,
+              help="Ignore any stdin data. Useful for running in CI server.")
+@click.option('--staged', envvar='GITLINT_STAGED', is_flag=True,
+              help="Read staged commit meta-info from the local repository.")
+@click.option('-v', '--verbose', envvar='GITLINT_VERBOSITY', count=True, default=0,
               help="Verbosity, more v's for more verbose output (e.g.: -v, -vv, -vvv). [default: -vvv]", )
-@click.option('-s', '--silent', help="Silent mode (no output). Takes precedence over -v, -vv, -vvv.", is_flag=True)
-@click.option('-d', '--debug', help="Enable debugging output.", is_flag=True)
+@click.option('-s', '--silent', envvar='GITLINT_SILENT', is_flag=True,
+              help="Silent mode (no output). Takes precedence over -v, -vv, -vvv.")
+@click.option('-d', '--debug', envvar='GITLINT_DEBUG', help="Enable debugging output.", is_flag=True)
 @click.version_option(version=gitlint.__version__)
 @click.pass_context
 def cli(  # pylint: disable=too-many-arguments

--- a/gitlint/config.py
+++ b/gitlint/config.py
@@ -12,7 +12,7 @@ import os
 import shutil
 
 from collections import OrderedDict
-from gitlint.utils import ustr, DEFAULT_ENCODING
+from gitlint.utils import ustr, sstr, DEFAULT_ENCODING
 from gitlint import rules  # For some weird reason pylint complains about this, pylint: disable=unused-import
 from gitlint import options
 from gitlint import rule_finder
@@ -292,7 +292,7 @@ class LintConfig(object):
         return_str = u"config-path: {0}\n".format(self._config_path)
         return_str += u"[GENERAL]\n"
         return_str += u"extra-path: {0}\n".format(self.extra_path)
-        return_str += u"contrib: {0}\n".format(self.contrib)
+        return_str += u"contrib: {0}\n".format(sstr(self.contrib))
         return_str += u"ignore: {0}\n".format(",".join(self.ignore))
         return_str += u"ignore-merge-commits: {0}\n".format(self.ignore_merge_commits)
         return_str += u"ignore-fixup-commits: {0}\n".format(self.ignore_fixup_commits)

--- a/gitlint/tests/config/test_config_precedence.py
+++ b/gitlint/tests/config/test_config_precedence.py
@@ -31,9 +31,10 @@ class LintConfigPrecedenceTests(BaseTestCase):
         # to more easily test everything
         # Test that the config precedence is followed:
         # 1. commandline convenience flags
-        # 2. commandline -c flags
-        # 3. config file
-        # 4. default config
+        # 2. environment variables
+        # 3. commandline -c flags
+        # 4. config file
+        # 5. default config
         config_path = self.get_sample_path("config/gitlintconfig")
 
         # 1. commandline convenience flags
@@ -42,19 +43,26 @@ class LintConfigPrecedenceTests(BaseTestCase):
             self.assertEqual(result.output, "")
             self.assertEqual(stderr.getvalue(), "1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP\"\n")
 
-        # 2. commandline -c flags
+        # 2. environment variables
+        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+            result = self.cli.invoke(cli.cli, ["-c", "general.verbosity=2", "--config", config_path],
+                                     env={"GITLINT_VERBOSITY": "3"})
+            self.assertEqual(result.output, "")
+            self.assertEqual(stderr.getvalue(), "1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP\"\n")
+
+        # 3. commandline -c flags
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["-c", "general.verbosity=2", "--config", config_path])
             self.assertEqual(result.output, "")
             self.assertEqual(stderr.getvalue(), "1: T5 Title contains the word 'WIP' (case-insensitive)\n")
 
-        # 3. config file
+        # 4. config file
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--config", config_path])
             self.assertEqual(result.output, "")
             self.assertEqual(stderr.getvalue(), "1: T5\n")
 
-        # 4. default config
+        # 5. default config
         with patch('gitlint.display.stderr', new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli)
             self.assertEqual(result.output, "")

--- a/qa/base.py
+++ b/qa/base.py
@@ -93,12 +93,18 @@ class BaseTestCase(TestCase):
         io.open(os.path.join(parent_dir, test_filename), 'a', encoding=DEFAULT_ENCODING).close()
         return test_filename
 
+    @staticmethod
+    def create_environment(envvars=None):
+        """ Creates a copy of the current os.environ and adds/overwrites a given set of variables to it """
+        environment = os.environ.copy()
+        if envvars:
+            environment.update(envvars)
+        return environment
+
     def create_tmp_git_config(self, contents):
         """ Creates an environment with the GIT_CONFIG variable set to a file with the given contents. """
         tmp_config = self.create_tmpfile(contents)
-        env = os.environ.copy()
-        env["GIT_CONFIG"] = tmp_config
-        return env
+        return self.create_environment({"GIT_CONFIG": tmp_config})
 
     def create_simple_commit(self, message, out=None, ok_code=None, env=None, git_repo=None, tty_in=False):
         """ Creates a simple commit with an empty test file.
@@ -110,9 +116,7 @@ class BaseTestCase(TestCase):
         # variables can influence how git runs.
         # This was needed to fix https://github.com/jorisroovers/gitlint/issues/15 as we need to make sure to use
         # the PATH variable that contains the virtualenv's python binary.
-        environment = os.environ
-        if env:
-            environment.update(env)
+        environment = self.create_environment(env)
 
         # Create file and add to git
         test_filename = self.create_file(git_repo)

--- a/qa/expected/test_config/test_config_from_env_1
+++ b/qa/expected/test_config/test_config_from_env_1
@@ -1,0 +1,91 @@
+DEBUG: gitlint.cli To report issues, please visit https://github.com/jorisroovers/gitlint/issues
+DEBUG: gitlint.cli Platform: {platform}
+DEBUG: gitlint.cli Python version: {python_version}
+DEBUG: gitlint.git ('--version',)
+DEBUG: gitlint.cli Git version: {git_version}
+DEBUG: gitlint.cli Gitlint version: {gitlint_version}
+DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
+DEBUG: gitlint.cli DEFAULT_ENCODING: {DEFAULT_ENCODING}
+DEBUG: gitlint.cli Configuration
+config-path: None
+[GENERAL]
+extra-path: None
+contrib: ['CC1', 'CT1']
+ignore: T1,T2
+ignore-merge-commits: True
+ignore-fixup-commits: True
+ignore-squash-commits: True
+ignore-revert-commits: True
+ignore-stdin: True
+staged: False
+verbosity: 2
+debug: True
+target: {target}
+[RULES]
+  I1: ignore-by-title
+     ignore=all
+     regex=None
+  I2: ignore-by-body
+     ignore=all
+     regex=None
+  I3: ignore-body-lines
+     regex=None
+  T1: title-max-length
+     line-length=72
+  T2: title-trailing-whitespace
+  T6: title-leading-whitespace
+  T3: title-trailing-punctuation
+  T4: title-hard-tab
+  T5: title-must-not-contain-word
+     words=WIP
+  T7: title-match-regex
+     regex=None
+  B1: body-max-line-length
+     line-length=80
+  B5: body-min-length
+     min-length=20
+  B6: body-is-missing
+     ignore-merge-commits=True
+  B2: body-trailing-whitespace
+  B3: body-hard-tab
+  B4: body-first-line-empty
+  B7: body-changed-file-mention
+     files=
+  B8: body-match-regex
+     regex=None
+  M1: author-valid-email
+     regex=[^@ ]+@[^@ ]+\.[^@ ]+
+  CC1: contrib-body-requires-signed-off-by
+  CT1: contrib-title-conventional-commits
+     types=fix,feat,chore,docs,style,refactor,perf,test,revert,ci,build
+
+DEBUG: gitlint.cli No --msg-filename flag, no or empty data passed to stdin. Using the local repo.
+DEBUG: gitlint.git ('rev-list', '{commit_sha}')
+DEBUG: gitlint.cli Linting 1 commit(s)
+DEBUG: gitlint.git ('log', '{commit_sha}', '-1', '--pretty=%aN%x00%aE%x00%ai%x00%P%n%B')
+DEBUG: gitlint.git ('config', '--get', 'core.commentchar')
+DEBUG: gitlint.lint Linting commit {commit_sha}
+DEBUG: gitlint.git ('branch', '--contains', '{commit_sha}')
+DEBUG: gitlint.git ('diff-tree', '--no-commit-id', '--name-only', '-r', '--root', '{commit_sha}')
+DEBUG: gitlint.lint Commit Object
+--- Commit Message ----
+WIP: Thïs is a title thåt is a bit longer.
+Content on the second line
+This line of the body is here because we need it
+
+--- Meta info ---------
+Author: gitlint-test-user <gitlint@test.com>
+Date:   {commit_date}
+is-merge-commit:  False
+is-fixup-commit:  False
+is-squash-commit: False
+is-revert-commit: False
+Branches: ['master']
+Changed Files: {changed_files}
+-----------------------
+1: CC1 Body does not contain a 'Signed-Off-By' line
+1: CT1 Title does not start with one of fix, feat, chore, docs, style, refactor, perf, test, revert, ci, build
+1: T3 Title has trailing punctuation (.)
+1: T5 Title contains the word 'WIP' (case-insensitive)
+2: B4 Second line is not empty
+DEBUG: gitlint.cli Exit Code = 5

--- a/qa/expected/test_config/test_config_from_env_2
+++ b/qa/expected/test_config/test_config_from_env_2
@@ -1,0 +1,81 @@
+DEBUG: gitlint.cli To report issues, please visit https://github.com/jorisroovers/gitlint/issues
+DEBUG: gitlint.cli Platform: {platform}
+DEBUG: gitlint.cli Python version: {python_version}
+DEBUG: gitlint.git ('--version',)
+DEBUG: gitlint.cli Git version: {git_version}
+DEBUG: gitlint.cli Gitlint version: {gitlint_version}
+DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
+DEBUG: gitlint.cli DEFAULT_ENCODING: {DEFAULT_ENCODING}
+DEBUG: gitlint.cli Configuration
+config-path: None
+[GENERAL]
+extra-path: None
+contrib: []
+ignore: 
+ignore-merge-commits: True
+ignore-fixup-commits: True
+ignore-squash-commits: True
+ignore-revert-commits: True
+ignore-stdin: False
+staged: True
+verbosity: 0
+debug: True
+target: {target}
+[RULES]
+  I1: ignore-by-title
+     ignore=all
+     regex=None
+  I2: ignore-by-body
+     ignore=all
+     regex=None
+  I3: ignore-body-lines
+     regex=None
+  T1: title-max-length
+     line-length=72
+  T2: title-trailing-whitespace
+  T6: title-leading-whitespace
+  T3: title-trailing-punctuation
+  T4: title-hard-tab
+  T5: title-must-not-contain-word
+     words=WIP
+  T7: title-match-regex
+     regex=None
+  B1: body-max-line-length
+     line-length=80
+  B5: body-min-length
+     min-length=20
+  B6: body-is-missing
+     ignore-merge-commits=True
+  B2: body-trailing-whitespace
+  B3: body-hard-tab
+  B4: body-first-line-empty
+  B7: body-changed-file-mention
+     files=
+  B8: body-match-regex
+     regex=None
+  M1: author-valid-email
+     regex=[^@ ]+@[^@ ]+\.[^@ ]+
+
+DEBUG: gitlint.cli Fetching additional meta-data from staged commit
+DEBUG: gitlint.cli Using --msg-filename.
+DEBUG: gitlint.git ('config', '--get', 'core.commentchar')
+DEBUG: gitlint.cli Linting 1 commit(s)
+DEBUG: gitlint.lint Linting commit [SHA UNKNOWN]
+DEBUG: gitlint.git ('config', '--get', 'user.name')
+DEBUG: gitlint.git ('config', '--get', 'user.email')
+DEBUG: gitlint.git ('rev-parse', '--abbrev-ref', 'HEAD')
+DEBUG: gitlint.git ('diff', '--staged', '--name-only', '-r')
+DEBUG: gitlint.lint Commit Object
+--- Commit Message ----
+WIP: msg-fïlename test.
+--- Meta info ---------
+Author: gitlint-test-user <gitlint@test.com>
+Date:   {date}
+is-merge-commit:  False
+is-fixup-commit:  False
+is-squash-commit: False
+is-revert-commit: False
+Branches: ['master']
+Changed Files: []
+-----------------------
+DEBUG: gitlint.cli Exit Code = 3


### PR DESCRIPTION
Many command-line flags can now also be set through environment variables
following the format GITLINT_<commandline_option>
