### PR TITLE
 Implements --fail-without-commits option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -363,6 +363,30 @@ GITLINT_STAGED=1 gitlint       # using env variable
 staged=true
 ```
 
+### fail-without-commits
+
+Hard fail when the target commit range is empty. Note that gitlint will
+already fail by default on invalid commit ranges. This option is specifically
+to tell gitlint to fail on **valid but empty** commit ranges.
+
+Default value  |  gitlint version | commandline flag  | environment variable   
+---------------|------------------|---------------------------|-----------------------
+ false         | >= 0.15.2        | `--fail-without-commits`  | `GITLINT_FAIL_WITHOUT_COMMITS`
+
+#### Examples
+```sh
+# CLI
+# The following will cause gitlint to hard fail (i.e. exit code > 0)
+# since HEAD..HEAD is a valid but empty commit range. 
+gitlint --fail-without-commits --commits HEAD..HEAD
+GITLINT_FAIL_WITHOUT_COMMITS=1 gitlint       # using env variable
+```
+```ini
+#.gitlint
+[general]
+fail-without-commits=true
+```
+
 ### ignore-stdin
 
 Ignore any stdin data. Sometimes useful when running gitlint in a CI server.

--- a/docs/index.md
+++ b/docs/index.md
@@ -134,8 +134,9 @@ Options:
                            current working directory]
   -C, --config FILE        Config file location [default: .gitlint]
   -c TEXT                  Config flags in format <rule>.<option>=<value>
-                           (e.g.: -c T1.line-length=80). Flag can be used
-                           multiple times to set multiple config values.
+                           (e.g.: -c T1.line-length=80). Flag can be
+                           used multiple times to set multiple config values.
+
   --commits TEXT           The range of commits to lint. [default: HEAD]
   -e, --extra-path PATH    Path to a directory or python module with extra
                            user-defined rules
@@ -147,10 +148,11 @@ Options:
                            server.
   --staged                 Read staged commit meta-info from the local
                            repository.
-  -v, --verbose            Verbosity, more v's for more verbose output (e.g.:
-                           -v, -vv, -vvv). [default: -vvv]
-  -s, --silent             Silent mode (no output). Takes precedence over -v,
-                           -vv, -vvv.
+  --fail-without-commits   Hard fail when the target commit range is empty.
+  -v, --verbose            Verbosity, more v's for more verbose output
+                           (e.g.: -v, -vv, -vvv). [default: -vvv]
+  -s, --silent             Silent mode (no output).
+                           Takes precedence over -v, -vv, -vvv.
   -d, --debug              Enable debugging output.
   --version                Show the version and exit.
   --help                   Show this message and exit.
@@ -159,6 +161,7 @@ Commands:
   generate-config  Generates a sample gitlint config file.
   install-hook     Install gitlint as a git commit-msg hook.
   lint             Lints a git repository [default command]
+  run-hook         Runs the gitlint commit-msg hook.
   uninstall-hook   Uninstall gitlint commit-msg hook.
 
   When no COMMAND is specified, gitlint defaults to 'gitlint lint'.

--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -281,8 +281,11 @@ def lint(ctx):
     # Exit if we don't have commits in the specified range. Use a 0 exit code, since a popular use-case is one
     # where users are using --commits in a check job to check the commit messages inside a CI job. By returning 0, we
     # ensure that these jobs don't fail if for whatever reason the specified commit range is empty.
+    # This behavior can be overridden by using the --fail-without-commits flag.
     if number_of_commits == 0:
         LOG.debug(u'No commits in range "%s"', refspec)
+        if lint_config.fail_without_commits:
+            raise GitLintUsageError(u'No commits in range "%s"' % refspec)
         ctx.exit(GITLINT_SUCCESS)
 
     LOG.debug(u'Linting %d commit(s)', number_of_commits)

--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -62,7 +62,8 @@ def log_system_info():
 
 
 def build_config(  # pylint: disable=too-many-arguments
-        target, config_path, c, extra_path, ignore, contrib, ignore_stdin, staged, verbose, silent, debug
+        target, config_path, c, extra_path, ignore, contrib, ignore_stdin, staged, fail_without_commits, verbose,
+        silent, debug
 ):
     """ Creates a LintConfig object based on a set of commandline parameters. """
     config_builder = LintConfigBuilder()
@@ -102,6 +103,9 @@ def build_config(  # pylint: disable=too-many-arguments
 
     if staged:
         config_builder.set_option('general', 'staged', staged)
+
+    if fail_without_commits:
+        config_builder.set_option('general', 'fail-without-commits', fail_without_commits)
 
     config = config_builder.build()
 
@@ -218,6 +222,8 @@ class ContextObj:
               help="Ignore any stdin data. Useful for running in CI server.")
 @click.option('--staged', envvar='GITLINT_STAGED', is_flag=True,
               help="Read staged commit meta-info from the local repository.")
+@click.option('--fail-without-commits', envvar='GITLINT_FAIL_WITHOUT_COMMITS', is_flag=True,
+              help="Hard fail when the target commit range is empty.")
 @click.option('-v', '--verbose', envvar='GITLINT_VERBOSITY', count=True, default=0,
               help="Verbosity, more v's for more verbose output (e.g.: -v, -vv, -vvv). [default: -vvv]", )
 @click.option('-s', '--silent', envvar='GITLINT_SILENT', is_flag=True,
@@ -227,7 +233,8 @@ class ContextObj:
 @click.pass_context
 def cli(  # pylint: disable=too-many-arguments
         ctx, target, config, c, commits, extra_path, ignore, contrib,
-        msg_filename, ignore_stdin, staged, verbose, silent, debug,
+        msg_filename, ignore_stdin, staged, fail_without_commits, verbose,
+        silent, debug,
 ):
     """ Git lint tool, checks your git commit messages for styling issues
 
@@ -243,8 +250,8 @@ def cli(  # pylint: disable=too-many-arguments
 
         # Get the lint config from the commandline parameters and
         # store it in the context (click allows storing an arbitrary object in ctx.obj).
-        config, config_builder = build_config(target, config, c, extra_path, ignore, contrib,
-                                              ignore_stdin, staged, verbose, silent, debug)
+        config, config_builder = build_config(target, config, c, extra_path, ignore, contrib, ignore_stdin, staged,
+                                              fail_without_commits, verbose, silent, debug)
         LOG.debug("Configuration\n%s", config)
 
         ctx.obj = ContextObj(config, config_builder, commits, msg_filename)

--- a/gitlint/cli.py
+++ b/gitlint/cli.py
@@ -18,6 +18,7 @@ from gitlint.utils import LOG_FORMAT
 from gitlint.exception import GitlintError
 
 # Error codes
+GITLINT_SUCCESS = 0
 MAX_VIOLATION_ERROR_CODE = 252
 USAGE_ERROR_CODE = 253
 GIT_CONTEXT_ERROR_CODE = 254
@@ -275,7 +276,7 @@ def lint(ctx):
     # ensure that these jobs don't fail if for whatever reason the specified commit range is empty.
     if number_of_commits == 0:
         LOG.debug(u'No commits in range "%s"', refspec)
-        ctx.exit(0)
+        ctx.exit(GITLINT_SUCCESS)
 
     LOG.debug(u'Linting %d commit(s)', number_of_commits)
     general_config_builder = ctx.obj.config_builder
@@ -283,7 +284,7 @@ def lint(ctx):
 
     # Let's get linting!
     first_violation = True
-    exit_code = 0
+    exit_code = GITLINT_SUCCESS
     for commit in gitcontext.commits:
         # Build a config_builder taking into account the commit specific config (if any)
         config_builder = general_config_builder.clone()
@@ -323,7 +324,7 @@ def install_hook(ctx):
         hooks.GitHookInstaller.install_commit_msg_hook(ctx.obj.config)
         hook_path = hooks.GitHookInstaller.commit_msg_hook_path(ctx.obj.config)
         click.echo(f"Successfully installed gitlint commit-msg hook in {hook_path}")
-        ctx.exit(0)
+        ctx.exit(GITLINT_SUCCESS)
     except hooks.GitHookInstallerError as e:
         click.echo(e, err=True)
         ctx.exit(GIT_CONTEXT_ERROR_CODE)
@@ -337,7 +338,7 @@ def uninstall_hook(ctx):
         hooks.GitHookInstaller.uninstall_commit_msg_hook(ctx.obj.config)
         hook_path = hooks.GitHookInstaller.commit_msg_hook_path(ctx.obj.config)
         click.echo(f"Successfully uninstalled gitlint commit-msg hook from {hook_path}")
-        ctx.exit(0)
+        ctx.exit(GITLINT_SUCCESS)
     except hooks.GitHookInstallerError as e:
         click.echo(e, err=True)
         ctx.exit(GIT_CONTEXT_ERROR_CODE)
@@ -361,7 +362,7 @@ def run_hook(ctx):
             sys.stdout.flush()
 
             exit_code = e.exit_code
-            if exit_code == 0:
+            if exit_code == GITLINT_SUCCESS:
                 click.echo("gitlint: " + click.style("OK", fg='green') + " (no violations in commit message)")
                 continue
 
@@ -387,7 +388,7 @@ def run_hook(ctx):
 
             if value == "y":
                 LOG.debug("run-hook: commit message accepted")
-                exit_code = 0
+                exit_code = GITLINT_SUCCESS
             elif value == "e":
                 LOG.debug("run-hook: editing commit message")
                 msg_filename = ctx.obj.msg_filename
@@ -428,7 +429,7 @@ def generate_config(ctx):
 
     LintConfigGenerator.generate_config(path)
     click.echo(f"Successfully generated {path}")
-    ctx.exit(0)
+    ctx.exit(GITLINT_SUCCESS)
 
 
 # Let's Party!

--- a/gitlint/config.py
+++ b/gitlint/config.py
@@ -76,6 +76,8 @@ class LintConfig:
         ignore_stdin_description = "Ignore any stdin data. Useful for running in CI server."
         self._ignore_stdin = options.BoolOption('ignore-stdin', False, ignore_stdin_description)
         self._staged = options.BoolOption('staged', False, "Read staged commit meta-info from the local repository.")
+        self._fail_without_commits = options.BoolOption('fail-without-commits', False,
+                                                        "Hard fail when the target commit range is empty")
 
     @property
     def target(self):
@@ -169,6 +171,15 @@ class LintConfig:
     @handle_option_error
     def staged(self, value):
         return self._staged.set(value)
+
+    @property
+    def fail_without_commits(self):
+        return self._fail_without_commits.value
+
+    @fail_without_commits.setter
+    @handle_option_error
+    def fail_without_commits(self, value):
+        return self._fail_without_commits.set(value)
 
     @property
     def extra_path(self):
@@ -275,6 +286,7 @@ class LintConfig:
             self.ignore_revert_commits == other.ignore_revert_commits and \
             self.ignore_stdin == other.ignore_stdin and \
             self.staged == other.staged and \
+            self.fail_without_commits == other.fail_without_commits and \
             self.debug == other.debug and \
             self.ignore == other.ignore and \
             self._config_path == other._config_path  # noqa
@@ -292,6 +304,7 @@ class LintConfig:
                 f"ignore-revert-commits: {self.ignore_revert_commits}\n"
                 f"ignore-stdin: {self.ignore_stdin}\n"
                 f"staged: {self.staged}\n"
+                f"fail-without-commits: {self.fail_without_commits}\n"
                 f"verbosity: {self.verbosity}\n"
                 f"debug: {self.debug}\n"
                 f"target: {self.target}\n"

--- a/gitlint/files/gitlint
+++ b/gitlint/files/gitlint
@@ -27,6 +27,12 @@
 # commit message to gitlint via stdin or --commit-msg. Disabled by default.
 # staged=true
 
+# Hard fail when the target commit range is empty. Note that gitlint will
+# already fail by default on invalid commit ranges. This option is specifically
+# to tell gitlint to fail on *valid but empty* commit ranges.
+# Disabled by default.
+# fail-without-commits=true
+
 # Enable debug mode (prints more output). Disabled by default.
 # debug=true
 

--- a/gitlint/tests/base.py
+++ b/gitlint/tests/base.py
@@ -126,6 +126,10 @@ class BaseTestCase(unittest.TestCase):
         """
         return super().assertRaisesRegex(expected_exception, re.escape(expected_regex), *args, **kwargs)
 
+    def clearlog(self):
+        """ Clears the log capture """
+        self.logcapture.clear()
+
     @contextlib.contextmanager
     def assertRaisesMessage(self, expected_exception, expected_msg):  # pylint: disable=invalid-name
         """ Asserts an exception has occurred with a given error message """
@@ -182,3 +186,6 @@ class LogCapture(logging.Handler):
 
     def emit(self, record):
         self.messages.append(self.format(record))
+
+    def clear(self):
+        self.messages = []

--- a/gitlint/tests/cli/test_cli.py
+++ b/gitlint/tests/cli/test_cli.py
@@ -26,6 +26,7 @@ class CLITests(BaseTestCase):
     USAGE_ERROR_CODE = 253
     GIT_CONTEXT_ERROR_CODE = 254
     CONFIG_ERROR_CODE = 255
+    GITLINT_SUCCESS_CODE = 0
 
     def setUp(self):
         super(CLITests, self).setUp()
@@ -475,7 +476,7 @@ class CLITests(BaseTestCase):
     def test_generate_config(self, generate_config):
         """ Test for the generate-config subcommand """
         result = self.cli.invoke(cli.cli, ["generate-config"], input="tëstfile\n")
-        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.exit_code, self.GITLINT_SUCCESS_CODE)
         expected_msg = "Please specify a location for the sample gitlint config file [.gitlint]: tëstfile\n" + \
                        f"Successfully generated {os.path.realpath('tëstfile')}\n"
         self.assertEqual(result.output, expected_msg)
@@ -517,7 +518,7 @@ class CLITests(BaseTestCase):
         result = self.cli.invoke(cli.cli, ["--commits", "master...HEAD"])
 
         self.assert_log_contains("DEBUG: gitlint.cli No commits in range \"master...HEAD\"")
-        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.exit_code, self.GITLINT_SUCCESS_CODE)
 
     @patch('gitlint.cli.get_stdin_data', return_value="WIP: tëst tïtle")
     def test_named_rules(self, _):

--- a/gitlint/tests/config/test_config.py
+++ b/gitlint/tests/config/test_config.py
@@ -50,6 +50,7 @@ class LintConfigTests(BaseTestCase):
 
         self.assertFalse(config.ignore_stdin)
         self.assertFalse(config.staged)
+        self.assertFalse(config.fail_without_commits)
         self.assertFalse(config.debug)
         self.assertEqual(config.verbosity, 3)
         active_rule_classes = tuple(type(rule) for rule in config.rules)
@@ -94,6 +95,10 @@ class LintConfigTests(BaseTestCase):
         # staged
         config.set_general_option("staged", "true")
         self.assertTrue(config.staged)
+
+        # fail-without-commits
+        config.set_general_option("fail-without-commits", "true")
+        self.assertTrue(config.fail_without_commits)
 
         # target
         config.set_general_option("target", self.SAMPLES_DIR)
@@ -227,7 +232,7 @@ class LintConfigTests(BaseTestCase):
         # splitting which means it it will accept just about everything
 
         # invalid boolean options
-        for attribute in ['debug', 'staged', 'ignore_stdin']:
+        for attribute in ['debug', 'staged', 'ignore_stdin', 'fail_without_commits']:
             option_name = attribute.replace("_", "-")
             with self.assertRaisesMessage(LintConfigError,
                                           f"Option '{option_name}' must be either 'true' or 'false'"):

--- a/gitlint/tests/expected/cli/test_cli/test_debug_1
+++ b/gitlint/tests/expected/cli/test_cli/test_debug_1
@@ -17,6 +17,7 @@ ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False
 staged: False
+fail-without-commits: False
 verbosity: 1
 debug: True
 target: {target}

--- a/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
+++ b/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
@@ -17,6 +17,7 @@ ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False
 staged: False
+fail-without-commits: False
 verbosity: 3
 debug: True
 target: {target}

--- a/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
+++ b/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
@@ -17,6 +17,7 @@ ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False
 staged: True
+fail-without-commits: False
 verbosity: 3
 debug: True
 target: {target}

--- a/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
+++ b/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
@@ -17,6 +17,7 @@ ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False
 staged: True
+fail-without-commits: False
 verbosity: 3
 debug: True
 target: {target}

--- a/gitlint/tests/expected/cli/test_cli/test_named_rules_2
+++ b/gitlint/tests/expected/cli/test_cli/test_named_rules_2
@@ -17,6 +17,7 @@ ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False
 staged: False
+fail-without-commits: False
 verbosity: 3
 debug: True
 target: {target}

--- a/qa/base.py
+++ b/qa/base.py
@@ -29,6 +29,7 @@ class BaseTestCase(TestCase):
 
     GITLINT_USE_SH_LIB = os.environ.get("GITLINT_USE_SH_LIB", "[NOT SET]")
     GIT_CONTEXT_ERROR_CODE = 254
+    GITLINT_USAGE_ERROR = 253
 
     @classmethod
     def setUpClass(cls):

--- a/qa/expected/test_commits/test_lint_staged_msg_filename_1
+++ b/qa/expected/test_commits/test_lint_staged_msg_filename_1
@@ -18,6 +18,7 @@ ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False
 staged: True
+fail-without-commits: False
 verbosity: 3
 debug: True
 target: {target}

--- a/qa/expected/test_commits/test_lint_staged_stdin_1
+++ b/qa/expected/test_commits/test_lint_staged_stdin_1
@@ -18,6 +18,7 @@ ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False
 staged: True
+fail-without-commits: False
 verbosity: 3
 debug: True
 target: {target}

--- a/qa/expected/test_config/test_config_from_env_1
+++ b/qa/expected/test_config/test_config_from_env_1
@@ -18,6 +18,7 @@ ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: True
 staged: False
+fail-without-commits: False
 verbosity: 2
 debug: True
 target: {target}

--- a/qa/expected/test_config/test_config_from_env_1
+++ b/qa/expected/test_config/test_config_from_env_1
@@ -18,7 +18,7 @@ ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: True
 staged: False
-fail-without-commits: False
+fail-without-commits: True
 verbosity: 2
 debug: True
 target: {target}

--- a/qa/expected/test_config/test_config_from_env_2
+++ b/qa/expected/test_config/test_config_from_env_2
@@ -18,6 +18,7 @@ ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False
 staged: True
+fail-without-commits: False
 verbosity: 0
 debug: True
 target: {target}

--- a/qa/expected/test_config/test_config_from_file_debug_1
+++ b/qa/expected/test_config/test_config_from_file_debug_1
@@ -18,6 +18,7 @@ ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False
 staged: False
+fail-without-commits: False
 verbosity: 2
 debug: True
 target: {target}

--- a/qa/test_config.py
+++ b/qa/test_config.py
@@ -80,7 +80,8 @@ class ConfigTests(BaseTestCase):
         filename = self.create_simple_commit(commit_msg, git_repo=target_repo)
         env = self.create_environment({"GITLINT_DEBUG": "1", "GITLINT_VERBOSITY": "2",
                                        "GITLINT_IGNORE": "T1,T2", "GITLINT_CONTRIB": "CC1,CT1",
-                                       "GITLINT_IGNORE_STDIN": "1", "GITLINT_TARGET": target_repo,
+                                       "GITLINT_FAIL_WITHOUT_COMMITS": "1", "GITLINT_IGNORE_STDIN": "1",
+                                       "GITLINT_TARGET": target_repo,
                                        "GITLINT_COMMITS": self.get_last_commit_hash(git_repo=target_repo)})
         output = gitlint(_env=env, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[5])
         expected_kwargs = self.get_debug_vars_last_commit(git_repo=target_repo)


### PR DESCRIPTION
Gitlint will now hard fail when passing an empty commit range via --commits and specifying the --fail-without-commits option.