### PR TITLE
compatibility with 'git commit -s'

### DIFF
--- a/docs/contrib_rules.md
+++ b/docs/contrib_rules.md
@@ -10,7 +10,7 @@ re-implement these commonly used rules themselves as [user-defined](user_defined
 To enable certain contrib rules, you can use the `--contrib` flag.
 ```sh
 $ cat examples/commit-message-1 | gitlint --contrib contrib-title-conventional-commits,CC1
-1: CC1 Body does not contain a 'Signed-Off-By' line
+1: CC1 Body does not contain a 'Signed-off-by' line
 1: CL1 Title does not start with one of fix, feat, chore, docs, style, refactor, perf, test: "WIP: This is the title of a commit message."
 
 # These are the default violations
@@ -41,7 +41,7 @@ You can also configure contrib rules using [any of the other ways to configure g
 ID    | Name                                | gitlint version   | Description
 ------|-------------------------------------|------------------ |-------------------------------------------
 CT1   | contrib-title-conventional-commits  | >= 0.12.0         | Enforces [Conventional Commits](https://www.conventionalcommits.org/) commit message style on the title.
-CC1   | contrib-body-requires-signed-off-by | >= 0.12.0         | Commit body must contain a `Signed-Off-By` line.
+CC1   | contrib-body-requires-signed-off-by | >= 0.12.0         | Commit body must contain a `Signed-off-by` line.
 
 ## CT1: contrib-title-conventional-commits ##
 
@@ -60,7 +60,7 @@ types          | >= 0.12.0          | `fix,feat,chore,docs,style,refactor,perf,t
 
 ID    | Name                                  | gitlint version    | Description
 ------|---------------------------------------|--------------------|-------------------------------------------
-CC1   | contrib-body-requires-signed-off-by   | >= 0.12.0          | Commit body must contain a `Signed-Off-By` line. This means, a line that starts with the `Signed-Off-By` keyword.
+CC1   | contrib-body-requires-signed-off-by   | >= 0.12.0          | Commit body must contain a `Signed-off-by` line. This means, a line that starts with the `Signed-off-by` keyword.
 
 
 ## Contributing Contrib rules

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -397,9 +397,9 @@ regex                 | >= 0.14.0         | None                         |  [Pyt
 [ignore-body-lines]
 regex=^Co-Authored-By
 
-# Ignore lines that start with 'Co-Authored-By' or with 'Signed-Off-By'
+# Ignore lines that start with 'Co-Authored-By' or with 'Signed-off-by'
 [ignore-body-lines]
-regex=(^Co-Authored-By)|(^Signed-Off-By)
+regex=(^Co-Authored-By)|(^Signed-off-by)
 
 # Ignore lines that contain 'foobar'
 [ignore-body-lines]

--- a/docs/user_defined_rules.md
+++ b/docs/user_defined_rules.md
@@ -9,8 +9,8 @@ for python files containing gitlint rule classes. You can also specify a single 
 
 ```sh
 cat examples/commit-message-1 | gitlint --extra-path examples/
-# Example output of a user-defined Signed-Off-By rule
-1: UC2 Body does not contain a 'Signed-Off-By Line' 
+# Example output of a user-defined Signed-off-by rule
+1: UC2 Body does not contain a 'Signed-off-by Line'
 # other violations were removed for brevity
 ```
 
@@ -23,9 +23,9 @@ which is part of the examples directory that was passed via `--extra-path`:
 from gitlint.rules import CommitRule, RuleViolation
 
 class SignedOffBy(CommitRule):
-    """ This rule will enforce that each commit contains a "Signed-Off-By" line.
+    """ This rule will enforce that each commit contains a "Signed-off-by" line.
     We keep things simple here and just check whether the commit body contains a
-    line that starts with "Signed-Off-By".
+    line that starts with "Signed-off-by".
     """
 
     # A rule MUST have a human friendly name
@@ -39,10 +39,10 @@ class SignedOffBy(CommitRule):
         self.log.debug("SignedOffBy: This will be visible when running `gitlint --debug`")
 
         for line in commit.message.body:
-            if line.startswith("Signed-Off-By"):
+            if line.startswith("Signed-off-by"):
                 return
 
-        msg = "Body does not contain a 'Signed-Off-By' line"
+        msg = "Body does not contain a 'Signed-off-by' line"
         return [RuleViolation(self.id, msg, line_nr=1)]
 ```
 
@@ -95,9 +95,9 @@ Consider the following `CommitRule` that can be found in [examples/my_commit_rul
 from gitlint.rules import CommitRule, RuleViolation
 
 class SignedOffBy(CommitRule):
-    """ This rule will enforce that each commit contains a "Signed-Off-By" line.
+    """ This rule will enforce that each commit contains a "Signed-off-by" line.
     We keep things simple here and just check whether the commit body contains a
-    line that starts with "Signed-Off-By".
+    line that starts with "Signed-off-by".
     """
 
     # A rule MUST have a human friendly name
@@ -111,10 +111,10 @@ class SignedOffBy(CommitRule):
         self.log.debug("SignedOffBy: This will be visible when running `gitlint --debug`")
 
         for line in commit.message.body:
-            if line.startswith("Signed-Off-By"):
+            if line.startswith("Signed-off-by"):
                 return
 
-        msg = "Body does not contain a 'Signed-Off-By' line"
+        msg = "Body does not contain a 'Signed-off-by' line"
         return [RuleViolation(self.id, msg, line_nr=1)]
 ```
 Note the use of the `name` and `id` class attributes and the `validate(...)` method taking a single `commit` parameter.
@@ -368,7 +368,7 @@ class ReleaseConfigurationRule(ConfigurationRule):
             # NOT modify your actual commit in git)
             commit.message.body = [line for line in commit.message.body if not line.startswith("$")]
 
-            # You can add any extra properties you want to the commit object, 
+            # You can add any extra properties you want to the commit object,
             # these will be available later on in all rules.
             commit.my_property = "This is my property"
 ```

--- a/examples/my_commit_rules.py
+++ b/examples/my_commit_rules.py
@@ -40,8 +40,8 @@ class BodyMaxLineCount(CommitRule):
 
 
 class SignedOffBy(CommitRule):
-    """ This rule will enforce that each commit contains a "Signed-Off-By" line.
-    We keep things simple here and just check whether the commit body contains a line that starts with "Signed-Off-By".
+    """ This rule will enforce that each commit contains a "Signed-off-by" line.
+    We keep things simple here and just check whether the commit body contains a line that starts with "Signed-off-by".
     """
 
     # A rule MUST have a human friendly name
@@ -54,10 +54,10 @@ class SignedOffBy(CommitRule):
         self.log.debug("SignedOffBy: This will be visible when running `gitlint --debug`")
 
         for line in commit.message.body:
-            if line.startswith("Signed-Off-By"):
+            if line.startswith("Signed-off-by"):
                 return
 
-        return [RuleViolation(self.id, "Body does not contain a 'Signed-Off-By' line", line_nr=1)]
+        return [RuleViolation(self.id, "Body does not contain a 'Signed-off-by' line", line_nr=1)]
 
 
 class BranchNamingConventions(CommitRule):

--- a/gitlint/contrib/rules/signedoff_by.py
+++ b/gitlint/contrib/rules/signedoff_by.py
@@ -3,8 +3,8 @@ from gitlint.rules import CommitRule, RuleViolation
 
 
 class SignedOffBy(CommitRule):
-    """ This rule will enforce that each commit body contains a "Signed-Off-By" line.
-    We keep things simple here and just check whether the commit body contains a line that starts with "Signed-Off-By".
+    """ This rule will enforce that each commit body contains a "Signed-off-by" line.
+    We keep things simple here and just check whether the commit body contains a line that starts with "Signed-off-by".
     """
 
     name = "contrib-body-requires-signed-off-by"
@@ -12,7 +12,7 @@ class SignedOffBy(CommitRule):
 
     def validate(self, commit):
         for line in commit.message.body:
-            if line.startswith("Signed-Off-By"):
+            if line.lower().startswith("signed-off-by"):
                 return []
 
-        return [RuleViolation(self.id, "Body does not contain a 'Signed-Off-By' line", line_nr=1)]
+        return [RuleViolation(self.id, "Body does not contain a 'Signed-off-by' line", line_nr=1)]

--- a/gitlint/tests/contrib/rules/test_signedoff_by.py
+++ b/gitlint/tests/contrib/rules/test_signedoff_by.py
@@ -17,16 +17,16 @@ class ContribSignedOffByTests(BaseTestCase):
             self.assertIn(SignedOffBy(), config.rules)
 
     def test_signedoff_by(self):
-        # No violations when 'Signed-Off-By' line is present
+        # No violations when 'Signed-off-by' line is present
         rule = SignedOffBy()
-        violations = rule.validate(self.gitcommit("Föobar\n\nMy Body\nSigned-Off-By: John Smith"))
+        violations = rule.validate(self.gitcommit("Föobar\n\nMy Body\nSigned-off-by: John Smith"))
         self.assertListEqual([], violations)
 
-        # Assert violation when no 'Signed-Off-By' line is present
+        # Assert violation when no 'Signed-off-by' line is present
         violations = rule.validate(self.gitcommit("Föobar\n\nMy Body"))
-        expected_violation = RuleViolation("CC1", "Body does not contain a 'Signed-Off-By' line", line_nr=1)
+        expected_violation = RuleViolation("CC1", "Body does not contain a 'Signed-off-by' line", line_nr=1)
         self.assertListEqual(violations, [expected_violation])
 
-        # Assert violation when no 'Signed-Off-By' in title but not in body
-        violations = rule.validate(self.gitcommit("Signed-Off-By\n\nFöobar"))
+        # Assert violation when no 'Signed-off-by' in title but not in body
+        violations = rule.validate(self.gitcommit("Signed-off-by\n\nFöobar"))
         self.assertListEqual(violations, [expected_violation])

--- a/gitlint/tests/expected/cli/test_cli/test_contrib_1
+++ b/gitlint/tests/expected/cli/test_cli/test_contrib_1
@@ -1,3 +1,3 @@
-1: CC1 Body does not contain a 'Signed-Off-By' line
+1: CC1 Body does not contain a 'Signed-off-by' line
 1: CT1 Title does not start with one of fix, feat, chore, docs, style, refactor, perf, test, revert, ci, build: "Test tïtle"
 1: CT1 Title does not follow ConventionalCommits.org format 'type(optional-scope): description': "Test tïtle"

--- a/qa/expected/test_config/test_config_from_env_1
+++ b/qa/expected/test_config/test_config_from_env_1
@@ -85,7 +85,7 @@ is-revert-commit: False
 Branches: ['master']
 Changed Files: {changed_files}
 -----------------------
-1: CC1 Body does not contain a 'Signed-Off-By' line
+1: CC1 Body does not contain a 'Signed-off-by' line
 1: CT1 Title does not start with one of fix, feat, chore, docs, style, refactor, perf, test, revert, ci, build
 1: T3 Title has trailing punctuation (.)
 1: T5 Title contains the word 'WIP' (case-insensitive)

--- a/qa/expected/test_contrib/test_contrib_rules_1
+++ b/qa/expected/test_contrib/test_contrib_rules_1
@@ -1,4 +1,4 @@
-1: CC1 Body does not contain a 'Signed-Off-By' line
+1: CC1 Body does not contain a 'Signed-off-by' line
 1: CT1 Title does not start with one of fix, feat, chore, docs, style, refactor, perf, test, revert, ci, build: "WIP Thi$ is å title"
 1: CT1 Title does not follow ConventionalCommits.org format 'type(optional-scope): description': "WIP Thi$ is å title"
 1: T5 Title contains the word 'WIP' (case-insensitive): "WIP Thi$ is å title"

--- a/qa/expected/test_contrib/test_contrib_rules_with_config_1
+++ b/qa/expected/test_contrib/test_contrib_rules_with_config_1
@@ -1,4 +1,4 @@
-1: CC1 Body does not contain a 'Signed-Off-By' line
+1: CC1 Body does not contain a 'Signed-off-by' line
 1: CT1 Title does not start with one of föo, bår: "WIP Thi$ is å title"
 1: CT1 Title does not follow ConventionalCommits.org format 'type(optional-scope): description': "WIP Thi$ is å title"
 1: T5 Title contains the word 'WIP' (case-insensitive): "WIP Thi$ is å title"

--- a/qa/expected/test_user_defined/test_user_defined_rules_examples_1
+++ b/qa/expected/test_user_defined/test_user_defined_rules_examples_1
@@ -1,5 +1,5 @@
 1: T5 Title contains the word 'WIP' (case-insensitive): "WIP: Thi$ is å title"
-1: UC2 Body does not contain a 'Signed-Off-By' line
+1: UC2 Body does not contain a 'Signed-off-by' line
 1: UC3 Branch name 'master' does not start with one of ['feature/', 'hotfix/', 'release/']
 1: UL1 Title contains the special character '$': "WIP: Thi$ is å title"
 2: B4 Second line is not empty: "Content on the second line"

--- a/qa/expected/test_user_defined/test_user_defined_rules_examples_2
+++ b/qa/expected/test_user_defined/test_user_defined_rules_examples_2
@@ -1,4 +1,4 @@
-1: UC2 Body does not contain a 'Signed-Off-By' line
+1: UC2 Body does not contain a 'Signed-off-by' line
 1: UC3 Branch name 'master' does not start with one of ['feature/', 'hotfix/', 'release/']
 1: UL1 Title contains the special character '$'
 2: B4 Second line is not empty

--- a/qa/expected/test_user_defined/test_user_defined_rules_examples_with_config_1
+++ b/qa/expected/test_user_defined/test_user_defined_rules_examples_with_config_1
@@ -1,6 +1,6 @@
 1: T5 Title contains the word 'WIP' (case-insensitive): "WIP: Thi$ is å title"
 1: UC1 Body contains too many lines (2 > 1)
-1: UC2 Body does not contain a 'Signed-Off-By' line
+1: UC2 Body does not contain a 'Signed-off-by' line
 1: UC3 Branch name 'master' does not start with one of ['feature/', 'hotfix/', 'release/']
 1: UL1 Title contains the special character '$': "WIP: Thi$ is å title"
 2: B4 Second line is not empty: "Content on the second line"


### PR DESCRIPTION
git 2.30: `git commit -s` adds a `Signed-off-by` line, not a `Signed-Off-By`.

