### PR TITLE
Fix pypy pylint(no-member) failure in CI

### DIFF
--- a/gitlint/utils.py
+++ b/gitlint/utils.py
@@ -71,7 +71,7 @@ def getpreferredencoding():
         # This scenario is fairly common on Windows where git sets LC_CTYPE=C when invoking the commit-msg hook, which
         # is not a valid encoding in Python on Windows.
         try:
-            codecs.lookup(default_encoding)
+            codecs.lookup(default_encoding)  # pylint: disable=no-member
         except LookupError:
             default_encoding = fallback_encoding
 


### PR DESCRIPTION
pylint is not able to find the member statically. It means that the
lookup member is created dynamically in the pypy implementation
