### PR TITLE
Fixed recogize merge commit fail while merge commit's parents is empty

### DIFF
--- a/gitlint/git.py
+++ b/gitlint/git.py
@@ -206,7 +206,7 @@ class LocalGitCommit(GitCommit, PropertyCache):
         (name, email, date, parents), commit_msg = raw_commit[0].split('\x00'), "\n".join(raw_commit[1:])
 
         commit_parents = parents.split(" ")
-        commit_is_merge_commit = len(commit_parents) > 1
+        commit_is_merge_commit = len(commit_parents) > 1 or commit_msg.startswith("Merge")
 
         # "YYYY-MM-DD HH:mm:ss Z" -> ISO 8601-like format
         # Use arrow for datetime parsing, because apparently python is quirky around ISO-8601 dates:


### PR DESCRIPTION
<!--- THIS IS A COMMENT BLOCK, REMOVE IT BEFORE SUBMITTING YOUR PR

Thank you for your interest in gitlint and putting in the effort to create a PR!

A few quick notes:

- It's really just me (https://github.com/jorisroovers) maintaining gitlint, and I do so in a hobby capacity. More recently it has become harder for me to find time to maintain gitlint on a regular basis, which in practice means that it might take me a while (sometimes months) to get back to you. Rest assured though, I absolutely look at all PRs as soon as they come in - I just tend to only "work" on gitlint a few times a year.
- Similarly, after your code is merged, it typically still takes months before I do another release that contains your code. Please don't let that deter you from contributing - I appreciate your patience and understanding!
- Please review: http://jorisroovers.github.io/gitlint/contributing/

-->

os: ubuntu16.04
git: 2.33.1
gitlint: 0.16.0

when i use gitlint --commits HEAD to check the commit-msg
one merge commit check the format fail, but the others will not.
I had set ignore-merge-commits=true.
I found the parents of this commit is empty.
and then, I use git git log 273b7ecde3a1151185b70244febc40a3f2049e15 -1 --pretty=%P to check,
the parents is still empty.

now, we set:
commit_is_merge_commit = len(commit_parents) > 1
can we set:
commit_is_merge_commit = len(commit_parents) > 1 or commit_msg.startswith("Merge")

the last,
the error occurs, only when gitlint runs on gitlab-ci(docker)
it never occurs, then gitlint runs on my local pc.

self.__class__.__name__: LocalGitCommit {'message': <gitlint.git.GitCommitMessage object at 0x7fb9dd7540d0>, 'author_name': 'huangkh', 'author_email': 'huang_kh@robotics-robotics.com', 'date': datetime.datetime(2021, 9, 1, 13, 12, 25, tzinfo=tzoffset(None, 28800)), 'parents': ['273b7ecde3a1151185b70244febc40a3f2049e15'], 'is_merge_commit': False} {'message': <gitlint.git.GitCommitMessage object at 0x7fb9dd7540d0>, 'author_name': 'huangkh', 'author_email': 'huang_kh@robotics-robotics.com', 'date': datetime.datetime(2021, 9, 1, 13, 12, 25, tzinfo=tzoffset(None, 28800)), 'parents': ['273b7ecde3a1151185b70244febc40a3f2049e15'], 'is_merge_commit': False, 'branches': ['(HEAD detached at 441231c)'], 'changed_files': ['src/rrdevices/three_color_lamp/__init__.py', 'src/rrdevices/three_color_lamp/base_color_lamp.py', 'src/rrdevices/three_color_lamp/ddr_color_lamp.py', 'src/rrdevices/three_color_lamp/kent_color_lamp.py', 'tests/test_color_lamp.py']} try cache: fFalse parents: commit_msg: Merge branch 'io_board' into 'master' feat: add io_board ui See merge request hkh/rrdevices!1 commit_parents: [''] commit_is_merge_commit: False commit_msg_obj: Merge branch 'io_board' into 'master' feat: add io_board ui See merge request hkh/rrdevices!1 
