### PR TITLE
Document when one would want to use --staged

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -387,8 +387,16 @@ contrib=contrib-title-conventional-commits,CC1
 
 ### staged
 
-Fetch additional meta-data from the local repository when manually passing a commit message to gitlint via stdin or `--commit-msg`.
-Useful if checking other properties of a commit besides just the message.
+Attempt smart guesses about meta info (like author name, email, branch, changed files, etc) when manually passing a
+commit message to gitlint via stdin or `--commit-msg`.
+
+Since in such cases no actual git commit exists (yet) for the message being linted, gitlint
+needs to apply some heuristics (like checking `git config` and any staged changes) to make a smart guess about what the
+likely author name, email, commit date, changed files and branch of the ensuing commit would be.
+
+When not using the `--staged` flag while linting a commit message via stdin or `--commit-msg`, gitlint will only have
+access to the commit message itself for linting and won't be able to enforce rules like
+[M1:author-valid-email](rules.md#m1-author-valid-email).
 
 | Default value | gitlint version | commandline flag | environment variable |
 | ------------- | --------------- | ---------------- | -------------------- |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -388,6 +388,7 @@ contrib=contrib-title-conventional-commits,CC1
 ### staged
 
 Fetch additional meta-data from the local repository when manually passing a commit message to gitlint via stdin or `--commit-msg`.
+Useful if checking other properties of a commit besides just the message.
 
 | Default value | gitlint version | commandline flag | environment variable |
 | ------------- | --------------- | ---------------- | -------------------- |

--- a/docs/index.md
+++ b/docs/index.md
@@ -163,9 +163,9 @@ Options:
   --msg-filename FILENAME  Path to a file containing a commit-msg.
   --ignore-stdin           Ignore any stdin data. Useful for running in CI
                            server.
-  --staged                 Read staged commit meta-info from the local
-                           repository. Useful if checking other properties of
-                           a commit besides just the message.
+  --staged                 Attempt smart guesses about meta info (like
+                           author name, email, branch, changed files, etc)
+                           for staged commits.
   --fail-without-commits   Hard fail when the target commit range is empty.
   -v, --verbose            Verbosity, more v's for more verbose output
                            (e.g.: -v, -vv, -vvv). [default: -vvv]

--- a/docs/index.md
+++ b/docs/index.md
@@ -164,7 +164,8 @@ Options:
   --ignore-stdin           Ignore any stdin data. Useful for running in CI
                            server.
   --staged                 Read staged commit meta-info from the local
-                           repository.
+                           repository. Useful if checking other properties of
+                           a commit besides just the message.
   --fail-without-commits   Hard fail when the target commit range is empty.
   -v, --verbose            Verbosity, more v's for more verbose output
                            (e.g.: -v, -vv, -vvv). [default: -vvv]

--- a/gitlint-core/gitlint/cli.py
+++ b/gitlint-core/gitlint/cli.py
@@ -272,8 +272,8 @@ class ContextObj:
 @click.option('--ignore-stdin', envvar='GITLINT_IGNORE_STDIN', is_flag=True,
               help="Ignore any stdin data. Useful for running in CI server.")
 @click.option('--staged', envvar='GITLINT_STAGED', is_flag=True,
-              help="Read staged commit meta-info from the local repository. " +
-                   "Useful if checking other properties of a commit besides just the message.")
+              help="Attempt smart guesses about meta info (like author name, email, branch, changed files, etc) " +
+                   "for staged commits.")
 @click.option('--fail-without-commits', envvar='GITLINT_FAIL_WITHOUT_COMMITS', is_flag=True,
               help="Hard fail when the target commit range is empty.")
 @click.option('-v', '--verbose', envvar='GITLINT_VERBOSITY', count=True, default=0,

--- a/gitlint-core/gitlint/cli.py
+++ b/gitlint-core/gitlint/cli.py
@@ -272,7 +272,8 @@ class ContextObj:
 @click.option('--ignore-stdin', envvar='GITLINT_IGNORE_STDIN', is_flag=True,
               help="Ignore any stdin data. Useful for running in CI server.")
 @click.option('--staged', envvar='GITLINT_STAGED', is_flag=True,
-              help="Read staged commit meta-info from the local repository.")
+              help="Read staged commit meta-info from the local repository. " +
+                   "Useful if checking other properties of a commit besides just the message.")
 @click.option('--fail-without-commits', envvar='GITLINT_FAIL_WITHOUT_COMMITS', is_flag=True,
               help="Hard fail when the target commit range is empty.")
 @click.option('-v', '--verbose', envvar='GITLINT_VERBOSITY', count=True, default=0,


### PR DESCRIPTION
I was wondering why I'd need to set `user.name` and `user.email` when running gitlint with pre-commit in CI, and realized it's because of `--staged` in the hook's default config. It wasn't immediately clear to me why I'd want `--staged` (turns out I don't), so I thought I'd document it.

Might be nice to also document that with `--staged` one needs those git configs set, but don't know if that's too much detail on this level.