### PR TITLE
tests: Set minimum test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,5 @@
+[report]
+fail_under = 97
+
 [run]
 omit=*dist-packages*,*site-packages*,gitlint/tests/*,.venv/*,*virtualenv*


### PR DESCRIPTION
This ensures that code which significantly reduces the coverage won't be
accepted.
