### PR TITLE
Make requirement pinning optional

### DIFF
--- a/docs/demos/scenario.txt
+++ b/docs/demos/scenario.txt
@@ -26,7 +26,7 @@ asciicinema rec demo.json
 
 ------------------------------------
 
-pip install gitlint
+pip install gitlint[pinned]
 
 # Go to your git repo
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ useful throughout the years.
 ### Installation
 ```sh
 # Pip is recommended to install the latest version
-pip install gitlint
+pip install gitlint[pinned]
 
 # Community maintained packages:
 brew install gitlint       # Homebrew (macOS)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 setuptools
 wheel==0.37.0
-Click==8.0.3
-sh==1.14.2; sys_platform != 'win32' # sh is not supported on windows
-arrow==1.2.1
+-e .[pinned]

--- a/setup.py
+++ b/setup.py
@@ -60,12 +60,15 @@ setup(
     ],
     python_requires=">=3.6",
     install_requires=[
-        'Click==8.0.3',
-        'arrow==1.2.1',
+        'Click>=8',
+        'arrow>=1',
+        'sh>=1 ; sys_platform != "win32"',
     ],
     extras_require={
-        ':sys_platform != "win32"': [
-            'sh==1.14.2',
+        'pinned': [
+            'Click==8.0.3',
+            'arrow==1.2.1',
+            'sh==1.14.2 ; sys_platform != "win32"',
         ],
     },
     keywords='gitlint git lint',


### PR DESCRIPTION
gitlint’s pinned requirements make it difficult to use with other libraries and tools that have newer requirements, and may hold back important security updates. With this change, it’s possible to install gitlint with its requirements either pinned:

```sh
pip install gitlint[pinned]
```

or unpinned:

```sh
pip install gitlint
```

At this time, we document only the pinned option because the maintainer has indicated a preference for supporting that configuration.

Fixes #162.