### PR TITLE
Allow "!" for breaking change commits

### DIFF
--- a/gitlint/contrib/rules/conventional_commit.py
+++ b/gitlint/contrib/rules/conventional_commit.py
@@ -3,7 +3,7 @@ import re
 from gitlint.options import ListOption
 from gitlint.rules import CommitMessageTitle, LineRule, RuleViolation
 
-RULE_REGEX = re.compile(r"[^(]+?(\([^)]+?\))?: .+")
+RULE_REGEX = re.compile(r"[^(]+?(\([^)]+?\))?!?: .+")
 
 
 class ConventionalCommit(LineRule):

--- a/gitlint/contrib/rules/conventional_commit.py
+++ b/gitlint/contrib/rules/conventional_commit.py
@@ -3,7 +3,7 @@ import re
 from gitlint.options import ListOption
 from gitlint.rules import CommitMessageTitle, LineRule, RuleViolation
 
-RULE_REGEX = re.compile(r"[^(]+?(\([^)]+?\))?!?: .+")
+RULE_REGEX = re.compile(r"([^(]+?)(\([^)]+?\))?!?: .+")
 
 
 class ConventionalCommit(LineRule):
@@ -23,16 +23,18 @@ class ConventionalCommit(LineRule):
 
     def validate(self, line, _commit):
         violations = []
+        match = RULE_REGEX.match(line)
 
-        for commit_type in self.options["types"].value:
-            if line.startswith(commit_type):
-                break
-        else:
-            msg = "Title does not start with one of {0}".format(', '.join(self.options['types'].value))
-            violations.append(RuleViolation(self.id, msg, line))
-
-        if not RULE_REGEX.match(line):
+        if not match:
             msg = "Title does not follow ConventionalCommits.org format 'type(optional-scope): description'"
             violations.append(RuleViolation(self.id, msg, line))
+        else:
+            line_commit_type = match.group(1)
+            for commit_type in self.options["types"].value:
+                if line_commit_type == commit_type:
+                    break
+            else:
+                msg = "Title does not start with one of {0}".format(', '.join(self.options['types'].value))
+                violations.append(RuleViolation(self.id, msg, line))
 
         return violations

--- a/gitlint/contrib/rules/conventional_commit.py
+++ b/gitlint/contrib/rules/conventional_commit.py
@@ -30,10 +30,7 @@ class ConventionalCommit(LineRule):
             violations.append(RuleViolation(self.id, msg, line))
         else:
             line_commit_type = match.group(1)
-            for commit_type in self.options["types"].value:
-                if line_commit_type == commit_type:
-                    break
-            else:
+            if line_commit_type not in self.options["types"].value:
                 msg = "Title does not start with one of {0}".format(', '.join(self.options['types'].value))
                 violations.append(RuleViolation(self.id, msg, line))
 

--- a/gitlint/tests/cli/test_cli.py
+++ b/gitlint/tests/cli/test_cli.py
@@ -405,7 +405,7 @@ class CLITests(BaseTestCase):
             result = self.cli.invoke(cli.cli, ["--contrib", "contrib-title-conventional-commits,CC1"])
             expected_output = self.get_expected('cli/test_cli/test_contrib_1')
             self.assertEqual(stderr.getvalue(), expected_output)
-            self.assertEqual(result.exit_code, 3)
+            self.assertEqual(result.exit_code, 2)
 
     @patch('gitlint.cli.get_stdin_data', return_value="Test tïtle\n")
     def test_contrib_negative(self, _):

--- a/gitlint/tests/contrib/rules/test_conventional_commit.py
+++ b/gitlint/tests/contrib/rules/test_conventional_commit.py
@@ -29,11 +29,33 @@ class ContribConventionalCommitTests(BaseTestCase):
         violations = rule.validate("bår: foo", None)
         self.assertListEqual([expected_violation], violations)
 
+        # assert violation when use strange chars after correct type
+        expected_violation = RuleViolation("CT1", "Title does not start with one of fix, feat, chore, docs,"
+                                                  " style, refactor, perf, test, revert, ci, build",
+                                                  "feat_wrong_chars: föo")
+        violations = rule.validate("feat_wrong_chars: föo", None)
+        self.assertListEqual([expected_violation], violations)
+
+        # assert violation when use strange chars after correct type
+        expected_violation = RuleViolation("CT1", "Title does not start with one of fix, feat, chore, docs,"
+                                                  " style, refactor, perf, test, revert, ci, build",
+                                                  "feat_wrong_chars(scope): föo")
+        violations = rule.validate("feat_wrong_chars(scope): föo", None)
+        self.assertListEqual([expected_violation], violations)
+
         # assert violation on wrong format
         expected_violation = RuleViolation("CT1", "Title does not follow ConventionalCommits.org format "
                                                   "'type(optional-scope): description'", "fix föo")
         violations = rule.validate("fix föo", None)
         self.assertListEqual([expected_violation], violations)
+
+        # assert no violation when use ! for breaking changes without scope
+        violations = rule.validate("feat!: föo", None)
+        self.assertListEqual([], violations)
+
+        # assert no violation when use ! for breaking changes with scope
+        violations = rule.validate("fix(scope)!: föo", None)
+        self.assertListEqual([], violations)
 
         # assert no violation when adding new type
         rule = ConventionalCommit({'types': ["föo", "bär"]})
@@ -45,3 +67,9 @@ class ContribConventionalCommitTests(BaseTestCase):
         violations = rule.validate("fix: hür dur", None)
         expected_violation = RuleViolation("CT1", "Title does not start with one of föo, bär", "fix: hür dur")
         self.assertListEqual([expected_violation], violations)
+
+        # assert no violation when adding new type named with numbers
+        rule = ConventionalCommit({'types': ["föo123", "123bär"]})
+        for typ in ["föo123", "123bär"]:
+            violations = rule.validate(typ + ": hür dur", None)
+            self.assertListEqual([], violations)

--- a/gitlint/tests/expected/cli/test_cli/test_contrib_1
+++ b/gitlint/tests/expected/cli/test_cli/test_contrib_1
@@ -1,3 +1,2 @@
 1: CC1 Body does not contain a 'Signed-off-by' line
-1: CT1 Title does not start with one of fix, feat, chore, docs, style, refactor, perf, test, revert, ci, build: "Test tïtle"
 1: CT1 Title does not follow ConventionalCommits.org format 'type(optional-scope): description': "Test tïtle"

--- a/qa/expected/test_contrib/test_contrib_rules_1
+++ b/qa/expected/test_contrib/test_contrib_rules_1
@@ -1,4 +1,3 @@
 1: CC1 Body does not contain a 'Signed-off-by' line
-1: CT1 Title does not start with one of fix, feat, chore, docs, style, refactor, perf, test, revert, ci, build: "WIP Thi$ is å title"
 1: CT1 Title does not follow ConventionalCommits.org format 'type(optional-scope): description': "WIP Thi$ is å title"
 1: T5 Title contains the word 'WIP' (case-insensitive): "WIP Thi$ is å title"

--- a/qa/expected/test_contrib/test_contrib_rules_with_config_1
+++ b/qa/expected/test_contrib/test_contrib_rules_with_config_1
@@ -1,4 +1,3 @@
 1: CC1 Body does not contain a 'Signed-off-by' line
-1: CT1 Title does not start with one of föo, bår: "WIP Thi$ is å title"
 1: CT1 Title does not follow ConventionalCommits.org format 'type(optional-scope): description': "WIP Thi$ is å title"
 1: T5 Title contains the word 'WIP' (case-insensitive): "WIP Thi$ is å title"

--- a/qa/test_contrib.py
+++ b/qa/test_contrib.py
@@ -10,14 +10,14 @@ class ContribRuleTests(BaseTestCase):
     def test_contrib_rules(self):
         self.create_simple_commit("WIP Thi$ is å title\n\nMy bödy that is a bit longer than 20 chars")
         output = gitlint("--contrib", "contrib-title-conventional-commits,CC1",
-                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[4])
+                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3])
         self.assertEqualStdout(output, self.get_expected("test_contrib/test_contrib_rules_1"))
 
     def test_contrib_rules_with_config(self):
         self.create_simple_commit("WIP Thi$ is å title\n\nMy bödy that is a bit longer than 20 chars")
         output = gitlint("--contrib", "contrib-title-conventional-commits,CC1",
                          "-c", "contrib-title-conventional-commits.types=föo,bår",
-                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[4])
+                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3])
         self.assertEqualStdout(output, self.get_expected("test_contrib/test_contrib_rules_with_config_1"))
 
     def test_invalid_contrib_rules(self):


### PR DESCRIPTION
Following conventional commits docs.

[Commit message with ! to draw attention to breaking change](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with--to-draw-attention-to-breaking-change)

fixes: #186 #185 