### PR TITLE
Fix: correct date parsing in create-test-repo.bat

### DIFF
--- a/tools/windows/create-test-repo.bat
+++ b/tools/windows/create-test-repo.bat
@@ -2,15 +2,16 @@
 :: Use pushd, so we can popd back at the end (directory changes are not contained inside batch file)
 PUSHD C:\Windows\Temp
 
-:: Determine unique git repo name
-:: Note that date/time parsing on windows is locale dependent, so this might not work on every windows machine
-:: (see https://stackoverflow.com/questions/203090/how-do-i-get-current-date-time-on-the-windows-command-line-in-a-suitable-format)
 @echo off
-For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
-For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a-%%b)
-echo %mydate%_%mytime%
 
-set Reponame=gitlint-test-%mydate%_%mytime%
+:: Determine unique git repo name
+:: We use Python to determine to get a datetime stamp since other workarounds in BATCH are locale dependent
+:: Note that we double escape the % in the format string to %%
+FOR /F "tokens=* USEBACKQ" %%F IN (`python -c "import datetime; print(datetime.datetime.now().strftime('%%Y-%%m-%%d_%%H-%%M-%%S'))"`) DO (
+SET datetime=%%F
+)
+echo %datetime%
+set Reponame=gitlint-test-%datetime%
 echo %Reponame%
 
 :: Create git repo
@@ -28,8 +29,9 @@ echo "tëst 123" > test.txt
 git add test.txt
 git commit -m "test cömmit title" -m "test cömmit body that has a bit more text"
 
-:: echo. -> the dot allows us to print and empty line
+:: echo. -> the dot allows us to print an empty line
 echo.
 echo Created C:\Windows\Temp\%Reponame%
+
 :: Move back to original dir
 POPD


### PR DESCRIPTION
Previously, the date parsing in create-test-repo.bat was locale depend,
which tended to cause issues.

This fix uses python for date parsing which is much more reliable.
