### PR TITLE
Add check to block GitHub author information

### DIFF
--- a/gitlint-core/gitlint/contrib/rules/block-github-author.py
+++ b/gitlint-core/gitlint/contrib/rules/block-github-author.py
@@ -1,0 +1,32 @@
+import re
+
+from gitlint.options import ListOption
+from gitlint.rules import CommitMessageTitle, LineRule, RuleViolation
+
+RULE_REGEX = re.compile(r"(.*)users\.noreply\.github\.com(.*)")
+
+
+class BlockGithubAuthor(CommitRule):
+    """ This rule enforces that no github author information (email address) is
+    used for committing
+    """
+
+    name = "contrib-block-github-author"
+    id = "BG1"
+
+    def validate(self, line, commit):
+        if commit.is_merge_commit:
+            # We do not care about merge-commits here
+            return []
+
+        if commit.author_email is None:
+            return [RuleViolation(self.id, f"No author information in commit", line)]
+        else:
+            match = RULE_REGEX.match(commit.author_email)
+
+            if not match:
+                # All good
+                return []
+
+            return [RuleViolation(self.id, f"GitHub email address found in commit author information", line)]
+


### PR DESCRIPTION
This adds a new rule for blocking github generated commits from a PR.

Usecases:

* Block commits that were generated from "Suggestions" but not rebase-squashed
* Block github web-ui commits / commits without a user email address.

The latter point might be relevant for projects because of legal issues - if a PR author does not provide contact information, changes from them might be not acceptable for certain projects.

---

The commit(s) from this PR were made before or during my initial efforts in #312, so obviously this is all not up to date regarding details like rule ID and so on.
That's why I'm filing this as a draft for now, so that you can first review the general idea and if you reject this entire idea, I do not waste effort :smile: 
