### PR TITLE
Error message was confusing with silent enabled.

### DIFF
--- a/docs/demos/asciicinema.json
+++ b/docs/demos/asciicinema.json
@@ -2412,7 +2412,7 @@
     ],
     [
       0.000020,
-      "gitlint: \u001b[31mYour commit message contains the above violations.\u001b[0m\r\n"
+      "gitlint: \u001b[31mYour commit message contains violations.\u001b[0m\r\n"
     ],
     [
       0.002541,

--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -366,7 +366,7 @@ def run_hook(ctx):
                 continue
 
             click.echo("-----------------------------------------------")
-            click.echo("gitlint: " + click.style("Your commit message contains the above violations.", fg='red'))
+            click.echo("gitlint: " + click.style("Your commit message contains violations.", fg='red'))
 
             value = None
             while value not in ["y", "n", "e"]:

--- a/gitlint/tests/expected/cli/test_cli_hooks/test_hook_config_1_stdout
+++ b/gitlint/tests/expected/cli/test_cli_hooks/test_hook_config_1_stdout
@@ -1,5 +1,5 @@
 gitlint: checking commit message...
 -----------------------------------------------
-gitlint: Your commit message contains the above violations.
+gitlint: Your commit message contains violations.
 Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] 
 Aborted!

--- a/gitlint/tests/expected/cli/test_cli_hooks/test_hook_edit_1_stdout
+++ b/gitlint/tests/expected/cli/test_cli_hooks/test_hook_edit_1_stdout
@@ -1,12 +1,12 @@
 gitlint: checking commit message...
 -----------------------------------------------
-gitlint: Your commit message contains the above violations.
+gitlint: Your commit message contains violations.
 Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] gitlint: checking commit message...
 -----------------------------------------------
-gitlint: Your commit message contains the above violations.
+gitlint: Your commit message contains violations.
 Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] gitlint: checking commit message...
 -----------------------------------------------
-gitlint: Your commit message contains the above violations.
+gitlint: Your commit message contains violations.
 Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] Commit aborted.
 Your commit message: 
 -----------------------------------------------

--- a/gitlint/tests/expected/cli/test_cli_hooks/test_hook_local_commit_1_stdout
+++ b/gitlint/tests/expected/cli/test_cli_hooks/test_hook_local_commit_1_stdout
@@ -1,4 +1,4 @@
 gitlint: checking commit message...
 -----------------------------------------------
-gitlint: Your commit message contains the above violations.
+gitlint: Your commit message contains violations.
 Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] Editing only possible when --msg-filename is specified.

--- a/gitlint/tests/expected/cli/test_cli_hooks/test_hook_no_1_stdout
+++ b/gitlint/tests/expected/cli/test_cli_hooks/test_hook_no_1_stdout
@@ -1,6 +1,6 @@
 gitlint: checking commit message...
 -----------------------------------------------
-gitlint: Your commit message contains the above violations.
+gitlint: Your commit message contains violations.
 Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] Commit aborted.
 Your commit message: 
 -----------------------------------------------

--- a/gitlint/tests/expected/cli/test_cli_hooks/test_hook_no_tty_1_stdout
+++ b/gitlint/tests/expected/cli/test_cli_hooks/test_hook_no_tty_1_stdout
@@ -1,5 +1,5 @@
 gitlint: checking commit message...
 -----------------------------------------------
-gitlint: Your commit message contains the above violations.
+gitlint: Your commit message contains violations.
 Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] 
 Aborted!

--- a/gitlint/tests/expected/cli/test_cli_hooks/test_hook_stdin_violations_1_stdout
+++ b/gitlint/tests/expected/cli/test_cli_hooks/test_hook_stdin_violations_1_stdout
@@ -1,5 +1,5 @@
 gitlint: checking commit message...
 -----------------------------------------------
-gitlint: Your commit message contains the above violations.
+gitlint: Your commit message contains violations.
 Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] 
 Aborted!

--- a/gitlint/tests/expected/cli/test_cli_hooks/test_hook_yes_1_stdout
+++ b/gitlint/tests/expected/cli/test_cli_hooks/test_hook_yes_1_stdout
@@ -1,4 +1,4 @@
 gitlint: checking commit message...
 -----------------------------------------------
-gitlint: Your commit message contains the above violations.
+gitlint: Your commit message contains violations.
 Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] 

--- a/qa/test_hooks.py
+++ b/qa/test_hooks.py
@@ -14,7 +14,7 @@ class HookTests(BaseTestCase):
                   u'2: B4 Second line is not empty: "Contënt on the second line"\n',
                   '3: B6 Body message is missing\n',
                   '-----------------------------------------------\n',
-                  'gitlint: \x1b[31mYour commit message contains the above violations.\x1b[0m\n']
+                  'gitlint: \x1b[31mYour commit message contains violations.\x1b[0m\n']
 
     def setUp(self):
         self.responses = []
@@ -48,7 +48,7 @@ class HookTests(BaseTestCase):
     def _interact(self, line, stdin):
         self.githook_output.append(line)
         # Answer 'yes' to question to keep violating commit-msg
-        if "Your commit message contains the above violations" in line:
+        if "Your commit message contains violations" in line:
             response = self.responses[self.response_index]
             stdin.put(f"{response}\n")
             self.response_index = (self.response_index + 1) % len(self.responses)


### PR DESCRIPTION
If the silent option was enabled, no violations were printed.
The error message then referred to non-existing "above violations".