### PR TITLE
Add changelog project URL to project metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
     project_urls={
         'Documentation': 'https://jorisroovers.github.io/gitlint',
         'Source': 'https://github.com/jorisroovers/gitlint',
+        'Changelog': 'https://github.com/jorisroovers/gitlint/blob/main/CHANGELOG.md',
     },
     license='MIT',
 )


### PR DESCRIPTION
For easy/"standard" access from the PyPI project page.

`Changelog` matches the title of the linked doc here, and is one of
the recognized names that get the distinctive icon:
https://github.com/pypa/warehouse/blob/64102a6a41f024e54bc0cfe52201d44bc80afd17/warehouse/templates/packaging/detail.html#L24

An example how it looks can be found e.g. in https://pypi.org/project/black/
