### PR TITLE
Unset EDITOR env var in test_run_hook_edit

### DIFF
--- a/gitlint-core/gitlint/tests/cli/test_cli_hooks.py
+++ b/gitlint-core/gitlint/tests/cli/test_cli_hooks.py
@@ -133,6 +133,7 @@ class CLIHookTests(BaseTestCase):
             if set_editors[i]:
                 os.environ['EDITOR'] = set_editors[i]
             else:
+                # When set_editors[i] == None, ensure we don't fallback to EDITOR set in shell invocating the tests
                 os.environ.pop('EDITOR', None)
 
             with self.patch_input(['e', 'e', 'n']):

--- a/gitlint-core/gitlint/tests/cli/test_cli_hooks.py
+++ b/gitlint-core/gitlint/tests/cli/test_cli_hooks.py
@@ -132,6 +132,8 @@ class CLIHookTests(BaseTestCase):
         for i in range(0, len(set_editors)):
             if set_editors[i]:
                 os.environ['EDITOR'] = set_editors[i]
+            else:
+                os.environ.pop('EDITOR', None)
 
             with self.patch_input(['e', 'e', 'n']):
                 with self.tempdir() as tmpdir:


### PR DESCRIPTION
Without this the test will fail if the `EDITOR` env var is set to
something different than `vim -n`.
