### PR TITLE
Add missing environment variable for config file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -318,13 +318,13 @@ Path where gitlint looks for a config file.
 
 Default value              |  gitlint version | commandline flag  | environment variable   
 ---------------------------|------------------|-------------------|-----------------------
- (empty)                   | >= 0.18.0        | `--config`        | `GITLINT_CONFIG`
+`.gitlint`                 | >= 0.1.0         | `--config`        | `GITLINT_CONFIG`
 
 #### Examples
 ```sh
-gitlint --config=~/.config/gitlint/gitlint.ini
-gitlint -C ~/.gitlint
-GITLINT_CONFIG=~/.gitlint gitlint
+gitlint --config=/home/joe/gitlint.ini
+gitlint -C /home/joe/gitlint.ini      # different way of doing the same
+GITLINT_CONFIG=/home/joe/gitlint.ini  # using env variable
 ```
 
 ### extra-path

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -312,6 +312,20 @@ GITLINT_TARGET=/home/joe/myrepo/ gitlint     # using env variable
 [general]
 target=/home/joe/myrepo/
 ```
+### config
+
+Path where gitlint looks for a config file.
+
+Default value              |  gitlint version | commandline flag  | environment variable   
+---------------------------|------------------|-------------------|-----------------------
+ (empty)                   | >= 0.18.0        | `--config`        | `GITLINT_CONFIG`
+
+#### Examples
+```sh
+gitlint --config=~/.config/gitlint/gitlint.ini
+gitlint -C ~/.gitlint
+GITLINT_CONFIG=~/.gitlint gitlint
+```
 
 ### extra-path
 

--- a/gitlint-core/gitlint/cli.py
+++ b/gitlint-core/gitlint/cli.py
@@ -210,7 +210,8 @@ class ContextObj:
 @click.option('--target', envvar='GITLINT_TARGET',
               type=click.Path(exists=True, resolve_path=True, file_okay=False, readable=True),
               help="Path of the target git repository. [default: current working directory]")
-@click.option('-C', '--config', type=click.Path(exists=True, dir_okay=False, readable=True, resolve_path=True),
+@click.option('-C', '--config', envvar='GITLINT_CONFIG',
+              type=click.Path(exists=True, dir_okay=False, readable=True, resolve_path=True),
               help=f"Config file location [default: {DEFAULT_CONFIG_FILE}]")
 @click.option('-c', multiple=True,
               help="Config flags in format <rule>.<option>=<value> (e.g.: -c T1.line-length=80). " +

--- a/gitlint-core/gitlint/tests/cli/test_cli.py
+++ b/gitlint-core/gitlint/tests/cli/test_cli.py
@@ -456,6 +456,28 @@ class CLITests(BaseTestCase):
             self.assertEqual(stderr.getvalue(), expected_output)
             self.assertEqual(result.exit_code, 2)
 
+    @patch('gitlint.cli.get_stdin_data', return_value="Test tïtle\n")
+    def test_extra_path_environment(self, _):
+        """ Test for GITLINT_EXTRA_PATH environment variable """
+        # Test setting extra-path to a directory from an environment variable
+        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+            extra_path = self.get_sample_path("user_rules")
+            result = self.cli.invoke(cli.cli, env={"GITLINT_EXTRA_PATH": extra_path})
+
+            expected_output = "1: UC1 Commit violåtion 1: \"Contënt 1\"\n" + \
+                              "3: B6 Body message is missing\n"
+            self.assertEqual(stderr.getvalue(), expected_output)
+            self.assertEqual(result.exit_code, 2)
+
+        # Test extra-path pointing to a file from an environment variable
+        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+            extra_path = self.get_sample_path(os.path.join("user_rules", "my_commit_rules.py"))
+            result = self.cli.invoke(cli.cli, env={"GITLINT_EXTRA_PATH": extra_path})
+            expected_output = "1: UC1 Commit violåtion 1: \"Contënt 1\"\n" + \
+                              "3: B6 Body message is missing\n"
+            self.assertEqual(stderr.getvalue(), expected_output)
+            self.assertEqual(result.exit_code, 2)
+
     @patch('gitlint.cli.get_stdin_data', return_value="Test tïtle\n\nMy body that is long enough")
     def test_contrib(self, _):
         # Test enabled contrib rules


### PR DESCRIPTION
Most of the gitlint command-line options have corresponding environment
variables following the format GITLINT_<commandline_option>, added in
69aa5ffaeb7dae849f8ab655ea0426e26deee44f.

---

The only remaining command-line option that's missing a corresponding environment variable is the `-c` option for overriding individual configuration options.

Additionally, I made the assumption in the documentation that this change would get released in 1.16.0.

I investigated adding tests, but I chose not to for a few, opinionated, reasons
* This is a quite small change, that follows an existing pattern
* The most similar environment variable, `GITLINT_EXTRA_PATH`, does not have a test
* I did not find a clean way to add a meaningful test, but I'm not very experienced with Python testing methods that interact with the system environment.