### PR TITLE
Fix missing body rules with multiple new lines

### DIFF
--- a/gitlint/rules.py
+++ b/gitlint/rules.py
@@ -290,7 +290,7 @@ class BodyMissing(CommitRule):
         # ignore merges when option tells us to, which may have no body
         if self.options['ignore-merge-commits'].value and commit.is_merge_commit:
             return
-        if len(commit.message.body) < 2:
+        if len(commit.message.body) < 2 or not ''.join(commit.message.body).strip():
             return [RuleViolation(self.id, "Body message is missing", None, 3)]
 
 

--- a/gitlint/tests/rules/test_body_rules.py
+++ b/gitlint/tests/rules/test_body_rules.py
@@ -126,6 +126,16 @@ class BodyRuleTests(BaseTestCase):
         violations = rule.validate(commit)
         self.assertListEqual(violations, [expected_violation])
 
+    def test_body_missing_multiple_empty_new_lines(self):
+        rule = rules.BodyMissing()
+
+        # body is too short
+        expected_violation = rules.RuleViolation("B6", "Body message is missing", None, 3)
+
+        commit = self.gitcommit("Tïtle\n\n\n\n")
+        violations = rule.validate(commit)
+        self.assertListEqual(violations, [expected_violation])
+
     def test_body_missing_merge_commit(self):
         rule = rules.BodyMissing()
 


### PR DESCRIPTION
A body could be crafted with multiple new lines and it would bypass
the body missing rule

It fixes: #176
