### PR TITLE
Also look for `.gitlint.ini` as the config file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,9 @@ You can also use a different config file like so:
 gitlint --config myconfigfile.ini 
 ```
 
+Without the `--config` flag, gitlint will look for `.gitlint` and `.gitlint.ini`
+in the current directory in that order.
+
 The block below shows a sample `.gitlint` file. Details about rule config options can be found on the
 [Rules](rules.md) page, details about the `[general]` section can be found in the
 [General Configuration](configuration.md#general-configuration) section of this page.


### PR DESCRIPTION
Renamed `DEFAULT_CONFIG_FILE` to `DEFAULT_CONFIG_FILES` and made it a list. Added `.gitlint.ini` as the second element. All previous references to `DEFAULT_CONFIG_FILE` are changed to `DEFAULT_CONFIG_FILES[0]` for backwards compatibility.

<!--- THIS IS A COMMENT BLOCK, REMOVE IT BEFORE SUBMITTING YOUR PR

Thank you for your interest in gitlint and putting in the effort to create a PR!

A few quick notes:

- It's really just me (https://github.com/jorisroovers) maintaining gitlint, and I do so in a hobby capacity. More recently it has become harder for me to find time to maintain gitlint on a regular basis, which in practice means that it might take me a while (sometimes months) to get back to you. Rest assured though, I absolutely look at all PRs as soon as they come in - I just tend to only "work" on gitlint a few times a year.
- Similarly, after your code is merged, it typically still takes months before I do another release that contains your code. Please don't let that deter you from contributing - I appreciate your patience and understanding!
- Please review: http://jorisroovers.github.io/gitlint/contributing/

-->

Enter your PR details here
I had to disable the `too-many-branches` pylint rule for the `build_config` function.