### PR TITLE
Various dependency upgrades

### DIFF
--- a/qa/requirements.txt
+++ b/qa/requirements.txt
@@ -1,4 +1,4 @@
 sh==1.14.1
-pytest==6.1.2;
-arrow==0.17.0;
+pytest==6.2.2;
+arrow==1.0.2;
 gitlint # no version as you want to test the currently installed version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools
-wheel==0.35.1
+wheel==0.36.2
 Click==7.1.2
 sh==1.14.1; sys_platform != 'win32' # sh is not supported on windows
-arrow==0.17.0
+arrow==1.0.2

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         'Click==7.1.2',
-        'arrow==0.17.0',
+        'arrow==1.0.2',
     ],
     extras_require={
         ':sys_platform != "win32"': [

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,8 @@
 flake8==3.8.4
-coverage==5.3
-python-coveralls==2.9.2
-radon==4.3.2
+coverage==5.5
+python-coveralls==2.9.3
+radon==4.4.0
 flake8-polyfill==1.0.2 # Required when installing both flake8 and radon>=4.3.1 
-pytest==6.1.2;
-pylint==2.6.0;
+pytest==6.2.2;
+pylint==2.7.2;
 -e .


### PR DESCRIPTION
wheel:            0.35.1 -> 0.36.2
arrow:            0.17.0 -> 1.0.2

Test dependencies:
pytest:           6.1.2  -> 6.2.2
coverage:         5.3    -> 5.5
radon:            4.3.2  -> 4.4.0
pylint:           2.6.0  -> 2.7.2
python-coveralls: 2.9.2  -> 2.9.3