### PR TITLE
tests: Check branch coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
+branch = true
 omit=*dist-packages*,*site-packages*,gitlint/tests/*,.venv/*,*virtualenv*


### PR DESCRIPTION
This strengthens the coverage metric information, by making sure that,
for example, `foo` in the following code is both truthy and falsy during
some test.

```
if foo:
   do_something()
```
