### PR TITLE
Support for fixup=amend:<sha> commands

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,10 +39,11 @@ ignore=title-trailing-punctuation, T3
 # precedence over this
 verbosity = 2
 
-# By default gitlint will ignore merge, revert, fixup and squash commits.
+# By default gitlint will ignore merge, revert, fixup, fixup=amend, and squash commits.
 ignore-merge-commits=true
 ignore-revert-commits=true
 ignore-fixup-commits=true
+ignore-fixup-amend-commits=true
 ignore-squash-commits=true
 
 # Ignore any data sent to gitlint via stdin
@@ -492,6 +493,25 @@ gitlint -c general.ignore-fixup-commits=false
 #.gitlint
 [general]
 ignore-fixup-commits=false
+```
+
+### ignore-fixup-amend-commits
+
+Whether or not to ignore [fixup=amend](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupamendrewordltcommitgt) commits.
+
+Default value  |  gitlint version | commandline flag  | environment variable  
+---------------|------------------|-------------------|-----------------------
+ true          | >= 0.18.0        | Not Available     | Not Available  
+
+#### Examples
+```sh
+# CLI
+gitlint -c general.ignore-fixup-amend-commits=false
+```
+```ini
+#.gitlint
+[general]
+ignore-fixup-amend-commits=false
 ```
 
 ### ignore-squash-commits

--- a/docs/index.md
+++ b/docs/index.md
@@ -292,9 +292,9 @@ done
 
 
 ## Merge, fixup, squash and revert commits
-_Introduced in gitlint v0.7.0 (merge), v0.9.0 (fixup, squash) and v0.13.0 (revert)_
+_Introduced in gitlint v0.7.0 (merge), v0.9.0 (fixup, squash), v0.13.0 (revert) and v0.18.0 (fixup=amend)_
 
-**Gitlint ignores merge, revert, fixup and squash commits by default.**
+**Gitlint ignores merge, revert, fixup, and squash commits by default.**
 
 For merge and revert commits, the rationale for ignoring them is
 that most users keep git's default messages for these commits (i.e *Merge/Revert "[original commit message]"*).
@@ -304,14 +304,14 @@ For example, a common case is that *"Merge:"* being auto-prepended triggers a
 [title-max-length](rules.md#t1-title-max-length) violation. Most users don't want this, so we disable linting
 on Merge and Revert commits by default.
 
-For [squash](https://git-scm.com/docs/git-commit#git-commit---squashltcommitgt) and [fixup](https://git-scm.com/docs/git-commit#git-commit---fixupltcommitgt) commits, the rationale is that these are temporary
+For [squash](https://git-scm.com/docs/git-commit#git-commit---squashltcommitgt) and [fixup](https://git-scm.com/docs/git-commit#git-commit---fixupltcommitgt) (including [fixup=amend](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupamendrewordltcommitgt)) commits, the rationale is that these are temporary
 commits that will be squashed into a different commit, and hence the commit messages for these commits are very
-short-lived and not intended to make it into the final commit history. In addition, by prepending *"fixup!"* or
-*"squash!"* to your commit message, certain gitlint rules might be violated
+short-lived and not intended to make it into the final commit history. In addition, by prepending *"fixup!"*,
+*"amend!"* or *"squash!"* to your commit message, certain gitlint rules might be violated
 (e.g. [title-max-length](rules.md#t1-title-max-length)) which is often undesirable.
 
 In case you *do* want to lint these commit messages, you can disable this behavior by setting the
-general `ignore-merge-commits`, `ignore-revert-commits`,  `ignore-fixup-commits` or
+general `ignore-merge-commits`, `ignore-revert-commits`,  `ignore-fixup-commits`, `ignore-fixup-amend-commits` or
 `ignore-squash-commits` option to `false`
 [using one of the various ways to configure gitlint](configuration.md).
 

--- a/docs/user_defined_rules.md
+++ b/docs/user_defined_rules.md
@@ -192,6 +192,7 @@ commit.date                    | datetime       | Python `datetime` object repre
 commit.is_merge_commit         | boolean        | Boolean indicating whether the commit is a merge commit or not.
 commit.is_revert_commit        | boolean        | Boolean indicating whether the commit is a revert commit or not.
 commit.is_fixup_commit         | boolean        | Boolean indicating whether the commit is a fixup commit or not.
+commit.is_fixup_amend_commit   | boolean        | Boolean indicating whether the commit is a (fixup) amend commit or not.
 commit.is_squash_commit        | boolean        | Boolean indicating whether the commit is a squash commit or not.
 commit.parents                 | string[]       | List of parent commit `sha`s (only for merge commits).
 commit.changed_files           | string[]       | List of files changed in the commit (relative paths).

--- a/gitlint-core/gitlint/config.py
+++ b/gitlint-core/gitlint/config.py
@@ -32,7 +32,7 @@ class LintConfigError(GitlintError):
     pass
 
 
-class LintConfig:
+class LintConfig:  # pylint: disable=too-many-instance-attributes
     """ Class representing gitlint configuration.
         Contains active config as well as number of methods to easily get/set the config.
     """
@@ -65,6 +65,8 @@ class LintConfig:
         self._verbosity = options.IntOption('verbosity', 3, "Verbosity")
         self._ignore_merge_commits = options.BoolOption('ignore-merge-commits', True, "Ignore merge commits")
         self._ignore_fixup_commits = options.BoolOption('ignore-fixup-commits', True, "Ignore fixup commits")
+        self._ignore_fixup_amend_commits = options.BoolOption('ignore-fixup-amend-commits', True,
+                                                              "Ignore fixup amend commits")
         self._ignore_squash_commits = options.BoolOption('ignore-squash-commits', True, "Ignore squash commits")
         self._ignore_revert_commits = options.BoolOption('ignore-revert-commits', True, "Ignore revert commits")
         self._debug = options.BoolOption('debug', False, "Enable debug mode")
@@ -117,6 +119,15 @@ class LintConfig:
     @handle_option_error
     def ignore_fixup_commits(self, value):
         return self._ignore_fixup_commits.set(value)
+
+    @property
+    def ignore_fixup_amend_commits(self):
+        return self._ignore_fixup_amend_commits.value
+
+    @ignore_fixup_amend_commits.setter
+    @handle_option_error
+    def ignore_fixup_amend_commits(self, value):
+        return self._ignore_fixup_amend_commits.set(value)
 
     @property
     def ignore_squash_commits(self):
@@ -283,6 +294,7 @@ class LintConfig:
             self.contrib == other.contrib and \
             self.ignore_merge_commits == other.ignore_merge_commits and \
             self.ignore_fixup_commits == other.ignore_fixup_commits and \
+            self.ignore_fixup_amend_commits == other.ignore_fixup_amend_commits and \
             self.ignore_squash_commits == other.ignore_squash_commits and \
             self.ignore_revert_commits == other.ignore_revert_commits and \
             self.ignore_stdin == other.ignore_stdin and \
@@ -301,6 +313,7 @@ class LintConfig:
                 f"ignore: {','.join(self.ignore)}\n"
                 f"ignore-merge-commits: {self.ignore_merge_commits}\n"
                 f"ignore-fixup-commits: {self.ignore_fixup_commits}\n"
+                f"ignore-fixup-amend-commits: {self.ignore_fixup_amend_commits}\n"
                 f"ignore-squash-commits: {self.ignore_squash_commits}\n"
                 f"ignore-revert-commits: {self.ignore_revert_commits}\n"
                 f"ignore-stdin: {self.ignore_stdin}\n"

--- a/gitlint-core/gitlint/files/gitlint
+++ b/gitlint-core/gitlint/files/gitlint
@@ -14,10 +14,11 @@
 # verbosity should be a value between 1 and 3, the commandline -v flags take precedence over this
 # verbosity = 2
 
-# By default gitlint will ignore merge, revert, fixup and squash commits. 
+# By default gitlint will ignore merge, revert, fixup, fixup=amend, and squash commits. 
 # ignore-merge-commits=true
 # ignore-revert-commits=true
 # ignore-fixup-commits=true
+# ignore-fixup-amend-commits=true
 # ignore-squash-commits=true
 
 # Ignore any data sent to gitlint via stdin

--- a/gitlint-core/gitlint/git.py
+++ b/gitlint-core/gitlint/git.py
@@ -171,6 +171,7 @@ class GitCommit:
                 f"Date:   {date_str}\n"
                 f"is-merge-commit:  {self.is_merge_commit}\n"
                 f"is-fixup-commit:  {self.is_fixup_commit}\n"
+                f"is-fixup-amend-commit: {self.is_fixup_amend_commit}\n"
                 f"is-squash-commit: {self.is_squash_commit}\n"
                 f"is-revert-commit: {self.is_revert_commit}\n"
                 f"Branches: {self.branches}\n"
@@ -184,6 +185,7 @@ class GitCommit:
                 and self.author_email == other.author_email
                 and self.date == other.date and self.parents == other.parents
                 and self.is_merge_commit == other.is_merge_commit and self.is_fixup_commit == other.is_fixup_commit
+                and self.is_fixup_amend_commit == other.is_fixup_amend_commit
                 and self.is_squash_commit == other.is_squash_commit and self.is_revert_commit == other.is_revert_commit
                 and self.changed_files == other.changed_files and self.branches == other.branches) # noqa
 

--- a/gitlint-core/gitlint/git.py
+++ b/gitlint-core/gitlint/git.py
@@ -156,6 +156,10 @@ class GitCommit:
         return self.message.title.startswith("squash!")
 
     @property
+    def is_fixup_amend_commit(self):
+        return self.message.title.startswith("amend!")
+
+    @property
     def is_revert_commit(self):
         return self.message.title.startswith("Revert")
 

--- a/gitlint-core/gitlint/lint.py
+++ b/gitlint-core/gitlint/lint.py
@@ -76,7 +76,7 @@ class GitLinter:
             rule.apply(self.config, commit)
 
         # Skip linting if this is a special commit type that is configured to be ignored
-        ignore_commit_types = ["merge", "squash", "fixup", "revert"]
+        ignore_commit_types = ["merge", "squash", "fixup", "fixup_amend", "revert"]
         for commit_type in ignore_commit_types:
             if getattr(commit, f"is_{commit_type}_commit") and \
                getattr(self.config, f"ignore_{commit_type}_commits"):

--- a/gitlint-core/gitlint/tests/config/test_config.py
+++ b/gitlint-core/gitlint/tests/config/test_config.py
@@ -45,6 +45,7 @@ class LintConfigTests(BaseTestCase):
         # Check that default general options are correct
         self.assertTrue(config.ignore_merge_commits)
         self.assertTrue(config.ignore_fixup_commits)
+        self.assertTrue(config.ignore_fixup_amend_commits)
         self.assertTrue(config.ignore_squash_commits)
         self.assertTrue(config.ignore_revert_commits)
 
@@ -75,6 +76,10 @@ class LintConfigTests(BaseTestCase):
         # ignore_fixup_commit
         config.set_general_option("ignore-fixup-commits", "false")
         self.assertFalse(config.ignore_fixup_commits)
+
+        # ignore_fixup_amend_commit
+        config.set_general_option("ignore-fixup-amend-commits", "false")
+        self.assertFalse(config.ignore_fixup_amend_commits)
 
         # ignore_squash_commit
         config.set_general_option("ignore-squash-commits", "false")
@@ -218,8 +223,8 @@ class LintConfigTests(BaseTestCase):
                 config.verbosity = value
 
         # invalid ignore_xxx_commits
-        ignore_attributes = ["ignore_merge_commits", "ignore_fixup_commits", "ignore_squash_commits",
-                             "ignore_revert_commits"]
+        ignore_attributes = ["ignore_merge_commits", "ignore_fixup_commits", "ignore_fixup_amend_commits",
+                             "ignore_squash_commits", "ignore_revert_commits"]
         incorrect_values = [-1, 4, "föo"]
         for attribute in ignore_attributes:
             for value in incorrect_values:
@@ -262,6 +267,7 @@ class LintConfigTests(BaseTestCase):
         attrs = [("verbosity", 1), ("rules", []), ("ignore_stdin", True), ("debug", True),
                  ("ignore", ["T1"]), ("staged", True), ("_config_path", self.get_sample_path()),
                  ("ignore_merge_commits", False), ("ignore_fixup_commits", False),
+                 ("ignore_fixup_amend_commits", False),
                  ("ignore_squash_commits", False), ("ignore_revert_commits", False),
                  ("extra_path", self.get_sample_path("user_rules")), ("target", self.get_sample_path()),
                  ("contrib", ["CC1"])]

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
@@ -79,6 +79,7 @@ Author: test åuthor1 <test-email1@föo.com>
 Date:   2016-12-03 15:28:15 +0100
 is-merge-commit:  False
 is-fixup-commit:  False
+is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
 Branches: ['commit-1-branch-1', 'commit-1-branch-2']
@@ -98,6 +99,7 @@ Author: test åuthor2 <test-email2@föo.com>
 Date:   2016-12-04 15:28:15 +0100
 is-merge-commit:  False
 is-fixup-commit:  False
+is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
 Branches: ['commit-2-branch-1', 'commit-2-branch-2']
@@ -116,6 +118,7 @@ Author: test åuthor3 <test-email3@föo.com>
 Date:   2016-12-05 15:28:15 +0100
 is-merge-commit:  False
 is-fixup-commit:  False
+is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
 Branches: ['commit-3-branch-1', 'commit-3-branch-2']

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
@@ -13,6 +13,7 @@ contrib: []
 ignore: title-trailing-whitespace,B2
 ignore-merge-commits: False
 ignore-fixup-commits: True
+ignore-fixup-amend-commits: True
 ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
@@ -13,6 +13,7 @@ contrib: []
 ignore: 
 ignore-merge-commits: True
 ignore-fixup-commits: True
+ignore-fixup-amend-commits: True
 ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
@@ -75,6 +75,7 @@ Author: None <None>
 Date:   None
 is-merge-commit:  False
 is-fixup-commit:  False
+is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
 Branches: []

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
@@ -13,6 +13,7 @@ contrib: []
 ignore: 
 ignore-merge-commits: True
 ignore-fixup-commits: True
+ignore-fixup-amend-commits: True
 ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
@@ -78,6 +78,7 @@ Author: föo user <föo@bar.com>
 Date:   2020-02-19 12:18:46 +0100
 is-merge-commit:  False
 is-fixup-commit:  False
+is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
 Branches: ['my-branch']

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
@@ -13,6 +13,7 @@ contrib: []
 ignore: 
 ignore-merge-commits: True
 ignore-fixup-commits: True
+ignore-fixup-amend-commits: True
 ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
@@ -80,6 +80,7 @@ Author: föo user <föo@bar.com>
 Date:   2020-02-19 12:18:46 +0100
 is-merge-commit:  False
 is-fixup-commit:  False
+is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
 Branches: ['my-branch']

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
@@ -78,6 +78,7 @@ Author: None <None>
 Date:   None
 is-merge-commit:  False
 is-fixup-commit:  False
+is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
 Branches: []

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
@@ -13,6 +13,7 @@ contrib: []
 ignore: 
 ignore-merge-commits: True
 ignore-fixup-commits: True
+ignore-fixup-amend-commits: True
 ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False

--- a/gitlint-core/gitlint/tests/git/test_git_commit.py
+++ b/gitlint-core/gitlint/tests/git/test_git_commit.py
@@ -61,6 +61,7 @@ class GitCommitTests(BaseTestCase):
         self.assertFalse(last_commit.is_merge_commit)
         self.assertFalse(last_commit.is_fixup_commit)
         self.assertFalse(last_commit.is_squash_commit)
+        self.assertFalse(last_commit.is_fixup_amend_commit)
         self.assertFalse(last_commit.is_revert_commit)
 
         # First 2 'git log' calls should've happened at this point
@@ -115,6 +116,7 @@ class GitCommitTests(BaseTestCase):
         self.assertFalse(last_commit.is_merge_commit)
         self.assertFalse(last_commit.is_fixup_commit)
         self.assertFalse(last_commit.is_squash_commit)
+        self.assertFalse(last_commit.is_fixup_amend_commit)
         self.assertFalse(last_commit.is_revert_commit)
 
         # First 2 'git log' calls should've happened at this point
@@ -168,6 +170,7 @@ class GitCommitTests(BaseTestCase):
         self.assertFalse(last_commit.is_merge_commit)
         self.assertFalse(last_commit.is_fixup_commit)
         self.assertFalse(last_commit.is_squash_commit)
+        self.assertFalse(last_commit.is_fixup_amend_commit)
         self.assertFalse(last_commit.is_revert_commit)
 
         # First 2 'git log' calls should've happened at this point
@@ -221,6 +224,7 @@ class GitCommitTests(BaseTestCase):
         self.assertTrue(last_commit.is_merge_commit)
         self.assertFalse(last_commit.is_fixup_commit)
         self.assertFalse(last_commit.is_squash_commit)
+        self.assertFalse(last_commit.is_fixup_amend_commit)
         self.assertFalse(last_commit.is_revert_commit)
 
         # First 2 'git log' calls should've happened at this point
@@ -336,6 +340,7 @@ class GitCommitTests(BaseTestCase):
         self.assertFalse(commit.is_merge_commit)
         self.assertFalse(commit.is_fixup_commit)
         self.assertFalse(commit.is_squash_commit)
+        self.assertFalse(commit.is_fixup_amend_commit)
         self.assertFalse(commit.is_revert_commit)
         self.assertEqual(len(gitcontext.commits), 1)
 
@@ -356,6 +361,7 @@ class GitCommitTests(BaseTestCase):
         self.assertFalse(commit.is_merge_commit)
         self.assertFalse(commit.is_fixup_commit)
         self.assertFalse(commit.is_squash_commit)
+        self.assertFalse(commit.is_fixup_amend_commit)
         self.assertFalse(commit.is_revert_commit)
         self.assertEqual(len(gitcontext.commits), 1)
 
@@ -377,6 +383,7 @@ class GitCommitTests(BaseTestCase):
         self.assertFalse(commit.is_merge_commit)
         self.assertFalse(commit.is_fixup_commit)
         self.assertFalse(commit.is_squash_commit)
+        self.assertFalse(commit.is_fixup_amend_commit)
         self.assertFalse(commit.is_revert_commit)
         self.assertEqual(len(gitcontext.commits), 1)
 
@@ -400,6 +407,7 @@ class GitCommitTests(BaseTestCase):
         self.assertFalse(commit.is_merge_commit)
         self.assertFalse(commit.is_fixup_commit)
         self.assertFalse(commit.is_squash_commit)
+        self.assertFalse(commit.is_fixup_amend_commit)
         self.assertFalse(commit.is_revert_commit)
         self.assertEqual(len(gitcontext.commits), 1)
 
@@ -422,6 +430,7 @@ class GitCommitTests(BaseTestCase):
         self.assertTrue(commit.is_merge_commit)
         self.assertFalse(commit.is_fixup_commit)
         self.assertFalse(commit.is_squash_commit)
+        self.assertFalse(commit.is_fixup_amend_commit)
         self.assertFalse(commit.is_revert_commit)
         self.assertEqual(len(gitcontext.commits), 1)
 
@@ -444,12 +453,15 @@ class GitCommitTests(BaseTestCase):
         self.assertFalse(commit.is_merge_commit)
         self.assertFalse(commit.is_fixup_commit)
         self.assertFalse(commit.is_squash_commit)
+        self.assertFalse(commit.is_fixup_amend_commit)
         self.assertTrue(commit.is_revert_commit)
         self.assertEqual(len(gitcontext.commits), 1)
 
-    def test_from_commit_msg_fixup_squash_commit(self):
-        commit_types = ["fixup", "squash"]
-        for commit_type in commit_types:
+    def test_from_commit_msg_fixup_squash_amend_commit(self):
+        # mapping between cleanup commit prefixes and the commit object attribute
+        commit_prefixes = {"fixup": "is_fixup_commit", "squash": "is_squash_commit", "amend": "is_fixup_amend_commit"}
+
+        for commit_type in commit_prefixes.keys():
             commit_msg = f"{commit_type}! Test message"
             gitcontext = GitContext.from_commit_msg(commit_msg)
             commit = gitcontext.commits[-1]
@@ -469,9 +481,8 @@ class GitCommitTests(BaseTestCase):
             self.assertFalse(commit.is_merge_commit)
             self.assertFalse(commit.is_revert_commit)
             # Asserting that squash and fixup are correct
-            for type in commit_types:
-                attr = "is_" + type + "_commit"
-                self.assertEqual(getattr(commit, attr), commit_type == type)
+            for type, commit_attr_name in commit_prefixes.items():
+                self.assertEqual(getattr(commit, commit_attr_name), commit_type == type)
 
     @patch('gitlint.git.sh')
     @patch('arrow.now')
@@ -521,6 +532,7 @@ class GitCommitTests(BaseTestCase):
         self.assertFalse(last_commit.is_merge_commit)
         self.assertTrue(last_commit.is_fixup_commit)
         self.assertFalse(last_commit.is_squash_commit)
+        self.assertFalse(last_commit.is_fixup_amend_commit)
         self.assertFalse(last_commit.is_revert_commit)
 
         self.assertListEqual(last_commit.branches, ["my-brånch"])

--- a/gitlint-core/gitlint/tests/git/test_git_commit.py
+++ b/gitlint-core/gitlint/tests/git/test_git_commit.py
@@ -60,8 +60,8 @@ class GitCommitTests(BaseTestCase):
         self.assertListEqual(last_commit.parents, ["åbc"])
         self.assertFalse(last_commit.is_merge_commit)
         self.assertFalse(last_commit.is_fixup_commit)
-        self.assertFalse(last_commit.is_squash_commit)
         self.assertFalse(last_commit.is_fixup_amend_commit)
+        self.assertFalse(last_commit.is_squash_commit)
         self.assertFalse(last_commit.is_revert_commit)
 
         # First 2 'git log' calls should've happened at this point
@@ -115,8 +115,8 @@ class GitCommitTests(BaseTestCase):
         self.assertListEqual(last_commit.parents, ["åbc"])
         self.assertFalse(last_commit.is_merge_commit)
         self.assertFalse(last_commit.is_fixup_commit)
-        self.assertFalse(last_commit.is_squash_commit)
         self.assertFalse(last_commit.is_fixup_amend_commit)
+        self.assertFalse(last_commit.is_squash_commit)
         self.assertFalse(last_commit.is_revert_commit)
 
         # First 2 'git log' calls should've happened at this point
@@ -169,8 +169,8 @@ class GitCommitTests(BaseTestCase):
         self.assertListEqual(last_commit.parents, ["åbc"])
         self.assertFalse(last_commit.is_merge_commit)
         self.assertFalse(last_commit.is_fixup_commit)
-        self.assertFalse(last_commit.is_squash_commit)
         self.assertFalse(last_commit.is_fixup_amend_commit)
+        self.assertFalse(last_commit.is_squash_commit)
         self.assertFalse(last_commit.is_revert_commit)
 
         # First 2 'git log' calls should've happened at this point
@@ -223,8 +223,8 @@ class GitCommitTests(BaseTestCase):
         self.assertListEqual(last_commit.parents, ["åbc", "def"])
         self.assertTrue(last_commit.is_merge_commit)
         self.assertFalse(last_commit.is_fixup_commit)
-        self.assertFalse(last_commit.is_squash_commit)
         self.assertFalse(last_commit.is_fixup_amend_commit)
+        self.assertFalse(last_commit.is_squash_commit)
         self.assertFalse(last_commit.is_revert_commit)
 
         # First 2 'git log' calls should've happened at this point
@@ -240,8 +240,8 @@ class GitCommitTests(BaseTestCase):
 
     @patch('gitlint.git.sh')
     def test_get_latest_commit_fixup_squash_commit(self, sh):
-        commit_types = ["fixup", "squash"]
-        for commit_type in commit_types:
+        commit_prefixes = {"fixup": "is_fixup_commit", "squash": "is_squash_commit", "amend": "is_fixup_amend_commit"}
+        for commit_type in commit_prefixes.keys():
             sample_sha = "d8ac47e9f2923c7f22d8668e3a1ed04eb4cdbca9"
 
             sh.git.side_effect = [
@@ -282,8 +282,7 @@ class GitCommitTests(BaseTestCase):
             self.assertEqual(sh.git.mock_calls, expected_calls[:3])
 
             # Asserting that squash and fixup are correct
-            for type in commit_types:
-                attr = "is_" + type + "_commit"
+            for type, attr in commit_prefixes.items():
                 self.assertEqual(getattr(last_commit, attr), commit_type == type)
 
             self.assertFalse(last_commit.is_merge_commit)
@@ -339,8 +338,8 @@ class GitCommitTests(BaseTestCase):
         self.assertListEqual(commit.branches, [])
         self.assertFalse(commit.is_merge_commit)
         self.assertFalse(commit.is_fixup_commit)
-        self.assertFalse(commit.is_squash_commit)
         self.assertFalse(commit.is_fixup_amend_commit)
+        self.assertFalse(commit.is_squash_commit)
         self.assertFalse(commit.is_revert_commit)
         self.assertEqual(len(gitcontext.commits), 1)
 
@@ -360,8 +359,8 @@ class GitCommitTests(BaseTestCase):
         self.assertListEqual(commit.branches, [])
         self.assertFalse(commit.is_merge_commit)
         self.assertFalse(commit.is_fixup_commit)
-        self.assertFalse(commit.is_squash_commit)
         self.assertFalse(commit.is_fixup_amend_commit)
+        self.assertFalse(commit.is_squash_commit)
         self.assertFalse(commit.is_revert_commit)
         self.assertEqual(len(gitcontext.commits), 1)
 
@@ -382,8 +381,8 @@ class GitCommitTests(BaseTestCase):
         self.assertListEqual(commit.branches, [])
         self.assertFalse(commit.is_merge_commit)
         self.assertFalse(commit.is_fixup_commit)
-        self.assertFalse(commit.is_squash_commit)
         self.assertFalse(commit.is_fixup_amend_commit)
+        self.assertFalse(commit.is_squash_commit)
         self.assertFalse(commit.is_revert_commit)
         self.assertEqual(len(gitcontext.commits), 1)
 
@@ -429,8 +428,8 @@ class GitCommitTests(BaseTestCase):
         self.assertListEqual(commit.branches, [])
         self.assertTrue(commit.is_merge_commit)
         self.assertFalse(commit.is_fixup_commit)
-        self.assertFalse(commit.is_squash_commit)
         self.assertFalse(commit.is_fixup_amend_commit)
+        self.assertFalse(commit.is_squash_commit)
         self.assertFalse(commit.is_revert_commit)
         self.assertEqual(len(gitcontext.commits), 1)
 
@@ -452,8 +451,8 @@ class GitCommitTests(BaseTestCase):
         self.assertListEqual(commit.branches, [])
         self.assertFalse(commit.is_merge_commit)
         self.assertFalse(commit.is_fixup_commit)
-        self.assertFalse(commit.is_squash_commit)
         self.assertFalse(commit.is_fixup_amend_commit)
+        self.assertFalse(commit.is_squash_commit)
         self.assertTrue(commit.is_revert_commit)
         self.assertEqual(len(gitcontext.commits), 1)
 
@@ -531,8 +530,8 @@ class GitCommitTests(BaseTestCase):
         self.assertListEqual(last_commit.parents, [])
         self.assertFalse(last_commit.is_merge_commit)
         self.assertTrue(last_commit.is_fixup_commit)
-        self.assertFalse(last_commit.is_squash_commit)
         self.assertFalse(last_commit.is_fixup_amend_commit)
+        self.assertFalse(last_commit.is_squash_commit)
         self.assertFalse(last_commit.is_revert_commit)
 
         self.assertListEqual(last_commit.branches, ["my-brånch"])

--- a/gitlint-core/gitlint/tests/samples/commit_message/fixup_amend
+++ b/gitlint-core/gitlint/tests/samples/commit_message/fixup_amend
@@ -1,0 +1,1 @@
+amend! WIP: This is a fixup cömmit with violations.

--- a/gitlint-core/gitlint/tests/test_lint.py
+++ b/gitlint-core/gitlint/tests/test_lint.py
@@ -160,7 +160,7 @@ class LintTests(BaseTestCase):
         self.assertListEqual(violations, expected_errors)
 
     def test_lint_special_commit(self):
-        for commit_type in ["merge", "revert", "squash", "fixup"]:
+        for commit_type in ["merge", "revert", "squash", "fixup", "fixup_amend"]:
             commit = self.gitcommit(self.get_sample(f"commit_message/{commit_type}"))
             lintconfig = LintConfig()
             linter = GitLinter(lintconfig)

--- a/qa/expected/test_commits/test_lint_staged_msg_filename_1
+++ b/qa/expected/test_commits/test_lint_staged_msg_filename_1
@@ -79,6 +79,7 @@ Author: gitlint-test-user <gitlint@test.com>
 Date:   {staged_date}
 is-merge-commit:  False
 is-fixup-commit:  False
+is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
 Branches: ['master']

--- a/qa/expected/test_commits/test_lint_staged_msg_filename_1
+++ b/qa/expected/test_commits/test_lint_staged_msg_filename_1
@@ -14,6 +14,7 @@ contrib: []
 ignore: 
 ignore-merge-commits: True
 ignore-fixup-commits: True
+ignore-fixup-amend-commits: True
 ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False

--- a/qa/expected/test_commits/test_lint_staged_stdin_1
+++ b/qa/expected/test_commits/test_lint_staged_stdin_1
@@ -14,6 +14,7 @@ contrib: []
 ignore: 
 ignore-merge-commits: True
 ignore-fixup-commits: True
+ignore-fixup-amend-commits: True
 ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False

--- a/qa/expected/test_commits/test_lint_staged_stdin_1
+++ b/qa/expected/test_commits/test_lint_staged_stdin_1
@@ -81,6 +81,7 @@ Author: gitlint-test-user <gitlint@test.com>
 Date:   {staged_date}
 is-merge-commit:  False
 is-fixup-commit:  False
+is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
 Branches: ['master']

--- a/qa/expected/test_config/test_config_from_env_1
+++ b/qa/expected/test_config/test_config_from_env_1
@@ -84,6 +84,7 @@ Author: gitlint-test-user <gitlint@test.com>
 Date:   {commit_date}
 is-merge-commit:  False
 is-fixup-commit:  False
+is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
 Branches: ['master']

--- a/qa/expected/test_config/test_config_from_env_1
+++ b/qa/expected/test_config/test_config_from_env_1
@@ -14,6 +14,7 @@ contrib: ['CC1', 'CT1']
 ignore: T1,T2
 ignore-merge-commits: True
 ignore-fixup-commits: True
+ignore-fixup-amend-commits: True
 ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: True

--- a/qa/expected/test_config/test_config_from_env_2
+++ b/qa/expected/test_config/test_config_from_env_2
@@ -79,6 +79,7 @@ Author: gitlint-test-user <gitlint@test.com>
 Date:   {date}
 is-merge-commit:  False
 is-fixup-commit:  False
+is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
 Branches: ['master']

--- a/qa/expected/test_config/test_config_from_env_2
+++ b/qa/expected/test_config/test_config_from_env_2
@@ -14,6 +14,7 @@ contrib: []
 ignore: 
 ignore-merge-commits: True
 ignore-fixup-commits: True
+ignore-fixup-amend-commits: True
 ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False

--- a/qa/expected/test_config/test_config_from_file_debug_1
+++ b/qa/expected/test_config/test_config_from_file_debug_1
@@ -81,6 +81,7 @@ Author: gitlint-test-user <gitlint@test.com>
 Date:   {commit_date}
 is-merge-commit:  False
 is-fixup-commit:  False
+is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
 Branches: ['master']

--- a/qa/expected/test_config/test_config_from_file_debug_1
+++ b/qa/expected/test_config/test_config_from_file_debug_1
@@ -14,6 +14,7 @@ contrib: []
 ignore: title-trailing-punctuation,B2
 ignore-merge-commits: True
 ignore-fixup-commits: True
+ignore-fixup-amend-commits: True
 ignore-squash-commits: True
 ignore-revert-commits: True
 ignore-stdin: False


### PR DESCRIPTION
This includes:
- a new config option `general.ignore_fixup_amend_commit`
- fixup=amend detection as part of commit.is_fixup_amend_commit
- skipping fixup=amend commits during linting
- Updated docs and tests

This fixes #318 