### PR TITLE
Black formatting

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -58,8 +58,8 @@ jobs:
           GITLINT_USE_SH_LIB: 0
         run: ./run_tests.sh -i
 
-      - name: PEP8
-        run: ./run_tests.sh -p
+      - name: Code formatting (black)
+        run: ./run_tests.sh -f
 
       - name: PyLint
         run: ./run_tests.sh -l
@@ -136,8 +136,8 @@ jobs:
         run: pytest -rw -s qa
         continue-on-error: true # Known to fail at this point
 
-      - name: PEP8
-        run: flake8 gitlint-core qa examples
+      - name: Code formatting (black)
+        run: black .
 
       - name: PyLint
         run: pylint gitlint-core\gitlint qa --rcfile=".pylintrc" -r n

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -59,11 +59,11 @@ To run tests:
 ./run_tests.sh --collect-only --no-coverage  # Only collect, don't run unit tests
 ./run_tests.sh --integration         # Run integration tests (requires that you have gitlint installed)
 ./run_tests.sh --build               # Run build tests (=build python package)
-./run_tests.sh --pep8                # pep8 checks
+./run_tests.sh --format              # format checks
 ./run_tests.sh --stats               # print some code stats
 ./run_tests.sh --git                 # inception: run gitlint against itself
 ./run_tests.sh --lint                # run pylint checks
-./run_tests.sh --all                 # Run unit, integration, pep8 and gitlint checks
+./run_tests.sh --all                 # Run unit, integration, format and gitlint checks
 ```
 
 The `Vagrantfile` comes with `virtualenv`s for python 3.6, 3.7, 3.8, 3.9 and pypy3.6.
@@ -71,7 +71,7 @@ You can easily run tests against specific python environments by using the follo
 ```sh
 ./run_tests.sh --envs 36               # Run the unit tests against Python 3.6
 ./run_tests.sh --envs 36,37,pypy36     # Run the unit tests against Python 3.6, Python 3.7 and Pypy3.6
-./run_tests.sh --envs 36,37 --pep8     # Run pep8 checks against Python 3.6 and Python 3.7 (also works for --git, --integration, --pep8, --stats and --lint.
+./run_tests.sh --envs 36,37 --format   # Run format checks against Python 3.6 and Python 3.7 (also works for --git, --integration, --format, --stats and --lint.
 ./run_tests.sh --envs all --all        # Run all tests against all environments
 ./run_tests.sh --all-env --all         # Idem: Run all tests against all environments
 ```

--- a/examples/my_commit_rules.py
+++ b/examples/my_commit_rules.py
@@ -27,20 +27,20 @@ class BodyMaxLineCount(CommitRule):
     id = "UC1"
 
     # A rule MAY have an option_spec if its behavior should be configurable.
-    options_spec = [IntOption('max-line-count', 3, "Maximum body line count")]
+    options_spec = [IntOption("max-line-count", 3, "Maximum body line count")]
 
     def validate(self, commit):
         self.log.debug("BodyMaxLineCount: This will be visible when running `gitlint --debug`")
 
         line_count = len(commit.message.body)
-        max_line_count = self.options['max-line-count'].value
+        max_line_count = self.options["max-line-count"].value
         if line_count > max_line_count:
             message = f"Body contains too many lines ({line_count} > {max_line_count})"
             return [RuleViolation(self.id, message, line_nr=1)]
 
 
 class SignedOffBy(CommitRule):
-    """ This rule will enforce that each commit contains a "Signed-off-by" line.
+    """This rule will enforce that each commit contains a "Signed-off-by" line.
     We keep things simple here and just check whether the commit body contains a line that starts with "Signed-off-by".
     """
 
@@ -61,8 +61,8 @@ class SignedOffBy(CommitRule):
 
 
 class BranchNamingConventions(CommitRule):
-    """ This rule will enforce that a commit is part of a branch that meets certain naming conventions.
-        See GitFlow for real-world example of this: https://nvie.com/posts/a-successful-git-branching-model/
+    """This rule will enforce that a commit is part of a branch that meets certain naming conventions.
+    See GitFlow for real-world example of this: https://nvie.com/posts/a-successful-git-branching-model/
     """
 
     # A rule MUST have a human friendly name
@@ -72,13 +72,13 @@ class BranchNamingConventions(CommitRule):
     id = "UC3"
 
     # A rule MAY have an option_spec if its behavior should be configurable.
-    options_spec = [ListOption('branch-prefixes', ["feature/", "hotfix/", "release/"], "Allowed branch prefixes")]
+    options_spec = [ListOption("branch-prefixes", ["feature/", "hotfix/", "release/"], "Allowed branch prefixes")]
 
     def validate(self, commit):
         self.log.debug("BranchNamingConventions: This line will be visible when running `gitlint --debug`")
 
         violations = []
-        allowed_branch_prefixes = self.options['branch-prefixes'].value
+        allowed_branch_prefixes = self.options["branch-prefixes"].value
         for branch in commit.branches:
             valid_branch_name = False
 

--- a/examples/my_configuration_rules.py
+++ b/examples/my_configuration_rules.py
@@ -36,7 +36,7 @@ class ReleaseConfigurationRule(ConfigurationRule):
     id = "UCR1"
 
     # A rule MAY have an option_spec if its behavior should be configurable.
-    options_spec = [IntOption('custom-verbosity', 2, "Gitlint verbosity for release commits")]
+    options_spec = [IntOption("custom-verbosity", 2, "Gitlint verbosity for release commits")]
 
     def apply(self, config, commit):
         self.log.debug("ReleaseConfigurationRule: This will be visible when running `gitlint --debug`")
@@ -60,7 +60,7 @@ class ReleaseConfigurationRule(ConfigurationRule):
             # config.set_general_option(<general-option>, <value>)
             config.set_general_option("verbosity", 2)
             # Wwe can also use custom options to make this configurable
-            config.set_general_option("verbosity", self.options['custom-verbosity'].value)
+            config.set_general_option("verbosity", self.options["custom-verbosity"].value)
 
             # Strip any lines starting with $ from the commit message
             # (this only affects how gitlint sees your commit message, it does

--- a/examples/my_configuration_rules.py
+++ b/examples/my_configuration_rules.py
@@ -44,7 +44,6 @@ class ReleaseConfigurationRule(ConfigurationRule):
         # If the commit title starts with 'Release', we want to modify
         # how all subsequent rules interpret that commit
         if commit.message.title.startswith("Release"):
-
             # If your Release commit messages are auto-generated, the
             # body might contain trailing whitespace. Let's ignore that
             config.ignore.append("body-trailing-whitespace")

--- a/examples/my_line_rules.py
+++ b/examples/my_line_rules.py
@@ -21,8 +21,8 @@ that fits your needs.
 
 
 class SpecialChars(LineRule):
-    """ This rule will enforce that the commit message title does not contain any of the following characters:
-        $^%@!*() """
+    """This rule will enforce that the commit message title does not contain any of the following characters:
+    $^%@!*()"""
 
     # A rule MUST have a human friendly name
     name = "title-no-special-chars"
@@ -35,15 +35,20 @@ class SpecialChars(LineRule):
     target = CommitMessageTitle
 
     # A rule MAY have an option_spec if its behavior should be configurable.
-    options_spec = [ListOption('special-chars', ['$', '^', '%', '@', '!', '*', '(', ')'],
-                               "Comma separated list of characters that should not occur in the title")]
+    options_spec = [
+        ListOption(
+            "special-chars",
+            ["$", "^", "%", "@", "!", "*", "(", ")"],
+            "Comma separated list of characters that should not occur in the title",
+        )
+    ]
 
     def validate(self, line, _commit):
         self.log.debug("SpecialChars: This will be visible when running `gitlint --debug`")
 
         violations = []
         # options can be accessed by looking them up by their name in self.options
-        for char in self.options['special-chars'].value:
+        for char in self.options["special-chars"].value:
             if char in line:
                 msg = f"Title contains the special character '{char}'"
                 violation = RuleViolation(self.id, msg, line)

--- a/gitlint-core/gitlint/cache.py
+++ b/gitlint-core/gitlint/cache.py
@@ -1,31 +1,31 @@
 class PropertyCache:
-    """ Mixin class providing a simple cache. """
+    """Mixin class providing a simple cache."""
 
     def __init__(self):
         self._cache = {}
 
     def _try_cache(self, cache_key, cache_populate_func):
-        """ Tries to get a value from the cache identified by `cache_key`.
-            If no value is found in the cache, do a function call to `cache_populate_func` to populate the cache
-            and then return the value from the cache. """
+        """Tries to get a value from the cache identified by `cache_key`.
+        If no value is found in the cache, do a function call to `cache_populate_func` to populate the cache
+        and then return the value from the cache."""
         if cache_key not in self._cache:
             cache_populate_func()
         return self._cache[cache_key]
 
 
 def cache(original_func=None, cachekey=None):  # pylint: disable=unused-argument
-    """ Cache decorator. Caches function return values.
-        Requires the parent class to extend and initialize PropertyCache.
-        Usage:
-            # Use function name as cache key
-            @cache
-            def myfunc(args):
-                ...
+    """Cache decorator. Caches function return values.
+    Requires the parent class to extend and initialize PropertyCache.
+    Usage:
+        # Use function name as cache key
+        @cache
+        def myfunc(args):
+            ...
 
-            # Specify cache key
-            @cache(cachekey="foobar")
-            def myfunc(args):
-                ...
+        # Specify cache key
+        @cache(cachekey="foobar")
+        def myfunc(args):
+            ...
     """
 
     # Decorators with optional arguments are a bit convoluted in python, see some of the links below for details.
@@ -41,6 +41,7 @@ def cache(original_func=None, cachekey=None):  # pylint: disable=unused-argument
             def cache_func_result():
                 # Call decorated function and store its result in the cache
                 args[0]._cache[cachekey] = func(*args)
+
             return args[0]._try_cache(cachekey, cache_func_result)
 
         return wrapped

--- a/gitlint-core/gitlint/cli.py
+++ b/gitlint-core/gitlint/cli.py
@@ -232,109 +232,51 @@ class ContextObj:
         self.gitcontext = gitcontext
 
 
-@click.group(
-    invoke_without_command=True,
-    context_settings={"max_content_width": 120},
-    epilog="When no COMMAND is specified, gitlint defaults to 'gitlint lint'.",
-)
-@click.option(
-    "--target",
-    envvar="GITLINT_TARGET",
-    type=click.Path(exists=True, resolve_path=True, file_okay=False, readable=True),
-    help="Path of the target git repository. [default: current working directory]",
-)
-@click.option(
-    "-C",
-    "--config",
-    envvar="GITLINT_CONFIG",
-    type=click.Path(exists=True, dir_okay=False, readable=True, resolve_path=True),
-    help=f"Config file location [default: {DEFAULT_CONFIG_FILE}]",
-)
-@click.option(
-    "-c",
-    multiple=True,
-    help="Config flags in format <rule>.<option>=<value> (e.g.: -c T1.line-length=80). "
-    "Flag can be used multiple times to set multiple config values.",
-)  # pylint: disable=bad-continuation
-@click.option("--commit", envvar="GITLINT_COMMIT", default=None, help="Hash (SHA) of specific commit to lint.")
-@click.option(
-    "--commits",
-    envvar="GITLINT_COMMITS",
-    default=None,
-    help="The range of commits (refspec or comma-separated hashes) to lint. [default: HEAD]",
-)
-@click.option(
-    "-e",
-    "--extra-path",
-    envvar="GITLINT_EXTRA_PATH",
-    help="Path to a directory or python module with extra user-defined rules",
-    type=click.Path(exists=True, resolve_path=True, readable=True),
-)
-@click.option("--ignore", envvar="GITLINT_IGNORE", default="", help="Ignore rules (comma-separated by id or name).")
-@click.option(
-    "--contrib", envvar="GITLINT_CONTRIB", default="", help="Contrib rules to enable (comma-separated by id or name)."
-)
-@click.option(
-    "--msg-filename",
-    type=click.File(encoding=gitlint.utils.DEFAULT_ENCODING),
-    help="Path to a file containing a commit-msg.",
-)
-@click.option(
-    "--ignore-stdin",
-    envvar="GITLINT_IGNORE_STDIN",
-    is_flag=True,
-    help="Ignore any stdin data. Useful for running in CI server.",
-)
-@click.option(
-    "--staged", envvar="GITLINT_STAGED", is_flag=True, help="Read staged commit meta-info from the local repository."
-)
-@click.option(
-    "--fail-without-commits",
-    envvar="GITLINT_FAIL_WITHOUT_COMMITS",
-    is_flag=True,
-    help="Hard fail when the target commit range is empty.",
-)
-@click.option(
-    "-v",
-    "--verbose",
-    envvar="GITLINT_VERBOSITY",
-    count=True,
-    default=0,
-    help="Verbosity, more v's for more verbose output (e.g.: -v, -vv, -vvv). [default: -vvv]",
-)
-@click.option(
-    "-s",
-    "--silent",
-    envvar="GITLINT_SILENT",
-    is_flag=True,
-    help="Silent mode (no output). Takes precedence over -v, -vv, -vvv.",
-)
-@click.option("-d", "--debug", envvar="GITLINT_DEBUG", help="Enable debugging output.", is_flag=True)
+# fmt: off
+@click.group(invoke_without_command=True, context_settings={'max_content_width': 120},
+             epilog="When no COMMAND is specified, gitlint defaults to 'gitlint lint'.")
+@click.option('--target', envvar='GITLINT_TARGET',
+              type=click.Path(exists=True, resolve_path=True, file_okay=False, readable=True),
+              help="Path of the target git repository. [default: current working directory]")
+@click.option('-C', '--config', envvar='GITLINT_CONFIG',
+              type=click.Path(exists=True, dir_okay=False, readable=True, resolve_path=True),
+              help=f"Config file location [default: {DEFAULT_CONFIG_FILE}]")
+@click.option('-c', multiple=True,
+              help="Config flags in format <rule>.<option>=<value> (e.g.: -c T1.line-length=80). " +
+                   "Flag can be used multiple times to set multiple config values.")  # pylint: disable=bad-continuation
+@click.option('--commit', envvar='GITLINT_COMMIT', default=None, help="Hash (SHA) of specific commit to lint.")
+@click.option('--commits', envvar='GITLINT_COMMITS', default=None,
+              help="The range of commits (refspec or comma-separated hashes) to lint. [default: HEAD]")
+@click.option('-e', '--extra-path', envvar='GITLINT_EXTRA_PATH',
+              help="Path to a directory or python module with extra user-defined rules",
+              type=click.Path(exists=True, resolve_path=True, readable=True))
+@click.option('--ignore', envvar='GITLINT_IGNORE', default="", help="Ignore rules (comma-separated by id or name).")
+@click.option('--contrib', envvar='GITLINT_CONTRIB', default="",
+              help="Contrib rules to enable (comma-separated by id or name).")
+@click.option('--msg-filename', type=click.File(encoding=gitlint.utils.DEFAULT_ENCODING),
+              help="Path to a file containing a commit-msg.")
+@click.option('--ignore-stdin', envvar='GITLINT_IGNORE_STDIN', is_flag=True,
+              help="Ignore any stdin data. Useful for running in CI server.")
+@click.option('--staged', envvar='GITLINT_STAGED', is_flag=True,
+              help="Read staged commit meta-info from the local repository.")
+@click.option('--fail-without-commits', envvar='GITLINT_FAIL_WITHOUT_COMMITS', is_flag=True,
+              help="Hard fail when the target commit range is empty.")
+@click.option('-v', '--verbose', envvar='GITLINT_VERBOSITY', count=True, default=0,
+              help="Verbosity, more v's for more verbose output (e.g.: -v, -vv, -vvv). [default: -vvv]", )
+@click.option('-s', '--silent', envvar='GITLINT_SILENT', is_flag=True,
+              help="Silent mode (no output). Takes precedence over -v, -vv, -vvv.")
+@click.option('-d', '--debug', envvar='GITLINT_DEBUG', help="Enable debugging output.", is_flag=True)
 @click.version_option(version=gitlint.__version__)
 @click.pass_context
 def cli(  # pylint: disable=too-many-arguments
-    ctx,
-    target,
-    config,
-    c,
-    commit,
-    commits,
-    extra_path,
-    ignore,
-    contrib,
-    msg_filename,
-    ignore_stdin,
-    staged,
-    fail_without_commits,
-    verbose,
-    silent,
-    debug,
+        ctx, target, config, c, commit, commits, extra_path, ignore, contrib,
+        msg_filename, ignore_stdin, staged, fail_without_commits, verbose,
+        silent, debug,
 ):
-    """Git lint tool, checks your git commit messages for styling issues
+    """ Git lint tool, checks your git commit messages for styling issues
 
-    Documentation: http://jorisroovers.github.io/gitlint
+        Documentation: http://jorisroovers.github.io/gitlint
     """
-
     try:
         if debug:
             logging.getLogger("gitlint").setLevel(logging.DEBUG)
@@ -344,20 +286,8 @@ def cli(  # pylint: disable=too-many-arguments
 
         # Get the lint config from the commandline parameters and
         # store it in the context (click allows storing an arbitrary object in ctx.obj).
-        config, config_builder = build_config(
-            target,
-            config,
-            c,
-            extra_path,
-            ignore,
-            contrib,
-            ignore_stdin,
-            staged,
-            fail_without_commits,
-            verbose,
-            silent,
-            debug,
-        )
+        config, config_builder = build_config(target, config, c, extra_path, ignore, contrib, ignore_stdin,
+                                              staged, fail_without_commits, verbose, silent, debug)
         LOG.debug("Configuration\n%s", config)
 
         ctx.obj = ContextObj(config, config_builder, commit, commits, msg_filename)
@@ -368,6 +298,7 @@ def cli(  # pylint: disable=too-many-arguments
 
     except GitlintError as e:
         handle_gitlint_error(ctx, e)
+# fmt: on
 
 
 @cli.command("lint")

--- a/gitlint-core/gitlint/cli.py
+++ b/gitlint-core/gitlint/cli.py
@@ -37,12 +37,13 @@ LOG = logging.getLogger("gitlint.cli")
 
 
 class GitLintUsageError(GitlintError):
-    """ Exception indicating there is an issue with how gitlint is used. """
+    """Exception indicating there is an issue with how gitlint is used."""
+
     pass
 
 
 def setup_logging():
-    """ Setup gitlint logging """
+    """Setup gitlint logging"""
     root_log = logging.getLogger("gitlint")
     root_log.propagate = False  # Don't propagate to child loggers, the gitlint root logger handles everything
     handler = logging.StreamHandler()
@@ -62,10 +63,20 @@ def log_system_info():
 
 
 def build_config(  # pylint: disable=too-many-arguments
-        target, config_path, c, extra_path, ignore, contrib, ignore_stdin, staged, fail_without_commits, verbose,
-        silent, debug
+    target,
+    config_path,
+    c,
+    extra_path,
+    ignore,
+    contrib,
+    ignore_stdin,
+    staged,
+    fail_without_commits,
+    verbose,
+    silent,
+    debug,
 ):
-    """ Creates a LintConfig object based on a set of commandline parameters. """
+    """Creates a LintConfig object based on a set of commandline parameters."""
     config_builder = LintConfigBuilder()
     # Config precedence:
     # First, load default config or config from configfile
@@ -79,33 +90,33 @@ def build_config(  # pylint: disable=too-many-arguments
 
     # Finally, overwrite with any convenience commandline flags
     if ignore:
-        config_builder.set_option('general', 'ignore', ignore)
+        config_builder.set_option("general", "ignore", ignore)
 
     if contrib:
-        config_builder.set_option('general', 'contrib', contrib)
+        config_builder.set_option("general", "contrib", contrib)
 
     if ignore_stdin:
-        config_builder.set_option('general', 'ignore-stdin', ignore_stdin)
+        config_builder.set_option("general", "ignore-stdin", ignore_stdin)
 
     if silent:
-        config_builder.set_option('general', 'verbosity', 0)
+        config_builder.set_option("general", "verbosity", 0)
     elif verbose > 0:
-        config_builder.set_option('general', 'verbosity', verbose)
+        config_builder.set_option("general", "verbosity", verbose)
 
     if extra_path:
-        config_builder.set_option('general', 'extra-path', extra_path)
+        config_builder.set_option("general", "extra-path", extra_path)
 
     if target:
-        config_builder.set_option('general', 'target', target)
+        config_builder.set_option("general", "target", target)
 
     if debug:
-        config_builder.set_option('general', 'debug', debug)
+        config_builder.set_option("general", "debug", debug)
 
     if staged:
-        config_builder.set_option('general', 'staged', staged)
+        config_builder.set_option("general", "staged", staged)
 
     if fail_without_commits:
-        config_builder.set_option('general', 'fail-without-commits', fail_without_commits)
+        config_builder.set_option("general", "fail-without-commits", fail_without_commits)
 
     config = config_builder.build()
 
@@ -113,7 +124,7 @@ def build_config(  # pylint: disable=too-many-arguments
 
 
 def get_stdin_data():
-    """ Helper function that returns data sent to stdin or False if nothing is sent """
+    """Helper function that returns data sent to stdin or False if nothing is sent"""
     # STDIN can only be 3 different types of things ("modes")
     #  1. An interactive terminal device (i.e. a TTY -> sys.stdin.isatty() or stat.S_ISCHR)
     #  2. A (named) pipe (stat.S_ISFIFO)
@@ -145,7 +156,7 @@ def get_stdin_data():
 
 
 def build_git_context(lint_config, msg_filename, commit_hash, refspec):
-    """ Builds a git context based on passed parameters and order of precedence """
+    """Builds a git context based on passed parameters and order of precedence"""
 
     # Determine which GitContext method to use if a custom message is passed
     from_commit_msg = GitContext.from_commit_msg
@@ -168,8 +179,10 @@ def build_git_context(lint_config, msg_filename, commit_hash, refspec):
             return from_commit_msg(stdin_input)
 
     if lint_config.staged:
-        raise GitLintUsageError("The 'staged' option (--staged) can only be used when using '--msg-filename' or "
-                                "when piping data to gitlint via stdin.")
+        raise GitLintUsageError(
+            "The 'staged' option (--staged) can only be used when using '--msg-filename' or "
+            "when piping data to gitlint via stdin."
+        )
 
     # 3. Fallback to reading from local repository
     LOG.debug("No --msg-filename flag, no or empty data passed to stdin. Using the local repo.")
@@ -195,7 +208,7 @@ def build_git_context(lint_config, msg_filename, commit_hash, refspec):
 
 
 def handle_gitlint_error(ctx, exc):
-    """ Helper function to handle exceptions """
+    """Helper function to handle exceptions"""
     if isinstance(exc, GitContextError):
         click.echo(exc)
         ctx.exit(GIT_CONTEXT_ERROR_CODE)
@@ -208,7 +221,7 @@ def handle_gitlint_error(ctx, exc):
 
 
 class ContextObj:
-    """ Simple class to hold data that is passed between Click commands via the Click context. """
+    """Simple class to hold data that is passed between Click commands via the Click context."""
 
     def __init__(self, config, config_builder, commit_hash, refspec, msg_filename, gitcontext=None):
         self.config = config
@@ -219,49 +232,107 @@ class ContextObj:
         self.gitcontext = gitcontext
 
 
-@click.group(invoke_without_command=True, context_settings={'max_content_width': 120},
-             epilog="When no COMMAND is specified, gitlint defaults to 'gitlint lint'.")
-@click.option('--target', envvar='GITLINT_TARGET',
-              type=click.Path(exists=True, resolve_path=True, file_okay=False, readable=True),
-              help="Path of the target git repository. [default: current working directory]")
-@click.option('-C', '--config', envvar='GITLINT_CONFIG',
-              type=click.Path(exists=True, dir_okay=False, readable=True, resolve_path=True),
-              help=f"Config file location [default: {DEFAULT_CONFIG_FILE}]")
-@click.option('-c', multiple=True,
-              help="Config flags in format <rule>.<option>=<value> (e.g.: -c T1.line-length=80). " +
-                   "Flag can be used multiple times to set multiple config values.")  # pylint: disable=bad-continuation
-@click.option('--commit', envvar='GITLINT_COMMIT', default=None, help="Hash (SHA) of specific commit to lint.")
-@click.option('--commits', envvar='GITLINT_COMMITS', default=None,
-              help="The range of commits (refspec or comma-separated hashes) to lint. [default: HEAD]")
-@click.option('-e', '--extra-path', envvar='GITLINT_EXTRA_PATH',
-              help="Path to a directory or python module with extra user-defined rules",
-              type=click.Path(exists=True, resolve_path=True, readable=True))
-@click.option('--ignore', envvar='GITLINT_IGNORE', default="", help="Ignore rules (comma-separated by id or name).")
-@click.option('--contrib', envvar='GITLINT_CONTRIB', default="",
-              help="Contrib rules to enable (comma-separated by id or name).")
-@click.option('--msg-filename', type=click.File(encoding=gitlint.utils.DEFAULT_ENCODING),
-              help="Path to a file containing a commit-msg.")
-@click.option('--ignore-stdin', envvar='GITLINT_IGNORE_STDIN', is_flag=True,
-              help="Ignore any stdin data. Useful for running in CI server.")
-@click.option('--staged', envvar='GITLINT_STAGED', is_flag=True,
-              help="Read staged commit meta-info from the local repository.")
-@click.option('--fail-without-commits', envvar='GITLINT_FAIL_WITHOUT_COMMITS', is_flag=True,
-              help="Hard fail when the target commit range is empty.")
-@click.option('-v', '--verbose', envvar='GITLINT_VERBOSITY', count=True, default=0,
-              help="Verbosity, more v's for more verbose output (e.g.: -v, -vv, -vvv). [default: -vvv]", )
-@click.option('-s', '--silent', envvar='GITLINT_SILENT', is_flag=True,
-              help="Silent mode (no output). Takes precedence over -v, -vv, -vvv.")
-@click.option('-d', '--debug', envvar='GITLINT_DEBUG', help="Enable debugging output.", is_flag=True)
+@click.group(
+    invoke_without_command=True,
+    context_settings={"max_content_width": 120},
+    epilog="When no COMMAND is specified, gitlint defaults to 'gitlint lint'.",
+)
+@click.option(
+    "--target",
+    envvar="GITLINT_TARGET",
+    type=click.Path(exists=True, resolve_path=True, file_okay=False, readable=True),
+    help="Path of the target git repository. [default: current working directory]",
+)
+@click.option(
+    "-C",
+    "--config",
+    envvar="GITLINT_CONFIG",
+    type=click.Path(exists=True, dir_okay=False, readable=True, resolve_path=True),
+    help=f"Config file location [default: {DEFAULT_CONFIG_FILE}]",
+)
+@click.option(
+    "-c",
+    multiple=True,
+    help="Config flags in format <rule>.<option>=<value> (e.g.: -c T1.line-length=80). "
+    "Flag can be used multiple times to set multiple config values.",
+)  # pylint: disable=bad-continuation
+@click.option("--commit", envvar="GITLINT_COMMIT", default=None, help="Hash (SHA) of specific commit to lint.")
+@click.option(
+    "--commits",
+    envvar="GITLINT_COMMITS",
+    default=None,
+    help="The range of commits (refspec or comma-separated hashes) to lint. [default: HEAD]",
+)
+@click.option(
+    "-e",
+    "--extra-path",
+    envvar="GITLINT_EXTRA_PATH",
+    help="Path to a directory or python module with extra user-defined rules",
+    type=click.Path(exists=True, resolve_path=True, readable=True),
+)
+@click.option("--ignore", envvar="GITLINT_IGNORE", default="", help="Ignore rules (comma-separated by id or name).")
+@click.option(
+    "--contrib", envvar="GITLINT_CONTRIB", default="", help="Contrib rules to enable (comma-separated by id or name)."
+)
+@click.option(
+    "--msg-filename",
+    type=click.File(encoding=gitlint.utils.DEFAULT_ENCODING),
+    help="Path to a file containing a commit-msg.",
+)
+@click.option(
+    "--ignore-stdin",
+    envvar="GITLINT_IGNORE_STDIN",
+    is_flag=True,
+    help="Ignore any stdin data. Useful for running in CI server.",
+)
+@click.option(
+    "--staged", envvar="GITLINT_STAGED", is_flag=True, help="Read staged commit meta-info from the local repository."
+)
+@click.option(
+    "--fail-without-commits",
+    envvar="GITLINT_FAIL_WITHOUT_COMMITS",
+    is_flag=True,
+    help="Hard fail when the target commit range is empty.",
+)
+@click.option(
+    "-v",
+    "--verbose",
+    envvar="GITLINT_VERBOSITY",
+    count=True,
+    default=0,
+    help="Verbosity, more v's for more verbose output (e.g.: -v, -vv, -vvv). [default: -vvv]",
+)
+@click.option(
+    "-s",
+    "--silent",
+    envvar="GITLINT_SILENT",
+    is_flag=True,
+    help="Silent mode (no output). Takes precedence over -v, -vv, -vvv.",
+)
+@click.option("-d", "--debug", envvar="GITLINT_DEBUG", help="Enable debugging output.", is_flag=True)
 @click.version_option(version=gitlint.__version__)
 @click.pass_context
 def cli(  # pylint: disable=too-many-arguments
-        ctx, target, config, c, commit, commits, extra_path, ignore, contrib,
-        msg_filename, ignore_stdin, staged, fail_without_commits, verbose,
-        silent, debug,
+    ctx,
+    target,
+    config,
+    c,
+    commit,
+    commits,
+    extra_path,
+    ignore,
+    contrib,
+    msg_filename,
+    ignore_stdin,
+    staged,
+    fail_without_commits,
+    verbose,
+    silent,
+    debug,
 ):
-    """ Git lint tool, checks your git commit messages for styling issues
+    """Git lint tool, checks your git commit messages for styling issues
 
-        Documentation: http://jorisroovers.github.io/gitlint
+    Documentation: http://jorisroovers.github.io/gitlint
     """
 
     try:
@@ -273,8 +344,20 @@ def cli(  # pylint: disable=too-many-arguments
 
         # Get the lint config from the commandline parameters and
         # store it in the context (click allows storing an arbitrary object in ctx.obj).
-        config, config_builder = build_config(target, config, c, extra_path, ignore, contrib, ignore_stdin, staged,
-                                              fail_without_commits, verbose, silent, debug)
+        config, config_builder = build_config(
+            target,
+            config,
+            c,
+            extra_path,
+            ignore,
+            contrib,
+            ignore_stdin,
+            staged,
+            fail_without_commits,
+            verbose,
+            silent,
+            debug,
+        )
         LOG.debug("Configuration\n%s", config)
 
         ctx.obj = ContextObj(config, config_builder, commit, commits, msg_filename)
@@ -290,7 +373,7 @@ def cli(  # pylint: disable=too-many-arguments
 @cli.command("lint")
 @click.pass_context
 def lint(ctx):
-    """ Lints a git repository [default command] """
+    """Lints a git repository [default command]"""
     lint_config = ctx.obj.config
     refspec = ctx.obj.refspec
     commit_hash = ctx.obj.commit_hash
@@ -312,7 +395,7 @@ def lint(ctx):
             raise GitLintUsageError(f'No commits in range "{refspec}"')
         ctx.exit(GITLINT_SUCCESS)
 
-    LOG.debug('Linting %d commit(s)', number_of_commits)
+    LOG.debug("Linting %d commit(s)", number_of_commits)
     general_config_builder = ctx.obj.config_builder
     last_commit = gitcontext.commits[-1]
 
@@ -351,7 +434,7 @@ def lint(ctx):
 @cli.command("install-hook")
 @click.pass_context
 def install_hook(ctx):
-    """ Install gitlint as a git commit-msg hook. """
+    """Install gitlint as a git commit-msg hook."""
     try:
         hooks.GitHookInstaller.install_commit_msg_hook(ctx.obj.config)
         hook_path = hooks.GitHookInstaller.commit_msg_hook_path(ctx.obj.config)
@@ -365,7 +448,7 @@ def install_hook(ctx):
 @cli.command("uninstall-hook")
 @click.pass_context
 def uninstall_hook(ctx):
-    """ Uninstall gitlint commit-msg hook. """
+    """Uninstall gitlint commit-msg hook."""
     try:
         hooks.GitHookInstaller.uninstall_commit_msg_hook(ctx.obj.config)
         hook_path = hooks.GitHookInstaller.commit_msg_hook_path(ctx.obj.config)
@@ -379,7 +462,7 @@ def uninstall_hook(ctx):
 @cli.command("run-hook")
 @click.pass_context
 def run_hook(ctx):
-    """ Runs the gitlint commit-msg hook. """
+    """Runs the gitlint commit-msg hook."""
 
     exit_code = 1
     while exit_code > 0:
@@ -395,16 +478,18 @@ def run_hook(ctx):
 
             exit_code = e.exit_code
             if exit_code == GITLINT_SUCCESS:
-                click.echo("gitlint: " + click.style("OK", fg='green') + " (no violations in commit message)")
+                click.echo("gitlint: " + click.style("OK", fg="green") + " (no violations in commit message)")
                 continue
 
             click.echo("-----------------------------------------------")
-            click.echo("gitlint: " + click.style("Your commit message contains violations.", fg='red'))
+            click.echo("gitlint: " + click.style("Your commit message contains violations.", fg="red"))
 
             value = None
             while value not in ["y", "n", "e"]:
-                click.echo("Continue with commit anyways (this keeps the current commit message)? "
-                           "[y(es)/n(no)/e(dit)] ", nl=False)
+                click.echo(
+                    "Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] ",
+                    nl=False,
+                )
 
                 # Ideally, we'd want to use click.getchar() or click.prompt() to get user's input here instead of
                 # input(). However, those functions currently don't support getting answers from stdin.
@@ -448,15 +533,15 @@ def run_hook(ctx):
 @cli.command("generate-config")
 @click.pass_context
 def generate_config(ctx):
-    """ Generates a sample gitlint config file. """
-    path = click.prompt('Please specify a location for the sample gitlint config file', default=DEFAULT_CONFIG_FILE)
+    """Generates a sample gitlint config file."""
+    path = click.prompt("Please specify a location for the sample gitlint config file", default=DEFAULT_CONFIG_FILE)
     path = os.path.realpath(path)
     dir_name = os.path.dirname(path)
     if not os.path.exists(dir_name):
         click.echo(f"Error: Directory '{dir_name}' does not exist.", err=True)
         ctx.exit(USAGE_ERROR_CODE)
     elif os.path.exists(path):
-        click.echo(f"Error: File \"{path}\" already exists.", err=True)
+        click.echo(f'Error: File "{path}" already exists.', err=True)
         ctx.exit(USAGE_ERROR_CODE)
 
     LintConfigGenerator.generate_config(path)

--- a/gitlint-core/gitlint/config.py
+++ b/gitlint-core/gitlint/config.py
@@ -16,8 +16,8 @@ from gitlint.exception import GitlintError
 
 
 def handle_option_error(func):
-    """ Decorator that calls given method/function and handles any RuleOptionError gracefully by converting it to a
-    LintConfigError. """
+    """Decorator that calls given method/function and handles any RuleOptionError gracefully by converting it to a
+    LintConfigError."""
 
     def wrapped(*args):
         try:
@@ -33,54 +33,58 @@ class LintConfigError(GitlintError):
 
 
 class LintConfig:  # pylint: disable=too-many-instance-attributes
-    """ Class representing gitlint configuration.
-        Contains active config as well as number of methods to easily get/set the config.
+    """Class representing gitlint configuration.
+    Contains active config as well as number of methods to easily get/set the config.
     """
 
     # Default tuple of rule classes (tuple because immutable).
-    default_rule_classes = (rules.IgnoreByTitle,
-                            rules.IgnoreByBody,
-                            rules.IgnoreBodyLines,
-                            rules.IgnoreByAuthorName,
-                            rules.TitleMaxLength,
-                            rules.TitleTrailingWhitespace,
-                            rules.TitleLeadingWhitespace,
-                            rules.TitleTrailingPunctuation,
-                            rules.TitleHardTab,
-                            rules.TitleMustNotContainWord,
-                            rules.TitleRegexMatches,
-                            rules.TitleMinLength,
-                            rules.BodyMaxLineLength,
-                            rules.BodyMinLength,
-                            rules.BodyMissing,
-                            rules.BodyTrailingWhitespace,
-                            rules.BodyHardTab,
-                            rules.BodyFirstLineEmpty,
-                            rules.BodyChangedFileMention,
-                            rules.BodyRegexMatches,
-                            rules.AuthorValidEmail)
+    default_rule_classes = (
+        rules.IgnoreByTitle,
+        rules.IgnoreByBody,
+        rules.IgnoreBodyLines,
+        rules.IgnoreByAuthorName,
+        rules.TitleMaxLength,
+        rules.TitleTrailingWhitespace,
+        rules.TitleLeadingWhitespace,
+        rules.TitleTrailingPunctuation,
+        rules.TitleHardTab,
+        rules.TitleMustNotContainWord,
+        rules.TitleRegexMatches,
+        rules.TitleMinLength,
+        rules.BodyMaxLineLength,
+        rules.BodyMinLength,
+        rules.BodyMissing,
+        rules.BodyTrailingWhitespace,
+        rules.BodyHardTab,
+        rules.BodyFirstLineEmpty,
+        rules.BodyChangedFileMention,
+        rules.BodyRegexMatches,
+        rules.AuthorValidEmail,
+    )
 
     def __init__(self):
         self.rules = RuleCollection(self.default_rule_classes)
-        self._verbosity = options.IntOption('verbosity', 3, "Verbosity")
-        self._ignore_merge_commits = options.BoolOption('ignore-merge-commits', True, "Ignore merge commits")
-        self._ignore_fixup_commits = options.BoolOption('ignore-fixup-commits', True, "Ignore fixup commits")
-        self._ignore_fixup_amend_commits = options.BoolOption('ignore-fixup-amend-commits', True,
-                                                              "Ignore fixup amend commits")
-        self._ignore_squash_commits = options.BoolOption('ignore-squash-commits', True, "Ignore squash commits")
-        self._ignore_revert_commits = options.BoolOption('ignore-revert-commits', True, "Ignore revert commits")
-        self._debug = options.BoolOption('debug', False, "Enable debug mode")
+        self._verbosity = options.IntOption("verbosity", 3, "Verbosity")
+        self._ignore_merge_commits = options.BoolOption("ignore-merge-commits", True, "Ignore merge commits")
+        self._ignore_fixup_commits = options.BoolOption("ignore-fixup-commits", True, "Ignore fixup commits")
+        self._ignore_fixup_amend_commits = options.BoolOption(
+            "ignore-fixup-amend-commits", True, "Ignore fixup amend commits"
+        )
+        self._ignore_squash_commits = options.BoolOption("ignore-squash-commits", True, "Ignore squash commits")
+        self._ignore_revert_commits = options.BoolOption("ignore-revert-commits", True, "Ignore revert commits")
+        self._debug = options.BoolOption("debug", False, "Enable debug mode")
         self._extra_path = None
         target_description = "Path of the target git repository (default=current working directory)"
-        self._target = options.PathOption('target', os.path.realpath(os.getcwd()), target_description)
-        self._ignore = options.ListOption('ignore', [], 'List of rule-ids to ignore')
-        self._contrib = options.ListOption('contrib', [], 'List of contrib-rules to enable')
+        self._target = options.PathOption("target", os.path.realpath(os.getcwd()), target_description)
+        self._ignore = options.ListOption("ignore", [], "List of rule-ids to ignore")
+        self._contrib = options.ListOption("contrib", [], "List of contrib-rules to enable")
         self._config_path = None
         ignore_stdin_description = "Ignore any stdin data. Useful for running in CI server."
-        self._ignore_stdin = options.BoolOption('ignore-stdin', False, ignore_stdin_description)
-        self._staged = options.BoolOption('staged', False, "Read staged commit meta-info from the local repository.")
-        self._fail_without_commits = options.BoolOption('fail-without-commits', False,
-                                                        "Hard fail when the target commit range is empty")
+        self._ignore_stdin = options.BoolOption("ignore-stdin", False, ignore_stdin_description)
+        self._staged = options.BoolOption("staged", False, "Read staged commit meta-info from the local repository.")
+        self._fail_without_commits = options.BoolOption(
+            "fail-without-commits", False, "Hard fail when the target commit range is empty"
+        )
 
     @property
     def target(self):
@@ -204,9 +208,7 @@ class LintConfig:  # pylint: disable=too-many-instance-attributes
                 self._extra_path.set(value)
             else:
                 self._extra_path = options.PathOption(
-                    'extra-path', value,
-                    "Path to a directory or module with extra user-defined rules",
-                    type='both'
+                    "extra-path", value, "Path to a directory or module with extra user-defined rules", type="both"
                 )
 
             # Make sure we unload any previously loaded extra-path rules
@@ -214,7 +216,7 @@ class LintConfig:  # pylint: disable=too-many-instance-attributes
 
             # Find rules in the new extra-path and add them to the existing rules
             rule_classes = rule_finder.find_rule_classes(self.extra_path)
-            self.rules.add_rules(rule_classes, {'is_user_defined': True})
+            self.rules.add_rules(rule_classes, {"is_user_defined": True})
 
         except (options.RuleOptionError, rules.UserRuleError) as e:
             raise LintConfigError(str(e)) from e
@@ -237,12 +239,11 @@ class LintConfig:  # pylint: disable=too-many-instance-attributes
 
             # For each specified contrib rule, check whether it exists among the contrib classes
             for rule_id_or_name in self.contrib:
-                rule_class = next((rc for rc in rule_classes if
-                                   rule_id_or_name in (rc.id, rc.name)), False)
+                rule_class = next((rc for rc in rule_classes if rule_id_or_name in (rc.id, rc.name)), False)
 
                 # If contrib rule exists, instantiate it and add it to the rules list
                 if rule_class:
-                    self.rules.add_rule(rule_class, rule_class.id, {'is_contrib': True})
+                    self.rules.add_rule(rule_class, rule_class.id, {"is_contrib": True})
                 else:
                     raise LintConfigError(f"No contrib rule with id or name '{rule_id_or_name}' found.")
 
@@ -261,14 +262,14 @@ class LintConfig:  # pylint: disable=too-many-instance-attributes
         return option
 
     def get_rule_option(self, rule_name_or_id, option_name):
-        """ Returns the value of a given option for a given rule. LintConfigErrors will be raised if the
-        rule or option don't exist. """
+        """Returns the value of a given option for a given rule. LintConfigErrors will be raised if the
+        rule or option don't exist."""
         option = self._get_option(rule_name_or_id, option_name)
         return option.value
 
     def set_rule_option(self, rule_name_or_id, option_name, option_value):
-        """ Attempts to set a given value for a given option for a given rule.
-            LintConfigErrors will be raised if the rule or option don't exist or if the value is invalid. """
+        """Attempts to set a given value for a given option for a given rule.
+        LintConfigErrors will be raised if the rule or option don't exist or if the value is invalid."""
         option = self._get_option(rule_name_or_id, option_name)
         try:
             option.set(option_value)
@@ -286,47 +287,51 @@ class LintConfig:  # pylint: disable=too-many-instance-attributes
         setattr(self, attr_name, option_value)
 
     def __eq__(self, other):
-        return isinstance(other, LintConfig) and \
-            self.rules == other.rules and \
-            self.verbosity == other.verbosity and \
-            self.target == other.target and \
-            self.extra_path == other.extra_path and \
-            self.contrib == other.contrib and \
-            self.ignore_merge_commits == other.ignore_merge_commits and \
-            self.ignore_fixup_commits == other.ignore_fixup_commits and \
-            self.ignore_fixup_amend_commits == other.ignore_fixup_amend_commits and \
-            self.ignore_squash_commits == other.ignore_squash_commits and \
-            self.ignore_revert_commits == other.ignore_revert_commits and \
-            self.ignore_stdin == other.ignore_stdin and \
-            self.staged == other.staged and \
-            self.fail_without_commits == other.fail_without_commits and \
-            self.debug == other.debug and \
-            self.ignore == other.ignore and \
-            self._config_path == other._config_path  # noqa
+        return (
+            isinstance(other, LintConfig)
+            and self.rules == other.rules
+            and self.verbosity == other.verbosity
+            and self.target == other.target
+            and self.extra_path == other.extra_path
+            and self.contrib == other.contrib
+            and self.ignore_merge_commits == other.ignore_merge_commits
+            and self.ignore_fixup_commits == other.ignore_fixup_commits
+            and self.ignore_fixup_amend_commits == other.ignore_fixup_amend_commits
+            and self.ignore_squash_commits == other.ignore_squash_commits
+            and self.ignore_revert_commits == other.ignore_revert_commits
+            and self.ignore_stdin == other.ignore_stdin
+            and self.staged == other.staged
+            and self.fail_without_commits == other.fail_without_commits
+            and self.debug == other.debug
+            and self.ignore == other.ignore
+            and self._config_path == other._config_path
+        )  # noqa
 
     def __str__(self):
         # config-path is not a user exposed variable, so don't print it under the general section
-        return (f"config-path: {self._config_path}\n"
-                f"[GENERAL]\n"
-                f"extra-path: {self.extra_path}\n"
-                f"contrib: {self.contrib}\n"
-                f"ignore: {','.join(self.ignore)}\n"
-                f"ignore-merge-commits: {self.ignore_merge_commits}\n"
-                f"ignore-fixup-commits: {self.ignore_fixup_commits}\n"
-                f"ignore-fixup-amend-commits: {self.ignore_fixup_amend_commits}\n"
-                f"ignore-squash-commits: {self.ignore_squash_commits}\n"
-                f"ignore-revert-commits: {self.ignore_revert_commits}\n"
-                f"ignore-stdin: {self.ignore_stdin}\n"
-                f"staged: {self.staged}\n"
-                f"fail-without-commits: {self.fail_without_commits}\n"
-                f"verbosity: {self.verbosity}\n"
-                f"debug: {self.debug}\n"
-                f"target: {self.target}\n"
-                f"[RULES]\n{self.rules}")
+        return (
+            f"config-path: {self._config_path}\n"
+            f"[GENERAL]\n"
+            f"extra-path: {self.extra_path}\n"
+            f"contrib: {self.contrib}\n"
+            f"ignore: {','.join(self.ignore)}\n"
+            f"ignore-merge-commits: {self.ignore_merge_commits}\n"
+            f"ignore-fixup-commits: {self.ignore_fixup_commits}\n"
+            f"ignore-fixup-amend-commits: {self.ignore_fixup_amend_commits}\n"
+            f"ignore-squash-commits: {self.ignore_squash_commits}\n"
+            f"ignore-revert-commits: {self.ignore_revert_commits}\n"
+            f"ignore-stdin: {self.ignore_stdin}\n"
+            f"staged: {self.staged}\n"
+            f"fail-without-commits: {self.fail_without_commits}\n"
+            f"verbosity: {self.verbosity}\n"
+            f"debug: {self.debug}\n"
+            f"target: {self.target}\n"
+            f"[RULES]\n{self.rules}"
+        )
 
 
 class RuleCollection:
-    """ Class representing an ordered list of rules. Methods are provided to easily retrieve, add or delete rules. """
+    """Class representing an ordered list of rules. Methods are provided to easily retrieve, add or delete rules."""
 
     def __init__(self, rule_classes=None, rule_attrs=None):
         # Use an ordered dict so that the order in which rules are applied is always the same
@@ -342,13 +347,13 @@ class RuleCollection:
         return rule
 
     def add_rule(self, rule_class, rule_id, rule_attrs=None):
-        """ Instantiates and adds a rule to RuleCollection.
-            Note: There can be multiple instantiations of the same rule_class in the RuleCollection, as long as the
-            rule_id is unique.
-            :param rule_class python class representing the rule
-            :param rule_id unique identifier for the rule. If not unique, it will
-                           overwrite the existing rule with that id
-            :param rule_attrs dictionary of attributes to set on the instantiated rule obj
+        """Instantiates and adds a rule to RuleCollection.
+        Note: There can be multiple instantiations of the same rule_class in the RuleCollection, as long as the
+        rule_id is unique.
+        :param rule_class python class representing the rule
+        :param rule_id unique identifier for the rule. If not unique, it will
+                       overwrite the existing rule with that id
+        :param rule_attrs dictionary of attributes to set on the instantiated rule obj
         """
         rule_obj = rule_class()
         rule_obj.id = rule_id
@@ -358,12 +363,12 @@ class RuleCollection:
         self._rules[rule_obj.id] = rule_obj
 
     def add_rules(self, rule_classes, rule_attrs=None):
-        """ Convenience method to add multiple rules at once based on a list of rule classes. """
+        """Convenience method to add multiple rules at once based on a list of rule classes."""
         for rule_class in rule_classes:
             self.add_rule(rule_class, rule_class.id, rule_attrs)
 
     def delete_rules_by_attr(self, attr_name, attr_val):
-        """ Deletes all rules from the collection that match a given attribute name and value """
+        """Deletes all rules from the collection that match a given attribute name and value"""
         # Create a new list based on _rules.values() because in python 3, values() is a ValuesView as opposed to a list
         # This means you can't modify the ValueView while iterating over it.
         for rule in [r for r in self._rules.values()]:  # pylint: disable=unnecessary-comprehension
@@ -398,7 +403,7 @@ class RuleCollection:
 
 
 class LintConfigBuilder:
-    """ Factory class that can build gitlint config.
+    """Factory class that can build gitlint config.
     This is primarily useful to deal with complex configuration scenarios where configuration can be set and overridden
     from various sources (typically according to certain precedence rules) before the actual config should be
     normalized, validated and build. Example usage can be found in gitlint.cli.
@@ -416,19 +421,19 @@ class LintConfigBuilder:
         self._config_blueprint[section][option_name] = option_value
 
     def set_config_from_commit(self, commit):
-        """ Given a git commit, applies config specified in the commit message.
-            Supported:
-             - gitlint-ignore: all
+        """Given a git commit, applies config specified in the commit message.
+        Supported:
+         - gitlint-ignore: all
         """
         for line in commit.message.body:
             pattern = re.compile(r"^gitlint-ignore:\s*(.*)")
             matches = pattern.match(line)
             if matches and len(matches.groups()) == 1:
-                self.set_option('general', 'ignore', matches.group(1))
+                self.set_option("general", "ignore", matches.group(1))
 
     def set_config_from_string_list(self, config_options):
-        """ Given a list of config options of the form "<rule>.<option>=<value>", parses out the correct rule and option
-        and sets the value accordingly in this factory object. """
+        """Given a list of config options of the form "<rule>.<option>=<value>", parses out the correct rule and option
+        and sets the value accordingly in this factory object."""
         for config_option in config_options:
             try:
                 config_name, option_value = config_option.split("=", 1)
@@ -438,10 +443,11 @@ class LintConfigBuilder:
                 self.set_option(rule_name, option_name, option_value)
             except ValueError as e:  # raised if the config string is invalid
                 raise LintConfigError(
-                    f"'{config_option}' is an invalid configuration option. Use '<rule>.<option>=<value>'") from e
+                    f"'{config_option}' is an invalid configuration option. Use '<rule>.<option>=<value>'"
+                ) from e
 
     def set_from_config_file(self, filename):
-        """ Loads lint config from an ini-style config file """
+        """Loads lint config from an ini-style config file"""
         if not os.path.exists(filename):
             raise LintConfigError(f"Invalid file path: {filename}")
         self._config_path = os.path.realpath(filename)
@@ -459,8 +465,8 @@ class LintConfigBuilder:
             raise LintConfigError(str(e)) from e
 
     def _add_named_rule(self, config, qualified_rule_name):
-        """ Adds a Named Rule to a given LintConfig object.
-            IMPORTANT: This method does *NOT* overwrite existing Named Rules with the same canonical id.
+        """Adds a Named Rule to a given LintConfig object.
+        IMPORTANT: This method does *NOT* overwrite existing Named Rules with the same canonical id.
         """
 
         # Split up named rule in its parts: the name/id that specifies the parent rule,
@@ -488,13 +494,13 @@ class LintConfigBuilder:
 
         # Add the rule to the collection of rules if it's not there already
         if not config.rules.find_rule(canonical_id):
-            config.rules.add_rule(parent_rule.__class__, canonical_id, {'is_named': True, 'name': canonical_name})
+            config.rules.add_rule(parent_rule.__class__, canonical_id, {"is_named": True, "name": canonical_name})
 
         return canonical_id
 
     def build(self, config=None):
-        """ Build a real LintConfig object by normalizing and validating the options that were previously set on this
-        factory. """
+        """Build a real LintConfig object by normalizing and validating the options that were previously set on this
+        factory."""
         # If we are passed a config object, then rebuild that object instead of building a new lintconfig object from
         # scratch
         if not config:
@@ -503,7 +509,7 @@ class LintConfigBuilder:
         config._config_path = self._config_path
 
         # Set general options first as this might change the behavior or validity of the other options
-        general_section = self._config_blueprint.get('general')
+        general_section = self._config_blueprint.get("general")
         if general_section:
             for option_name, option_value in general_section.items():
                 config.set_general_option(option_name, option_value)
@@ -523,7 +529,7 @@ class LintConfigBuilder:
         return config
 
     def clone(self):
-        """ Creates an exact copy of a LintConfigBuilder.  """
+        """Creates an exact copy of a LintConfigBuilder."""
         builder = LintConfigBuilder()
         builder._config_blueprint = copy.deepcopy(self._config_blueprint)
         builder._config_path = self._config_path
@@ -536,6 +542,6 @@ GITLINT_CONFIG_TEMPLATE_SRC_PATH = os.path.join(os.path.dirname(os.path.realpath
 class LintConfigGenerator:
     @staticmethod
     def generate_config(dest):
-        """ Generates a gitlint config file at the given destination location.
-            Expects that the given ```dest``` points to a valid destination. """
+        """Generates a gitlint config file at the given destination location.
+        Expects that the given ```dest``` points to a valid destination."""
         shutil.copyfile(GITLINT_CONFIG_TEMPLATE_SRC_PATH, dest)

--- a/gitlint-core/gitlint/config.py
+++ b/gitlint-core/gitlint/config.py
@@ -311,7 +311,7 @@ class LintConfig:  # pylint: disable=too-many-instance-attributes
         # config-path is not a user exposed variable, so don't print it under the general section
         return (
             f"config-path: {self._config_path}\n"
-            f"[GENERAL]\n"
+            "[GENERAL]\n"
             f"extra-path: {self.extra_path}\n"
             f"contrib: {self.contrib}\n"
             f"ignore: {','.join(self.ignore)}\n"
@@ -518,7 +518,6 @@ class LintConfigBuilder:
             for option_name, option_value in section_dict.items():
                 # Skip over the general section, as we've already done that above
                 if section_name != "general":
-
                     # If the section name contains a colon (:), then this section is defining a Named Rule
                     # Which means we need to instantiate that Named Rule in the config.
                     if self.RULE_QUALIFIER_SYMBOL in section_name:

--- a/gitlint-core/gitlint/contrib/rules/conventional_commit.py
+++ b/gitlint-core/gitlint/contrib/rules/conventional_commit.py
@@ -7,7 +7,7 @@ RULE_REGEX = re.compile(r"([^(]+?)(\([^)]+?\))?!?: .+")
 
 
 class ConventionalCommit(LineRule):
-    """ This rule enforces the spec at https://www.conventionalcommits.org/. """
+    """This rule enforces the spec at https://www.conventionalcommits.org/."""
 
     name = "contrib-title-conventional-commits"
     id = "CT1"
@@ -31,7 +31,7 @@ class ConventionalCommit(LineRule):
         else:
             line_commit_type = match.group(1)
             if line_commit_type not in self.options["types"].value:
-                opt_str = ', '.join(self.options['types'].value)
+                opt_str = ", ".join(self.options["types"].value)
                 violations.append(RuleViolation(self.id, f"Title does not start with one of {opt_str}", line))
 
         return violations

--- a/gitlint-core/gitlint/contrib/rules/disallow_cleanup_commits.py
+++ b/gitlint-core/gitlint/contrib/rules/disallow_cleanup_commits.py
@@ -2,7 +2,7 @@ from gitlint.rules import CommitRule, RuleViolation
 
 
 class DisallowCleanupCommits(CommitRule):
-    """ This rule checks the commits for "fixup!"/"squash!"/"amend!" commits
+    """This rule checks the commits for "fixup!"/"squash!"/"amend!" commits
     and rejects them.
     """
 

--- a/gitlint-core/gitlint/contrib/rules/signedoff_by.py
+++ b/gitlint-core/gitlint/contrib/rules/signedoff_by.py
@@ -1,9 +1,8 @@
-
 from gitlint.rules import CommitRule, RuleViolation
 
 
 class SignedOffBy(CommitRule):
-    """ This rule will enforce that each commit body contains a "Signed-off-by" line.
+    """This rule will enforce that each commit body contains a "Signed-off-by" line.
     We keep things simple here and just check whether the commit body contains a line that starts with "Signed-off-by".
     """
 

--- a/gitlint-core/gitlint/display.py
+++ b/gitlint-core/gitlint/display.py
@@ -2,14 +2,14 @@ from sys import stdout, stderr
 
 
 class Display:
-    """ Utility class to print stuff to an output stream (stdout by default) based on the config's verbosity """
+    """Utility class to print stuff to an output stream (stdout by default) based on the config's verbosity"""
 
     def __init__(self, lint_config):
         self.config = lint_config
 
     def _output(self, message, verbosity, exact, stream):
-        """ Output a message if the config's verbosity is >= to the given verbosity. If exact == True, the message
-        will only be outputted if the given verbosity exactly matches the config's verbosity. """
+        """Output a message if the config's verbosity is >= to the given verbosity. If exact == True, the message
+        will only be outputted if the given verbosity exactly matches the config's verbosity."""
         if exact:
             if self.config.verbosity == verbosity:
                 stream.write(message + "\n")

--- a/gitlint-core/gitlint/exception.py
+++ b/gitlint-core/gitlint/exception.py
@@ -1,4 +1,4 @@
-
 class GitlintError(Exception):
-    """ Based Exception class for all gitlint exceptions """
+    """Based Exception class for all gitlint exceptions"""
+
     pass

--- a/gitlint-core/gitlint/hooks.py
+++ b/gitlint-core/gitlint/hooks.py
@@ -17,7 +17,7 @@ class GitHookInstallerError(GitlintError):
 
 
 class GitHookInstaller:
-    """ Utility class that provides methods for installing and uninstalling the gitlint commitmsg hook. """
+    """Utility class that provides methods for installing and uninstalling the gitlint commitmsg hook."""
 
     @staticmethod
     def commit_msg_hook_path(lint_config):
@@ -25,7 +25,7 @@ class GitHookInstaller:
 
     @staticmethod
     def _assert_git_repo(target):
-        """ Asserts that a given target directory is a git repository """
+        """Asserts that a given target directory is a git repository"""
         hooks_dir = git_hooks_dir(target)
         if not os.path.isdir(hooks_dir):
             raise GitHookInstallerError(f"{target} is not a git repository.")
@@ -36,8 +36,9 @@ class GitHookInstaller:
         dest_path = GitHookInstaller.commit_msg_hook_path(lint_config)
         if os.path.exists(dest_path):
             raise GitHookInstallerError(
-                f"There is already a commit-msg hook file present in {dest_path}.\n" +
-                "gitlint currently does not support appending to an existing commit-msg file.")
+                f"There is already a commit-msg hook file present in {dest_path}.\n"
+                "gitlint currently does not support appending to an existing commit-msg file."
+            )
 
         # copy hook file
         shutil.copy(COMMIT_MSG_HOOK_SRC_PATH, dest_path)
@@ -55,8 +56,10 @@ class GitHookInstaller:
         with io.open(dest_path, encoding=DEFAULT_ENCODING) as fp:
             lines = fp.readlines()
             if len(lines) < 2 or lines[1] != GITLINT_HOOK_IDENTIFIER:
-                msg = f"The commit-msg hook in {dest_path} was not installed by gitlint (or it was modified).\n" + \
-                      "Uninstallation of 3th party or modified gitlint hooks is not supported."
+                msg = (
+                    f"The commit-msg hook in {dest_path} was not installed by gitlint (or it was modified).\n"
+                    "Uninstallation of 3th party or modified gitlint hooks is not supported."
+                )
                 raise GitHookInstallerError(msg)
 
         # If we are sure it's a gitlint hook, go ahead and remove it

--- a/gitlint-core/gitlint/lint.py
+++ b/gitlint-core/gitlint/lint.py
@@ -8,7 +8,7 @@ logging.basicConfig()
 
 
 class GitLinter:
-    """ Main linter class. This is where rules actually get applied. See the lint() method. """
+    """Main linter class. This is where rules actually get applied. See the lint() method."""
 
     def __init__(self, config):
         self.config = config
@@ -16,34 +16,48 @@ class GitLinter:
         self.display = display.Display(config)
 
     def should_ignore_rule(self, rule):
-        """ Determines whether a rule should be ignored based on the general list of commits to ignore """
+        """Determines whether a rule should be ignored based on the general list of commits to ignore"""
         return rule.id in self.config.ignore or rule.name in self.config.ignore
 
     @property
     def configuration_rules(self):
-        return [rule for rule in self.config.rules if
-                isinstance(rule, gitlint_rules.ConfigurationRule) and not self.should_ignore_rule(rule)]
+        return [
+            rule
+            for rule in self.config.rules
+            if isinstance(rule, gitlint_rules.ConfigurationRule) and not self.should_ignore_rule(rule)
+        ]
 
     @property
     def title_line_rules(self):
-        return [rule for rule in self.config.rules if
-                isinstance(rule, gitlint_rules.LineRule) and
-                rule.target == gitlint_rules.CommitMessageTitle and not self.should_ignore_rule(rule)]
+        return [
+            rule
+            for rule in self.config.rules
+            if isinstance(rule, gitlint_rules.LineRule)
+            and rule.target == gitlint_rules.CommitMessageTitle
+            and not self.should_ignore_rule(rule)
+        ]
 
     @property
     def body_line_rules(self):
-        return [rule for rule in self.config.rules if
-                isinstance(rule, gitlint_rules.LineRule) and
-                rule.target == gitlint_rules.CommitMessageBody and not self.should_ignore_rule(rule)]
+        return [
+            rule
+            for rule in self.config.rules
+            if isinstance(rule, gitlint_rules.LineRule)
+            and rule.target == gitlint_rules.CommitMessageBody
+            and not self.should_ignore_rule(rule)
+        ]
 
     @property
     def commit_rules(self):
-        return [rule for rule in self.config.rules if isinstance(rule, gitlint_rules.CommitRule) and
-                not self.should_ignore_rule(rule)]
+        return [
+            rule
+            for rule in self.config.rules
+            if isinstance(rule, gitlint_rules.CommitRule) and not self.should_ignore_rule(rule)
+        ]
 
     @staticmethod
     def _apply_line_rules(lines, commit, rules, line_nr_start):
-        """ Iterates over the lines in a given list of lines and validates a given list of rules against each line """
+        """Iterates over the lines in a given list of lines and validates a given list of rules against each line"""
         all_violations = []
         line_nr = line_nr_start
         for line in lines:
@@ -58,7 +72,7 @@ class GitLinter:
 
     @staticmethod
     def _apply_commit_rules(rules, commit):
-        """ Applies a set of rules against a given commit and gitcontext """
+        """Applies a set of rules against a given commit and gitcontext"""
         all_violations = []
         for rule in rules:
             violations = rule.validate(commit)
@@ -67,7 +81,7 @@ class GitLinter:
         return all_violations
 
     def lint(self, commit):
-        """ Lint the last commit in a given git context by applying all ignore, title, body and commit rules. """
+        """Lint the last commit in a given git context by applying all ignore, title, body and commit rules."""
         LOG.debug("Linting commit %s", commit.sha or "[SHA UNKNOWN]")
         LOG.debug("Commit Object\n" + str(commit))
 
@@ -78,8 +92,7 @@ class GitLinter:
         # Skip linting if this is a special commit type that is configured to be ignored
         ignore_commit_types = ["merge", "squash", "fixup", "fixup_amend", "revert"]
         for commit_type in ignore_commit_types:
-            if getattr(commit, f"is_{commit_type}_commit") and \
-               getattr(self.config, f"ignore_{commit_type}_commits"):
+            if getattr(commit, f"is_{commit_type}_commit") and getattr(self.config, f"ignore_{commit_type}_commits"):
                 return []
 
         violations = []
@@ -95,12 +108,12 @@ class GitLinter:
         return violations
 
     def print_violations(self, violations):
-        """ Print a given set of violations to the standard error output """
+        """Print a given set of violations to the standard error output"""
         for v in violations:
             line_nr = v.line_nr if v.line_nr else "-"
             self.display.e(f"{line_nr}: {v.rule_id}", exact=True)
             self.display.ee(f"{line_nr}: {v.rule_id} {v.message}", exact=True)
             if v.content:
-                self.display.eee(f"{line_nr}: {v.rule_id} {v.message}: \"{v.content}\"", exact=True)
+                self.display.eee(f'{line_nr}: {v.rule_id} {v.message}: "{v.content}"', exact=True)
             else:
                 self.display.eee(f"{line_nr}: {v.rule_id} {v.message}", exact=True)

--- a/gitlint-core/gitlint/options.py
+++ b/gitlint-core/gitlint/options.py
@@ -6,7 +6,7 @@ from gitlint.exception import GitlintError
 
 
 def allow_none(func):
-    """ Decorator that sets option value to None if the passed value is None, otherwise calls the regular set method """
+    """Decorator that sets option value to None if the passed value is None, otherwise calls the regular set method"""
 
     def wrapped(obj, value):
         if value is None:
@@ -22,10 +22,10 @@ class RuleOptionError(GitlintError):
 
 
 class RuleOption:
-    """ Base class representing a configurable part (i.e. option) of a rule (e.g. the max-length of the title-max-line
-        rule).
-        This class should not be used directly. Instead, use on the derived classes like StrOption, IntOption to set
-        options of a particular type like int, str, etc.
+    """Base class representing a configurable part (i.e. option) of a rule (e.g. the max-length of the title-max-line
+    rule).
+    This class should not be used directly. Instead, use on the derived classes like StrOption, IntOption to set
+    options of a particular type like int, str, etc.
     """
 
     def __init__(self, name, value, description):
@@ -36,7 +36,7 @@ class RuleOption:
 
     @abstractmethod
     def set(self, value):
-        """ Validates and sets the option's value """
+        """Validates and sets the option's value"""
         pass  # pragma: no cover
 
     def __str__(self):
@@ -80,14 +80,13 @@ class BoolOption(RuleOption):
     # explicit choice to not annotate with @allow_none: Booleans must be False or True, they cannot be unset.
     def set(self, value):
         value = str(value).strip().lower()
-        if value not in ['true', 'false']:
+        if value not in ["true", "false"]:
             raise RuleOptionError(f"Option '{self.name}' must be either 'true' or 'false'")
-        self.value = value == 'true'
+        self.value = value == "true"
 
 
 class ListOption(RuleOption):
-    """ Option that is either a given list or a comma-separated string that can be split into a list when being set.
-    """
+    """Option that is either a given list or a comma-separated string that can be split into a list when being set."""
 
     @allow_none
     def set(self, value):
@@ -100,7 +99,7 @@ class ListOption(RuleOption):
 
 
 class PathOption(RuleOption):
-    """ Option that accepts either a directory or both a directory and a file. """
+    """Option that accepts either a directory or both a directory and a file."""
 
     def __init__(self, name, value, description, type="dir"):
         self.type = type
@@ -112,16 +111,17 @@ class PathOption(RuleOption):
 
         error_msg = ""
 
-        if self.type == 'dir':
+        if self.type == "dir":
             if not os.path.isdir(value):
                 error_msg = f"Option {self.name} must be an existing directory (current value: '{value}')"
-        elif self.type == 'file':
+        elif self.type == "file":
             if not os.path.isfile(value):
                 error_msg = f"Option {self.name} must be an existing file (current value: '{value}')"
-        elif self.type == 'both':
+        elif self.type == "both":
             if not os.path.isdir(value) and not os.path.isfile(value):
-                error_msg = (f"Option {self.name} must be either an existing directory or file "
-                             f"(current value: '{value}')")
+                error_msg = (
+                    f"Option {self.name} must be either an existing directory or file " f"(current value: '{value}')"
+                )
         else:
             error_msg = f"Option {self.name} type must be one of: 'file', 'dir', 'both' (current: '{self.type}')"
 
@@ -132,7 +132,6 @@ class PathOption(RuleOption):
 
 
 class RegexOption(RuleOption):
-
     @allow_none
     def set(self, value):
         try:

--- a/gitlint-core/gitlint/options.py
+++ b/gitlint-core/gitlint/options.py
@@ -76,7 +76,6 @@ class IntOption(RuleOption):
 
 
 class BoolOption(RuleOption):
-
     # explicit choice to not annotate with @allow_none: Booleans must be False or True, they cannot be unset.
     def set(self, value):
         value = str(value).strip().lower()
@@ -120,7 +119,7 @@ class PathOption(RuleOption):
         elif self.type == "both":
             if not os.path.isdir(value) and not os.path.isfile(value):
                 error_msg = (
-                    f"Option {self.name} must be either an existing directory or file " f"(current value: '{value}')"
+                    f"Option {self.name} must be either an existing directory or file (current value: '{value}')"
                 )
         else:
             error_msg = f"Option {self.name} type must be one of: 'file', 'dir', 'both' (current: '{self.type}')"

--- a/gitlint-core/gitlint/rule_finder.py
+++ b/gitlint-core/gitlint/rule_finder.py
@@ -104,9 +104,9 @@ def assert_valid_rule_class(clazz, rule_type="User-defined"):  # pylint: disable
     ):
         msg = (
             f"{rule_type} rule class '{clazz.__name__}' "
-            + f"must extend from {rules.CommitRule.__module__}.{rules.LineRule.__name__}, "
-            + f"{rules.CommitRule.__module__}.{rules.CommitRule.__name__} or "
-            + f"{rules.CommitRule.__module__}.{rules.ConfigurationRule.__name__}"
+            f"must extend from {rules.CommitRule.__module__}.{rules.LineRule.__name__}, "
+            f"{rules.CommitRule.__module__}.{rules.CommitRule.__name__} or "
+            f"{rules.CommitRule.__module__}.{rules.ConfigurationRule.__name__}"
         )
         raise rules.UserRuleError(msg)
 

--- a/gitlint-core/gitlint/rules.py
+++ b/gitlint-core/gitlint/rules.py
@@ -8,7 +8,8 @@ from gitlint.exception import GitlintError
 
 
 class Rule:
-    """ Class representing gitlint rules. """
+    """Class representing gitlint rules."""
+
     options_spec = []
     id = None
     name = None
@@ -33,48 +34,58 @@ class Rule:
         return self._log
 
     def __eq__(self, other):
-        return self.id == other.id and self.name == other.name and \
-               self.options == other.options and self.target == other.target  # noqa
+        return (
+            self.id == other.id
+            and self.name == other.name
+            and self.options == other.options
+            and self.target == other.target
+        )  # noqa
 
     def __str__(self):
         return f"{self.id} {self.name}"  # pragma: no cover
 
 
 class ConfigurationRule(Rule):
-    """ Class representing rules that can dynamically change the configuration of gitlint during runtime. """
+    """Class representing rules that can dynamically change the configuration of gitlint during runtime."""
+
     pass
 
 
 class CommitRule(Rule):
-    """ Class representing rules that act on an entire commit at once """
+    """Class representing rules that act on an entire commit at once"""
+
     pass
 
 
 class LineRule(Rule):
-    """ Class representing rules that act on a line by line basis """
+    """Class representing rules that act on a line by line basis"""
+
     pass
 
 
 class LineRuleTarget:
-    """ Base class for LineRule targets. A LineRuleTarget specifies where a given rule will be applied
+    """Base class for LineRule targets. A LineRuleTarget specifies where a given rule will be applied
     (e.g. commit message title, commit message body).
-    Each LineRule MUST have a target specified. """
+    Each LineRule MUST have a target specified."""
+
     pass
 
 
 class CommitMessageTitle(LineRuleTarget):
-    """ Target class used for rules that apply to a commit message title """
+    """Target class used for rules that apply to a commit message title"""
+
     pass
 
 
 class CommitMessageBody(LineRuleTarget):
-    """ Target class used for rules that apply to a commit message body """
+    """Target class used for rules that apply to a commit message body"""
+
     pass
 
 
 class RuleViolation:
-    """ Class representing a violation of a rule. I.e.: When a rule is broken, the rule will instantiate this class
-    to indicate how and where the rule was broken. """
+    """Class representing a violation of a rule. I.e.: When a rule is broken, the rule will instantiate this class
+    to indicate how and where the rule was broken."""
 
     def __init__(self, rule_id, message, content=None, line_nr=None):
         self.rule_id = rule_id
@@ -88,22 +99,23 @@ class RuleViolation:
         return equal
 
     def __str__(self):
-        return f"{self.line_nr}: {self.rule_id} {self.message}: \"{self.content}\""
+        return f'{self.line_nr}: {self.rule_id} {self.message}: "{self.content}"'
 
 
 class UserRuleError(GitlintError):
-    """ Error used to indicate that an error occurred while trying to load a user rule """
+    """Error used to indicate that an error occurred while trying to load a user rule"""
+
     pass
 
 
 class MaxLineLength(LineRule):
     name = "max-line-length"
     id = "R1"
-    options_spec = [IntOption('line-length', 80, "Max line length")]
+    options_spec = [IntOption("line-length", 80, "Max line length")]
     violation_message = "Line exceeds max length ({0}>{1})"
 
     def validate(self, line, _commit):
-        max_length = self.options['line-length'].value
+        max_length = self.options["line-length"].value
         if len(line) > max_length:
             return [RuleViolation(self.id, self.violation_message.format(len(line), max_length), line)]
 
@@ -130,15 +142,16 @@ class HardTab(LineRule):
 
 
 class LineMustNotContainWord(LineRule):
-    """ Violation if a line contains one of a list of words (NOTE: using a word in the list inside another word is not
-    a violation, e.g: WIPING is not a violation if 'WIP' is a word that is not allowed.) """
+    """Violation if a line contains one of a list of words (NOTE: using a word in the list inside another word is not
+    a violation, e.g: WIPING is not a violation if 'WIP' is a word that is not allowed.)"""
+
     name = "line-must-not-contain"
     id = "R5"
-    options_spec = [ListOption('words', [], "Comma separated list of words that should not be found")]
+    options_spec = [ListOption("words", [], "Comma separated list of words that should not be found")]
     violation_message = "Line contains {0}"
 
     def validate(self, line, _commit):
-        strings = self.options['words'].value
+        strings = self.options["words"].value
         violations = []
         for string in strings:
             regex = re.compile(rf"\b{string.lower()}\b", re.IGNORECASE | re.UNICODE)
@@ -163,7 +176,7 @@ class TitleMaxLength(MaxLineLength):
     name = "title-max-length"
     id = "T1"
     target = CommitMessageTitle
-    options_spec = [IntOption('line-length', 72, "Max line length")]
+    options_spec = [IntOption("line-length", 72, "Max line length")]
     violation_message = "Title exceeds max length ({0}>{1})"
 
 
@@ -180,7 +193,7 @@ class TitleTrailingPunctuation(LineRule):
     target = CommitMessageTitle
 
     def validate(self, title, _commit):
-        punctuation_marks = '?:!.,;'
+        punctuation_marks = "?:!.,;"
         for punctuation_mark in punctuation_marks:
             if title.endswith(punctuation_mark):
                 return [RuleViolation(self.id, f"Title has trailing punctuation ({punctuation_mark})", title)]
@@ -197,7 +210,7 @@ class TitleMustNotContainWord(LineMustNotContainWord):
     name = "title-must-not-contain-word"
     id = "T5"
     target = CommitMessageTitle
-    options_spec = [ListOption('words', ["WIP"], "Must not contain word")]
+    options_spec = [ListOption("words", ["WIP"], "Must not contain word")]
     violation_message = "Title contains the word '{0}' (case-insensitive)"
 
 
@@ -212,14 +225,14 @@ class TitleRegexMatches(LineRule):
     name = "title-match-regex"
     id = "T7"
     target = CommitMessageTitle
-    options_spec = [RegexOption('regex', None, "Regex the title should match")]
+    options_spec = [RegexOption("regex", None, "Regex the title should match")]
 
     def validate(self, title, _commit):
         # If no regex is specified, immediately return
-        if not self.options['regex'].value:
+        if not self.options["regex"].value:
             return
 
-        if not self.options['regex'].value.search(title):
+        if not self.options["regex"].value.search(title):
             violation_msg = f"Title does not match regex ({self.options['regex'].value.pattern})"
             return [RuleViolation(self.id, violation_msg, title)]
 
@@ -228,10 +241,10 @@ class TitleMinLength(LineRule):
     name = "title-min-length"
     id = "T8"
     target = CommitMessageTitle
-    options_spec = [IntOption('min-length', 5, "Minimum required title length")]
+    options_spec = [IntOption("min-length", 5, "Minimum required title length")]
 
     def validate(self, title, _commit):
-        min_length = self.options['min-length'].value
+        min_length = self.options["min-length"].value
         actual_length = len(title)
         if actual_length < min_length:
             violation_message = f"Title is too short ({actual_length}<{min_length})"
@@ -270,10 +283,10 @@ class BodyFirstLineEmpty(CommitRule):
 class BodyMinLength(CommitRule):
     name = "body-min-length"
     id = "B5"
-    options_spec = [IntOption('min-length', 20, "Minimum body length")]
+    options_spec = [IntOption("min-length", 20, "Minimum body length")]
 
     def validate(self, commit):
-        min_length = self.options['min-length'].value
+        min_length = self.options["min-length"].value
         body_message_no_newline = "".join([line for line in commit.message.body if line is not None])
         actual_length = len(body_message_no_newline)
         if 0 < actual_length < min_length:
@@ -284,24 +297,24 @@ class BodyMinLength(CommitRule):
 class BodyMissing(CommitRule):
     name = "body-is-missing"
     id = "B6"
-    options_spec = [BoolOption('ignore-merge-commits', True, "Ignore merge commits")]
+    options_spec = [BoolOption("ignore-merge-commits", True, "Ignore merge commits")]
 
     def validate(self, commit):
         # ignore merges when option tells us to, which may have no body
-        if self.options['ignore-merge-commits'].value and commit.is_merge_commit:
+        if self.options["ignore-merge-commits"].value and commit.is_merge_commit:
             return
-        if len(commit.message.body) < 2 or not ''.join(commit.message.body).strip():
+        if len(commit.message.body) < 2 or not "".join(commit.message.body).strip():
             return [RuleViolation(self.id, "Body message is missing", None, 3)]
 
 
 class BodyChangedFileMention(CommitRule):
     name = "body-changed-file-mention"
     id = "B7"
-    options_spec = [ListOption('files', [], "Files that need to be mentioned")]
+    options_spec = [ListOption("files", [], "Files that need to be mentioned")]
 
     def validate(self, commit):
         violations = []
-        for needs_mentioned_file in self.options['files'].value:
+        for needs_mentioned_file in self.options["files"].value:
             # if a file that we need to look out for is actually changed, then check whether it occurs
             # in the commit msg body
             if needs_mentioned_file in commit.changed_files:
@@ -314,11 +327,11 @@ class BodyChangedFileMention(CommitRule):
 class BodyRegexMatches(CommitRule):
     name = "body-match-regex"
     id = "B8"
-    options_spec = [RegexOption('regex', None, "Regex the body should match")]
+    options_spec = [RegexOption("regex", None, "Regex the body should match")]
 
     def validate(self, commit):
         # If no regex is specified, immediately return
-        if not self.options['regex'].value:
+        if not self.options["regex"].value:
             return
 
         # We intentionally ignore the first line in the body as that's the empty line after the title,
@@ -334,7 +347,7 @@ class BodyRegexMatches(CommitRule):
 
         full_body = "\n".join(body_lines)
 
-        if not self.options['regex'].value.search(full_body):
+        if not self.options["regex"].value.search(full_body):
             violation_msg = f"Body does not match regex ({self.options['regex'].value.pattern})"
             return [RuleViolation(self.id, violation_msg, None, len(commit.message.body) + 1)]
 
@@ -342,33 +355,37 @@ class BodyRegexMatches(CommitRule):
 class AuthorValidEmail(CommitRule):
     name = "author-valid-email"
     id = "M1"
-    options_spec = [RegexOption('regex', r"[^@ ]+@[^@ ]+\.[^@ ]+", "Regex that author email address should match")]
+    options_spec = [RegexOption("regex", r"[^@ ]+@[^@ ]+\.[^@ ]+", "Regex that author email address should match")]
 
     def validate(self, commit):
         # If no regex is specified, immediately return
-        if not self.options['regex'].value:
+        if not self.options["regex"].value:
             return
 
-        if commit.author_email and not self.options['regex'].value.match(commit.author_email):
+        if commit.author_email and not self.options["regex"].value.match(commit.author_email):
             return [RuleViolation(self.id, "Author email for commit is invalid", commit.author_email)]
 
 
 class IgnoreByTitle(ConfigurationRule):
     name = "ignore-by-title"
     id = "I1"
-    options_spec = [RegexOption('regex', None, "Regex matching the titles of commits this rule should apply to"),
-                    StrOption('ignore', "all", "Comma-separated list of rules to ignore")]
+    options_spec = [
+        RegexOption("regex", None, "Regex matching the titles of commits this rule should apply to"),
+        StrOption("ignore", "all", "Comma-separated list of rules to ignore"),
+    ]
 
     def apply(self, config, commit):
         # If no regex is specified, immediately return
-        if not self.options['regex'].value:
+        if not self.options["regex"].value:
             return
 
-        if self.options['regex'].value.match(commit.message.title):
-            config.ignore = self.options['ignore'].value
+        if self.options["regex"].value.match(commit.message.title):
+            config.ignore = self.options["ignore"].value
 
-            message = f"Commit title '{commit.message.title}' matches the regex " + \
-                      f"'{self.options['regex'].value.pattern}', ignoring rules: {self.options['ignore'].value}"
+            message = (
+                f"Commit title '{commit.message.title}' matches the regex "
+                f"'{self.options['regex'].value.pattern}', ignoring rules: {self.options['ignore'].value}"
+            )
 
             self.log.debug("Ignoring commit because of rule '%s': %s", self.id, message)
 
@@ -376,20 +393,24 @@ class IgnoreByTitle(ConfigurationRule):
 class IgnoreByBody(ConfigurationRule):
     name = "ignore-by-body"
     id = "I2"
-    options_spec = [RegexOption('regex', None, "Regex matching lines of the body of commits this rule should apply to"),
-                    StrOption('ignore', "all", "Comma-separated list of rules to ignore")]
+    options_spec = [
+        RegexOption("regex", None, "Regex matching lines of the body of commits this rule should apply to"),
+        StrOption("ignore", "all", "Comma-separated list of rules to ignore"),
+    ]
 
     def apply(self, config, commit):
         # If no regex is specified, immediately return
-        if not self.options['regex'].value:
+        if not self.options["regex"].value:
             return
 
         for line in commit.message.body:
-            if self.options['regex'].value.match(line):
-                config.ignore = self.options['ignore'].value
+            if self.options["regex"].value.match(line):
+                config.ignore = self.options["ignore"].value
 
-                message = f"Commit message line '{line}' matches the regex '{self.options['regex'].value.pattern}'," + \
-                          f" ignoring rules: {self.options['ignore'].value}"
+                message = (
+                    f"Commit message line '{line}' matches the regex '{self.options['regex'].value.pattern}',"
+                    f" ignoring rules: {self.options['ignore'].value}"
+                )
 
                 self.log.debug("Ignoring commit because of rule '%s': %s", self.id, message)
                 # No need to check other lines if we found a match
@@ -399,18 +420,18 @@ class IgnoreByBody(ConfigurationRule):
 class IgnoreBodyLines(ConfigurationRule):
     name = "ignore-body-lines"
     id = "I3"
-    options_spec = [RegexOption('regex', None, "Regex matching lines of the body that should be ignored")]
+    options_spec = [RegexOption("regex", None, "Regex matching lines of the body that should be ignored")]
 
     def apply(self, _, commit):
         # If no regex is specified, immediately return
-        if not self.options['regex'].value:
+        if not self.options["regex"].value:
             return
 
         new_body = []
         for line in commit.message.body:
-            if self.options['regex'].value.match(line):
+            if self.options["regex"].value.match(line):
                 debug_msg = "Ignoring line '%s' because it matches '%s'"
-                self.log.debug(debug_msg, line, self.options['regex'].value.pattern)
+                self.log.debug(debug_msg, line, self.options["regex"].value.pattern)
             else:
                 new_body.append(line)
 
@@ -421,19 +442,23 @@ class IgnoreBodyLines(ConfigurationRule):
 class IgnoreByAuthorName(ConfigurationRule):
     name = "ignore-by-author-name"
     id = "I4"
-    options_spec = [RegexOption('regex', None, "Regex matching the author name of commits this rule should apply to"),
-                    StrOption('ignore', "all", "Comma-separated list of rules to ignore")]
+    options_spec = [
+        RegexOption("regex", None, "Regex matching the author name of commits this rule should apply to"),
+        StrOption("ignore", "all", "Comma-separated list of rules to ignore"),
+    ]
 
     def apply(self, config, commit):
         # If no regex is specified, immediately return
-        if not self.options['regex'].value:
+        if not self.options["regex"].value:
             return
 
-        if self.options['regex'].value.match(commit.author_name):
-            config.ignore = self.options['ignore'].value
+        if self.options["regex"].value.match(commit.author_name):
+            config.ignore = self.options["ignore"].value
 
-            message = (f"Commit Author Name '{commit.author_name}' matches the regex "
-                       f"'{self.options['regex'].value.pattern}', ignoring rules: {self.options['ignore'].value}")
+            message = (
+                f"Commit Author Name '{commit.author_name}' matches the regex "
+                f"'{self.options['regex'].value.pattern}', ignoring rules: {self.options['ignore'].value}"
+            )
 
             self.log.debug("Ignoring commit because of rule '%s': %s", self.id, message)
             # No need to check other lines if we found a match

--- a/gitlint-core/gitlint/shell.py
+++ b/gitlint-core/gitlint/shell.py
@@ -1,4 +1,3 @@
-
 """
 This module implements a shim for the 'sh' library, mainly for use on Windows (sh is not supported on Windows).
 We might consider removing the 'sh' dependency altogether in the future, but 'sh' does provide a few
@@ -10,26 +9,28 @@ from gitlint.utils import USE_SH_LIB, DEFAULT_ENCODING
 
 
 def shell(cmd):
-    """ Convenience function that opens a given command in a shell. Does not use 'sh' library. """
+    """Convenience function that opens a given command in a shell. Does not use 'sh' library."""
     with subprocess.Popen(cmd, shell=True) as p:
         p.communicate()
 
 
 if USE_SH_LIB:
     from sh import git  # pylint: disable=unused-import,import-error
+
     # import exceptions separately, this makes it a little easier to mock them out in the unit tests
     from sh import CommandNotFound, ErrorReturnCode  # pylint: disable=import-error
 else:
 
     class CommandNotFound(Exception):
-        """ Exception indicating a command was not found during execution """
+        """Exception indicating a command was not found during execution"""
+
         pass
 
     class ShResult:
-        """ Result wrapper class. We use this to more easily migrate from using https://amoffat.github.io/sh/ to using
-        the builtin subprocess module """
+        """Result wrapper class. We use this to more easily migrate from using https://amoffat.github.io/sh/ to using
+        the builtin subprocess module"""
 
-        def __init__(self, full_cmd, stdout, stderr='', exitcode=0):
+        def __init__(self, full_cmd, stdout, stderr="", exitcode=0):
             self.full_cmd = full_cmd
             self.stdout = stdout
             self.stderr = stderr
@@ -39,22 +40,23 @@ else:
             return self.stdout
 
     class ErrorReturnCode(ShResult, Exception):
-        """ ShResult subclass for unexpected results (acts as an exception). """
+        """ShResult subclass for unexpected results (acts as an exception)."""
+
         pass
 
     def git(*command_parts, **kwargs):
-        """ Git shell wrapper.
+        """Git shell wrapper.
         Implemented as separate function here, so we can do a 'sh' style imports:
         `from shell import git`
         """
-        args = ['git'] + list(command_parts)
+        args = ["git"] + list(command_parts)
         return _exec(*args, **kwargs)
 
     def _exec(*args, **kwargs):
         pipe = subprocess.PIPE
-        popen_kwargs = {'stdout': pipe, 'stderr': pipe, 'shell': kwargs.get('_tty_out', False)}
-        if '_cwd' in kwargs:
-            popen_kwargs['cwd'] = kwargs['_cwd']
+        popen_kwargs = {"stdout": pipe, "stderr": pipe, "shell": kwargs.get("_tty_out", False)}
+        if "_cwd" in kwargs:
+            popen_kwargs["cwd"] = kwargs["_cwd"]
 
         try:
             with subprocess.Popen(args, **popen_kwargs) as p:
@@ -65,10 +67,10 @@ else:
         exit_code = p.returncode
         stdout = result[0].decode(DEFAULT_ENCODING)
         stderr = result[1]  # 'sh' does not decode the stderr bytes to unicode
-        full_cmd = '' if args is None else ' '.join(args)
+        full_cmd = "" if args is None else " ".join(args)
 
         # If not _ok_code is specified, then only a 0 exit code is allowed
-        ok_exit_codes = kwargs.get('_ok_code', [0])
+        ok_exit_codes = kwargs.get("_ok_code", [0])
 
         if exit_code in ok_exit_codes:
             return ShResult(full_cmd, stdout, stderr, exit_code)

--- a/gitlint-core/gitlint/tests/base.py
+++ b/gitlint-core/gitlint/tests/base.py
@@ -18,7 +18,7 @@ from gitlint.utils import LOG_FORMAT, DEFAULT_ENCODING
 
 
 class BaseTestCase(unittest.TestCase):
-    """ Base class of which all gitlint unit test classes are derived. Provides a number of convenience methods. """
+    """Base class of which all gitlint unit test classes are derived. Provides a number of convenience methods."""
 
     # In case of assert failures, print the full error message
     maxDiff = None
@@ -30,13 +30,13 @@ class BaseTestCase(unittest.TestCase):
     def setUp(self):
         self.logcapture = LogCapture()
         self.logcapture.setFormatter(logging.Formatter(LOG_FORMAT))
-        logging.getLogger('gitlint').setLevel(logging.DEBUG)
-        logging.getLogger('gitlint').handlers = [self.logcapture]
+        logging.getLogger("gitlint").setLevel(logging.DEBUG)
+        logging.getLogger("gitlint").handlers = [self.logcapture]
 
         # Make sure we don't propagate anything to child loggers, we need to do this explicitly here
         # because if you run a specific test file like test_lint.py, we won't be calling the setupLogging() method
         # in gitlint.cli that normally takes care of this
-        logging.getLogger('gitlint').propagate = False
+        logging.getLogger("gitlint").propagate = False
 
     @staticmethod
     @contextlib.contextmanager
@@ -57,7 +57,7 @@ class BaseTestCase(unittest.TestCase):
 
     @staticmethod
     def get_sample(filename=""):
-        """ Read and return the contents of a file in gitlint/tests/samples """
+        """Read and return the contents of a file in gitlint/tests/samples"""
         sample_path = BaseTestCase.get_sample_path(filename)
         with io.open(sample_path, encoding=DEFAULT_ENCODING) as content:
             sample = content.read()
@@ -65,15 +65,15 @@ class BaseTestCase(unittest.TestCase):
 
     @staticmethod
     def patch_input(side_effect):
-        """ Patches the built-in input() with a provided side-effect """
+        """Patches the built-in input() with a provided side-effect"""
         module_path = "builtins.input"
         patched_module = patch(module_path, side_effect=side_effect)
         return patched_module
 
     @staticmethod
     def get_expected(filename="", variable_dict=None):
-        """ Utility method to read an expected file from gitlint/tests/expected and return it as a string.
-        Optionally replace template variables specified by variable_dict. """
+        """Utility method to read an expected file from gitlint/tests/expected and return it as a string.
+        Optionally replace template variables specified by variable_dict."""
         expected_path = os.path.join(BaseTestCase.EXPECTED_DIR, filename)
         with io.open(expected_path, encoding=DEFAULT_ENCODING) as content:
             expected = content.read()
@@ -87,8 +87,8 @@ class BaseTestCase(unittest.TestCase):
         return os.path.join(BaseTestCase.SAMPLES_DIR, "user_rules")
 
     @staticmethod
-    def gitcontext(commit_msg_str, changed_files=None, ):
-        """ Utility method to easily create gitcontext objects based on a given commit msg string and an optional set of
+    def gitcontext(commit_msg_str, changed_files=None):
+        """Utility method to easily create gitcontext objects based on a given commit msg string and an optional set of
         changed files"""
         with patch("gitlint.git.git_commentchar") as comment_char:
             comment_char.return_value = "#"
@@ -100,7 +100,7 @@ class BaseTestCase(unittest.TestCase):
 
     @staticmethod
     def gitcommit(commit_msg_str, changed_files=None, **kwargs):
-        """ Utility method to easily create git commit given a commit msg string and an optional set of changed files"""
+        """Utility method to easily create git commit given a commit msg string and an optional set of changed files"""
         gitcontext = BaseTestCase.gitcontext(commit_msg_str, changed_files)
         commit = gitcontext.commits[-1]
         for attr, value in kwargs.items():
@@ -108,31 +108,31 @@ class BaseTestCase(unittest.TestCase):
         return commit
 
     def assert_logged(self, expected):
-        """ Asserts that the logs match an expected string or list.
-            This method knows how to compare a passed list of log lines as well as a newline concatenated string
-            of all loglines. """
+        """Asserts that the logs match an expected string or list.
+        This method knows how to compare a passed list of log lines as well as a newline concatenated string
+        of all loglines."""
         if isinstance(expected, list):
             self.assertListEqual(self.logcapture.messages, expected)
         else:
             self.assertEqual("\n".join(self.logcapture.messages), expected)
 
     def assert_log_contains(self, line):
-        """ Asserts that a certain line is in the logs """
+        """Asserts that a certain line is in the logs"""
         self.assertIn(line, self.logcapture.messages)
 
     def assertRaisesRegex(self, expected_exception, expected_regex, *args, **kwargs):
-        """ Pass-through method to unittest.TestCase.assertRaisesRegex that applies re.escape() to the passed
-            `expected_regex`. This is useful to automatically escape all file paths that might be present in the regex.
+        """Pass-through method to unittest.TestCase.assertRaisesRegex that applies re.escape() to the passed
+        `expected_regex`. This is useful to automatically escape all file paths that might be present in the regex.
         """
         return super().assertRaisesRegex(expected_exception, re.escape(expected_regex), *args, **kwargs)
 
     def clearlog(self):
-        """ Clears the log capture """
+        """Clears the log capture"""
         self.logcapture.clear()
 
     @contextlib.contextmanager
     def assertRaisesMessage(self, expected_exception, expected_msg):  # pylint: disable=invalid-name
-        """ Asserts an exception has occurred with a given error message """
+        """Asserts an exception has occurred with a given error message"""
         try:
             yield
         except expected_exception as exc:
@@ -149,10 +149,10 @@ class BaseTestCase(unittest.TestCase):
         raise self.fail(f"Expected to raise {expected_exception.__name__}, didn't get an exception at all")
 
     def object_equality_test(self, obj, attr_list, ctor_kwargs=None):
-        """ Helper function to easily implement object equality tests.
-            Creates an object clone for every passed attribute and checks for (in)equality
-            of the original object with the clone based on those attributes' values.
-            This function assumes all attributes in `attr_list` can be passed to the ctor of `obj.__class__`.
+        """Helper function to easily implement object equality tests.
+        Creates an object clone for every passed attribute and checks for (in)equality
+        of the original object with the clone based on those attributes' values.
+        This function assumes all attributes in `attr_list` can be passed to the ctor of `obj.__class__`.
         """
         if not ctor_kwargs:
             ctor_kwargs = {}
@@ -178,7 +178,7 @@ class BaseTestCase(unittest.TestCase):
 
 
 class LogCapture(logging.Handler):
-    """ Mock logging handler used to capture any log messages during tests."""
+    """Mock logging handler used to capture any log messages during tests."""
 
     def __init__(self, *args, **kwargs):
         logging.Handler.__init__(self, *args, **kwargs)

--- a/gitlint-core/gitlint/tests/cli/test_cli.py
+++ b/gitlint-core/gitlint/tests/cli/test_cli.py
@@ -33,7 +33,7 @@ class CLITests(BaseTestCase):
         self.cli = CliRunner()
 
         # Patch gitlint.cli.git_version() so that we don't have to patch it separately in every test
-        self.git_version_path = patch('gitlint.cli.git_version')
+        self.git_version_path = patch("gitlint.cli.git_version")
         cli.git_version = self.git_version_path.start()
         cli.git_version.return_value = "git version 1.2.3"
 
@@ -42,171 +42,182 @@ class CLITests(BaseTestCase):
 
     @staticmethod
     def get_system_info_dict():
-        """ Returns a dict with items related to system values logged by `gitlint --debug` """
-        return {'platform': platform.platform(), "python_version": sys.version, 'gitlint_version': __version__,
-                'GITLINT_USE_SH_LIB': BaseTestCase.GITLINT_USE_SH_LIB, 'target': os.path.realpath(os.getcwd()),
-                'DEFAULT_ENCODING': DEFAULT_ENCODING}
+        """Returns a dict with items related to system values logged by `gitlint --debug`"""
+        return {
+            "platform": platform.platform(),
+            "python_version": sys.version,
+            "gitlint_version": __version__,
+            "GITLINT_USE_SH_LIB": BaseTestCase.GITLINT_USE_SH_LIB,
+            "target": os.path.realpath(os.getcwd()),
+            "DEFAULT_ENCODING": DEFAULT_ENCODING,
+        }
 
     def test_version(self):
-        """ Test for --version option """
+        """Test for --version option"""
         result = self.cli.invoke(cli.cli, ["--version"])
         self.assertEqual(result.output.split("\n")[0], f"cli, version {__version__}")
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
-    @patch('gitlint.git.sh')
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
+    @patch("gitlint.git.sh")
     def test_lint(self, sh, _):
-        """ Test for basic simple linting functionality """
+        """Test for basic simple linting functionality"""
         sh.git.side_effect = [
             "6f29bf81a8322a04071bb794666e48c443a90360",
-            "test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
-            "commït-title\n\ncommït-body",
+            "test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "commït-title\n\ncommït-body",
             "#",  # git config --get core.commentchar
             "commit-1-branch-1\ncommit-1-branch-2\n",
-            "file1.txt\npåth/to/file2.txt\n"
+            "file1.txt\npåth/to/file2.txt\n",
         ]
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli)
-            self.assertEqual(stderr.getvalue(), u'3: B5 Body message is too short (11<20): "commït-body"\n')
+            self.assertEqual(stderr.getvalue(), '3: B5 Body message is too short (11<20): "commït-body"\n')
             self.assertEqual(result.exit_code, 1)
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
-    @patch('gitlint.git.sh')
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
+    @patch("gitlint.git.sh")
     def test_lint_multiple_commits(self, sh, _):
-        """ Test for --commits option """
+        """Test for --commits option"""
 
         sh.git.side_effect = [
-            "6f29bf81a8322a04071bb794666e48c443a90360\n" +  # git rev-list <SHA>
-            "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n" +
+            "6f29bf81a8322a04071bb794666e48c443a90360\n"
+            "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n"  # git rev-list <SHA>
             "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
             # git log --pretty <FORMAT> <SHA>
-            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
-            "commït-title1\n\ncommït-body1",
-            "#",                                           # git config --get core.commentchar
-            "commit-1-branch-1\ncommit-1-branch-2\n",      # git branch --contains <sha>
-            "commit-1/file-1\ncommit-1/file-2\n",          # git diff-tree
-                                                            # git log --pretty <FORMAT> <SHA>
-            "test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 +0100\x00åbc\n"
-            "commït-title2\n\ncommït-body2",
-            "commit-2-branch-1\ncommit-2-branch-2\n",      # git branch --contains <sha>
-            "commit-2/file-1\ncommit-2/file-2\n",          # git diff-tree
-                                                            # git log --pretty <FORMAT> <SHA>
-            "test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 +0100\x00åbc\n"
-            "commït-title3\n\ncommït-body3",
-            "commit-3-branch-1\ncommit-3-branch-2\n",      # git branch --contains <sha>
-            "commit-3/file-1\ncommit-3/file-2\n",          # git diff-tree
+            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "commït-title1\n\ncommït-body1",
+            "#",  # git config --get core.commentchar
+            "commit-1-branch-1\ncommit-1-branch-2\n",  # git branch --contains <sha>
+            "commit-1/file-1\ncommit-1/file-2\n",  # git diff-tree
+            # git log --pretty <FORMAT> <SHA>
+            "test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 +0100\x00åbc\n" "commït-title2\n\ncommït-body2",
+            "commit-2-branch-1\ncommit-2-branch-2\n",  # git branch --contains <sha>
+            "commit-2/file-1\ncommit-2/file-2\n",  # git diff-tree
+            # git log --pretty <FORMAT> <SHA>
+            "test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 +0100\x00åbc\n" "commït-title3\n\ncommït-body3",
+            "commit-3-branch-1\ncommit-3-branch-2\n",  # git branch --contains <sha>
+            "commit-3/file-1\ncommit-3/file-2\n",  # git diff-tree
         ]
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--commits", "foo...bar"])
             self.assertEqual(stderr.getvalue(), self.get_expected("cli/test_cli/test_lint_multiple_commits_1"))
             self.assertEqual(result.exit_code, 3)
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
-    @patch('gitlint.git.sh')
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
+    @patch("gitlint.git.sh")
     def test_lint_multiple_commits_config(self, sh, _):
-        """ Test for --commits option where some of the commits have gitlint config in the commit message """
+        """Test for --commits option where some of the commits have gitlint config in the commit message"""
 
         # Note that the second commit title has a trailing period that is being ignored by gitlint-ignore: T3
         sh.git.side_effect = [
-            "6f29bf81a8322a04071bb794666e48c443a90360\n" +  # git rev-list <SHA>
-            "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n" +
-            "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
+            "6f29bf81a8322a04071bb794666e48c443a90360\n"
+            + "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n"  # git rev-list <SHA>
+            + "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
             # git log --pretty <FORMAT> <SHA>
-            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
-            "commït-title1\n\ncommït-body1",
-            "#",                                           # git config --get core.commentchar
-            "commit-1-branch-1\ncommit-1-branch-2\n",      # git branch --contains <sha>
-            "commit-1/file-1\ncommit-1/file-2\n",          # git diff-tree
-                                                            # git log --pretty <FORMAT> <SHA>
+            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "commït-title1\n\ncommït-body1",
+            "#",  # git config --get core.commentchar
+            "commit-1-branch-1\ncommit-1-branch-2\n",  # git branch --contains <sha>
+            "commit-1/file-1\ncommit-1/file-2\n",  # git diff-tree
+            # git log --pretty <FORMAT> <SHA>
             "test åuthor2\x00test-email2@föo.com\x002016-12-04 15:28:15 +0100\x00åbc\n"
             "commït-title2.\n\ncommït-body2\ngitlint-ignore: T3\n",
-            "commit-2-branch-1\ncommit-2-branch-2\n",      # git branch --contains <sha>
-            "commit-2/file-1\ncommit-2/file-2\n",          # git diff-tree
-                                                            # git log --pretty <FORMAT> <SHA>
+            "commit-2-branch-1\ncommit-2-branch-2\n",  # git branch --contains <sha>
+            "commit-2/file-1\ncommit-2/file-2\n",  # git diff-tree
+            # git log --pretty <FORMAT> <SHA>
             "test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 +0100\x00åbc\n"
             "commït-title3.\n\ncommït-body3",
-            "commit-3-branch-1\ncommit-3-branch-2\n",      # git branch --contains <sha>
-            "commit-3/file-1\ncommit-3/file-2\n",          # git diff-tree
+            "commit-3-branch-1\ncommit-3-branch-2\n",  # git branch --contains <sha>
+            "commit-3/file-1\ncommit-3/file-2\n",  # git diff-tree
         ]
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--commits", "foo...bar"])
             # We expect that the second commit has no failures because of 'gitlint-ignore: T3' in its commit msg body
             self.assertEqual(stderr.getvalue(), self.get_expected("cli/test_cli/test_lint_multiple_commits_config_1"))
             self.assertEqual(result.exit_code, 3)
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
-    @patch('gitlint.git.sh')
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
+    @patch("gitlint.git.sh")
     def test_lint_multiple_commits_configuration_rules(self, sh, _):
-        """ Test for --commits option where where we have configured gitlint to ignore certain rules for certain commits
-        """
+        """Test for --commits option where where we have configured gitlint to ignore certain rules for certain commits"""
 
         # Note that the second commit
         sh.git.side_effect = [
-            "6f29bf81a8322a04071bb794666e48c443a90360\n" +  # git rev-list <SHA>
-            "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n" +
+            "6f29bf81a8322a04071bb794666e48c443a90360\n"
+            "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n"  # git rev-list <SHA>
             "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
             # git log --pretty <FORMAT> <SHA>
-            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
-            "commït-title1\n\ncommït-body1",
-            "#",                                           # git config --get core.commentchar
-            "commit-1-branch-1\ncommit-1-branch-2\n",      # git branch --contains <sha>
-            "commit-1/file-1\ncommit-1/file-2\n",          # git diff-tree
-                                                            # git log --pretty <FORMAT> <SHA>
+            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "commït-title1\n\ncommït-body1",
+            "#",  # git config --get core.commentchar
+            "commit-1-branch-1\ncommit-1-branch-2\n",  # git branch --contains <sha>
+            "commit-1/file-1\ncommit-1/file-2\n",  # git diff-tree
+            # git log --pretty <FORMAT> <SHA>
             "test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 +0100\x00åbc\n"
             # Normally T3 violation (trailing punctuation), but this commit is ignored because of
             # config below
             "commït-title2.\n\ncommït-body2\n",
-            "commit-2-branch-1\ncommit-2-branch-2\n",      # git branch --contains <sha>
-            "commit-2/file-1\ncommit-2/file-2\n",          # git diff-tree
-                                                            # git log --pretty <FORMAT> <SHA>
+            "commit-2-branch-1\ncommit-2-branch-2\n",  # git branch --contains <sha>
+            "commit-2/file-1\ncommit-2/file-2\n",  # git diff-tree
+            # git log --pretty <FORMAT> <SHA>
             "test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 +0100\x00åbc\n"
             # Normally T1 and B5 violations, now only T1 because we're ignoring B5 in config below
             "commït-title3.\n\ncommït-body3 foo",
-            "commit-3-branch-1\ncommit-3-branch-2\n",      # git branch --contains <sha>
-            "commit-3/file-1\ncommit-3/file-2\n",          # git diff-tree
+            "commit-3-branch-1\ncommit-3-branch-2\n",  # git branch --contains <sha>
+            "commit-3/file-1\ncommit-3/file-2\n",  # git diff-tree
         ]
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
-            result = self.cli.invoke(cli.cli, ["--commits", "foo...bar", "-c", "I1.regex=^commït-title2(.*)",
-                                               "-c", "I2.regex=^commït-body3(.*)", "-c", "I2.ignore=B5"])
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
+            result = self.cli.invoke(
+                cli.cli,
+                [
+                    "--commits",
+                    "foo...bar",
+                    "-c",
+                    "I1.regex=^commït-title2(.*)",
+                    "-c",
+                    "I2.regex=^commït-body3(.*)",
+                    "-c",
+                    "I2.ignore=B5",
+                ],
+            )
             # We expect that the second commit has no failures because of it matching against I1.regex
             # Because we do test for the 3th commit to return violations, this test also ensures that a unique
             # config object is passed to each commit lint call
-            expected = ("Commit 6f29bf81a8:\n"
-                        u'3: B5 Body message is too short (12<20): "commït-body1"\n\n'
-                        "Commit 4da2656b0d:\n"
-                        u'1: T3 Title has trailing punctuation (.): "commït-title3."\n')
+            expected = (
+                "Commit 6f29bf81a8:\n"
+                '3: B5 Body message is too short (12<20): "commït-body1"\n\n'
+                "Commit 4da2656b0d:\n"
+                '1: T3 Title has trailing punctuation (.): "commït-title3."\n'
+            )
             self.assertEqual(stderr.getvalue(), expected)
             self.assertEqual(result.exit_code, 2)
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
-    @patch('gitlint.git.sh')
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
+    @patch("gitlint.git.sh")
     def test_lint_commit(self, sh, _):
-        """ Test for --commit option """
+        """Test for --commit option"""
 
         sh.git.side_effect = [
             "6f29bf81a8322a04071bb794666e48c443a90360\n",  # git log -1 <SHA> --pretty=%H
             # git log --pretty <FORMAT> <SHA>
             "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
             "WIP: commït-title1\n\ncommït-body1",
-            "#",                                           # git config --get core.commentchar
-            "commit-1-branch-1\ncommit-1-branch-2\n",      # git branch --contains <sha>
-            "commit-1/file-1\ncommit-1/file-2\n",          # git diff-tree
+            "#",  # git config --get core.commentchar
+            "commit-1-branch-1\ncommit-1-branch-2\n",  # git branch --contains <sha>
+            "commit-1/file-1\ncommit-1/file-2\n",  # git diff-tree
         ]
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--commit", "foo"])
             self.assertEqual(result.output, "")
 
             self.assertEqual(stderr.getvalue(), self.get_expected("cli/test_cli/test_lint_commit_1"))
             self.assertEqual(result.exit_code, 2)
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
-    @patch('gitlint.git.sh')
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
+    @patch("gitlint.git.sh")
     def test_lint_commit_negative(self, sh, _):
-        """ Negative test for --commit option """
+        """Negative test for --commit option"""
 
         # Try using --commit and --commits at the same time (not allowed)
         result = self.cli.invoke(cli.cli, ["--commit", "foo", "--commits", "foo...bar"])
@@ -214,299 +225,297 @@ class CLITests(BaseTestCase):
         self.assertEqual(result.output, expected_output)
         self.assertEqual(result.exit_code, self.USAGE_ERROR_CODE)
 
-    @patch('gitlint.cli.get_stdin_data', return_value=u'WIP: tïtle \n')
+    @patch("gitlint.cli.get_stdin_data", return_value="WIP: tïtle \n")
     def test_input_stream(self, _):
-        """ Test for linting when a message is passed via stdin """
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        """Test for linting when a message is passed via stdin"""
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli)
             self.assertEqual(stderr.getvalue(), self.get_expected("cli/test_cli/test_input_stream_1"))
             self.assertEqual(result.exit_code, 3)
             self.assertEqual(result.output, "")
 
-    @patch('gitlint.cli.get_stdin_data', return_value=u'WIP: tïtle \n')
+    @patch("gitlint.cli.get_stdin_data", return_value="WIP: tïtle \n")
     def test_input_stream_debug(self, _):
-        """ Test for linting when a message is passed via stdin, and debug is enabled.
-            This tests specifically that git commit meta is not fetched when not passing --staged """
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        """Test for linting when a message is passed via stdin, and debug is enabled.
+        This tests specifically that git commit meta is not fetched when not passing --staged"""
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--debug"])
             self.assertEqual(stderr.getvalue(), self.get_expected("cli/test_cli/test_input_stream_debug_1"))
             self.assertEqual(result.exit_code, 3)
             self.assertEqual(result.output, "")
             expected_kwargs = self.get_system_info_dict()
-            expected_logs = self.get_expected('cli/test_cli/test_input_stream_debug_2', expected_kwargs)
+            expected_logs = self.get_expected("cli/test_cli/test_input_stream_debug_2", expected_kwargs)
             self.assert_logged(expected_logs)
 
-    @patch('gitlint.cli.get_stdin_data', return_value="Should be ignored\n")
-    @patch('gitlint.git.sh')
+    @patch("gitlint.cli.get_stdin_data", return_value="Should be ignored\n")
+    @patch("gitlint.git.sh")
     def test_lint_ignore_stdin(self, sh, stdin_data):
-        """ Test for ignoring stdin when --ignore-stdin flag is enabled"""
+        """Test for ignoring stdin when --ignore-stdin flag is enabled"""
         sh.git.side_effect = [
             "6f29bf81a8322a04071bb794666e48c443a90360",
-            "test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
-            "commït-title\n\ncommït-body",
-            "#",                                       # git config --get core.commentchar
+            "test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "commït-title\n\ncommït-body",
+            "#",  # git config --get core.commentchar
             "commit-1-branch-1\ncommit-1-branch-2\n",  # git branch --contains <sha>
-            "file1.txt\npåth/to/file2.txt\n"           # git diff-tree
+            "file1.txt\npåth/to/file2.txt\n",  # git diff-tree
         ]
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--ignore-stdin"])
-            self.assertEqual(stderr.getvalue(), u'3: B5 Body message is too short (11<20): "commït-body"\n')
+            self.assertEqual(stderr.getvalue(), '3: B5 Body message is too short (11<20): "commït-body"\n')
             self.assertEqual(result.exit_code, 1)
 
         # Assert that we didn't even try to get the stdin data
         self.assertEqual(stdin_data.call_count, 0)
 
-    @patch('gitlint.cli.get_stdin_data', return_value=u'WIP: tïtle \n')
-    @patch('arrow.now', return_value=arrow.get("2020-02-19T12:18:46.675182+01:00"))
-    @patch('gitlint.git.sh')
+    @patch("gitlint.cli.get_stdin_data", return_value="WIP: tïtle \n")
+    @patch("arrow.now", return_value=arrow.get("2020-02-19T12:18:46.675182+01:00"))
+    @patch("gitlint.git.sh")
     def test_lint_staged_stdin(self, sh, _, __):
-        """ Test for ignoring stdin when --ignore-stdin flag is enabled"""
+        """Test for ignoring stdin when --ignore-stdin flag is enabled"""
 
         sh.git.side_effect = [
-            "#",                                         # git config --get core.commentchar
-            "föo user\n",                                # git config --get user.name
-            "föo@bar.com\n",                             # git config --get user.email
-            "my-branch\n",                               # git rev-parse --abbrev-ref HEAD (=current branch)
-            "commit-1/file-1\ncommit-1/file-2\n",        # git diff-tree
+            "#",  # git config --get core.commentchar
+            "föo user\n",  # git config --get user.name
+            "föo@bar.com\n",  # git config --get user.email
+            "my-branch\n",  # git rev-parse --abbrev-ref HEAD (=current branch)
+            "commit-1/file-1\ncommit-1/file-2\n",  # git diff-tree
         ]
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--debug", "--staged"])
             self.assertEqual(stderr.getvalue(), self.get_expected("cli/test_cli/test_lint_staged_stdin_1"))
             self.assertEqual(result.exit_code, 3)
             self.assertEqual(result.output, "")
 
             expected_kwargs = self.get_system_info_dict()
-            expected_logs = self.get_expected('cli/test_cli/test_lint_staged_stdin_2', expected_kwargs)
+            expected_logs = self.get_expected("cli/test_cli/test_lint_staged_stdin_2", expected_kwargs)
             self.assert_logged(expected_logs)
 
-    @patch('arrow.now', return_value=arrow.get("2020-02-19T12:18:46.675182+01:00"))
-    @patch('gitlint.git.sh')
+    @patch("arrow.now", return_value=arrow.get("2020-02-19T12:18:46.675182+01:00"))
+    @patch("gitlint.git.sh")
     def test_lint_staged_msg_filename(self, sh, _):
-        """ Test for ignoring stdin when --ignore-stdin flag is enabled"""
+        """Test for ignoring stdin when --ignore-stdin flag is enabled"""
 
         sh.git.side_effect = [
-            "#",                                         # git config --get core.commentchar
-            "föo user\n",                                # git config --get user.name
-            "föo@bar.com\n",                             # git config --get user.email
-            "my-branch\n",                               # git rev-parse --abbrev-ref HEAD (=current branch)
-            "commit-1/file-1\ncommit-1/file-2\n",        # git diff-tree
+            "#",  # git config --get core.commentchar
+            "föo user\n",  # git config --get user.name
+            "föo@bar.com\n",  # git config --get user.email
+            "my-branch\n",  # git rev-parse --abbrev-ref HEAD (=current branch)
+            "commit-1/file-1\ncommit-1/file-2\n",  # git diff-tree
         ]
 
         with self.tempdir() as tmpdir:
             msg_filename = os.path.join(tmpdir, "msg")
-            with io.open(msg_filename, 'w', encoding=DEFAULT_ENCODING) as f:
+            with io.open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
                 f.write("WIP: msg-filename tïtle\n")
 
-            with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+            with patch("gitlint.display.stderr", new=StringIO()) as stderr:
                 result = self.cli.invoke(cli.cli, ["--debug", "--staged", "--msg-filename", msg_filename])
                 self.assertEqual(stderr.getvalue(), self.get_expected("cli/test_cli/test_lint_staged_msg_filename_1"))
                 self.assertEqual(result.exit_code, 2)
                 self.assertEqual(result.output, "")
 
                 expected_kwargs = self.get_system_info_dict()
-                expected_logs = self.get_expected('cli/test_cli/test_lint_staged_msg_filename_2', expected_kwargs)
+                expected_logs = self.get_expected("cli/test_cli/test_lint_staged_msg_filename_2", expected_kwargs)
                 self.assert_logged(expected_logs)
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
     def test_lint_staged_negative(self, _):
         result = self.cli.invoke(cli.cli, ["--staged"])
         self.assertEqual(result.exit_code, self.USAGE_ERROR_CODE)
-        self.assertEqual(result.output, ("Error: The 'staged' option (--staged) can only be used when using "
-                                         "'--msg-filename' or when piping data to gitlint via stdin.\n"))
+        self.assertEqual(
+            result.output,
+            (
+                "Error: The 'staged' option (--staged) can only be used when using "
+                "'--msg-filename' or when piping data to gitlint via stdin.\n"
+            ),
+        )
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
-    @patch('gitlint.git.sh')
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
+    @patch("gitlint.git.sh")
     def test_fail_without_commits(self, sh, _):
-        """ Test for --debug option """
+        """Test for --debug option"""
 
-        sh.git.side_effect = [
-            "",  # First invocation of git rev-list
-            ""   # Second invocation of git rev-list
-        ]
+        sh.git.side_effect = ["", ""]  # First 2 invocations of git rev-list
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             # By default, gitlint should silently exit with code GITLINT_SUCCESS when there are no commits
             result = self.cli.invoke(cli.cli, ["--commits", "foo..bar"])
             self.assertEqual(stderr.getvalue(), "")
             self.assertEqual(result.exit_code, cli.GITLINT_SUCCESS)
-            self.assert_log_contains("DEBUG: gitlint.cli No commits in range \"foo..bar\"")
+            self.assert_log_contains('DEBUG: gitlint.cli No commits in range "foo..bar"')
 
             # When --fail-without-commits is set, gitlint should hard fail with code USAGE_ERROR_CODE
             self.clearlog()
             result = self.cli.invoke(cli.cli, ["--commits", "foo..bar", "--fail-without-commits"])
             self.assertEqual(result.output, 'Error: No commits in range "foo..bar"\n')
             self.assertEqual(result.exit_code, self.USAGE_ERROR_CODE)
-            self.assert_log_contains("DEBUG: gitlint.cli No commits in range \"foo..bar\"")
+            self.assert_log_contains('DEBUG: gitlint.cli No commits in range "foo..bar"')
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
     def test_msg_filename(self, _):
         expected_output = "3: B6 Body message is missing\n"
 
         with self.tempdir() as tmpdir:
             msg_filename = os.path.join(tmpdir, "msg")
-            with io.open(msg_filename, 'w', encoding=DEFAULT_ENCODING) as f:
+            with io.open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
                 f.write("Commït title\n")
 
-            with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+            with patch("gitlint.display.stderr", new=StringIO()) as stderr:
                 result = self.cli.invoke(cli.cli, ["--msg-filename", msg_filename])
                 self.assertEqual(stderr.getvalue(), expected_output)
                 self.assertEqual(result.exit_code, 1)
                 self.assertEqual(result.output, "")
 
-    @patch('gitlint.cli.get_stdin_data', return_value="WIP: tïtle \n")
+    @patch("gitlint.cli.get_stdin_data", return_value="WIP: tïtle \n")
     def test_silent_mode(self, _):
-        """ Test for --silent option """
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        """Test for --silent option"""
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--silent"])
             self.assertEqual(stderr.getvalue(), "")
             self.assertEqual(result.exit_code, 3)
             self.assertEqual(result.output, "")
 
-    @patch('gitlint.cli.get_stdin_data', return_value="WIP: tïtle \n")
+    @patch("gitlint.cli.get_stdin_data", return_value="WIP: tïtle \n")
     def test_verbosity(self, _):
-        """ Test for --verbosity option """
+        """Test for --verbosity option"""
         # We only test -v and -vv, more testing is really not required here
         # -v
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["-v"])
             self.assertEqual(stderr.getvalue(), "1: T2\n1: T5\n3: B6\n")
             self.assertEqual(result.exit_code, 3)
             self.assertEqual(result.output, "")
 
         # -vv
-        expected_output = "1: T2 Title has trailing whitespace\n" + \
-                          "1: T5 Title contains the word 'WIP' (case-insensitive)\n" + \
-                          "3: B6 Body message is missing\n"
+        expected_output = (
+            "1: T2 Title has trailing whitespace\n"
+            "1: T5 Title contains the word 'WIP' (case-insensitive)\n"
+            "3: B6 Body message is missing\n"
+        )
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["-vv"], input="WIP: tïtle \n")
             self.assertEqual(stderr.getvalue(), expected_output)
             self.assertEqual(result.exit_code, 3)
             self.assertEqual(result.output, "")
 
         # -vvvv: not supported -> should print a config error
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
-            result = self.cli.invoke(cli.cli, ["-vvvv"], input=u'WIP: tïtle \n')
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
+            result = self.cli.invoke(cli.cli, ["-vvvv"], input="WIP: tïtle \n")
             self.assertEqual(stderr.getvalue(), "")
             self.assertEqual(result.exit_code, CLITests.CONFIG_ERROR_CODE)
             self.assertEqual(result.output, "Config Error: Option 'verbosity' must be set between 0 and 3\n")
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
-    @patch('gitlint.git.sh')
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
+    @patch("gitlint.git.sh")
     def test_debug(self, sh, _):
-        """ Test for --debug option """
+        """Test for --debug option"""
 
         sh.git.side_effect = [
             "6f29bf81a8322a04071bb794666e48c443a90360\n"  # git rev-list <SHA>
             "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n"
             "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
             # git log --pretty <FORMAT> <SHA>
-            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00abc\n"
-            "commït-title1\n\ncommït-body1",
-            "#",                                         # git config --get core.commentchar
-            "commit-1-branch-1\ncommit-1-branch-2\n",    # git branch --contains <sha>
-            "commit-1/file-1\ncommit-1/file-2\n",        # git diff-tree
+            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00abc\n" "commït-title1\n\ncommït-body1",
+            "#",  # git config --get core.commentchar
+            "commit-1-branch-1\ncommit-1-branch-2\n",  # git branch --contains <sha>
+            "commit-1/file-1\ncommit-1/file-2\n",  # git diff-tree
             "test åuthor2\x00test-email2@föo.com\x002016-12-04 15:28:15 +0100\x00abc\n"
             "commït-title2.\n\ncommït-body2",
-            "commit-2-branch-1\ncommit-2-branch-2\n",    # git branch --contains <sha>
-            "commit-2/file-1\ncommit-2/file-2\n",        # git diff-tree
-            "test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 +0100\x00abc\n"
-            "föobar\nbar",
-            "commit-3-branch-1\ncommit-3-branch-2\n",     # git branch --contains <sha>
-            "commit-3/file-1\ncommit-3/file-2\n",         # git diff-tree
+            "commit-2-branch-1\ncommit-2-branch-2\n",  # git branch --contains <sha>
+            "commit-2/file-1\ncommit-2/file-2\n",  # git diff-tree
+            "test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 +0100\x00abc\n" "föobar\nbar",
+            "commit-3-branch-1\ncommit-3-branch-2\n",  # git branch --contains <sha>
+            "commit-3/file-1\ncommit-3/file-2\n",  # git diff-tree
         ]
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             config_path = self.get_sample_path(os.path.join("config", "gitlintconfig"))
-            result = self.cli.invoke(cli.cli, ["--config", config_path, "--debug", "--commits",
-                                               "foo...bar"])
+            result = self.cli.invoke(cli.cli, ["--config", config_path, "--debug", "--commits", "foo...bar"])
 
-            expected = "Commit 6f29bf81a8:\n3: B5\n\n" + \
-                       "Commit 25053ccec5:\n1: T3\n3: B5\n\n" + \
-                       "Commit 4da2656b0d:\n2: B4\n3: B5\n3: B6\n"
+            expected = (
+                "Commit 6f29bf81a8:\n3: B5\n\n"
+                "Commit 25053ccec5:\n1: T3\n3: B5\n\n"
+                "Commit 4da2656b0d:\n2: B4\n3: B5\n3: B6\n"
+            )
 
             self.assertEqual(stderr.getvalue(), expected)
             self.assertEqual(result.exit_code, 6)
 
             expected_kwargs = self.get_system_info_dict()
-            expected_kwargs.update({'config_path': config_path})
-            expected_logs = self.get_expected('cli/test_cli/test_debug_1', expected_kwargs)
+            expected_kwargs.update({"config_path": config_path})
+            expected_logs = self.get_expected("cli/test_cli/test_debug_1", expected_kwargs)
             self.assert_logged(expected_logs)
 
-    @patch('gitlint.cli.get_stdin_data', return_value="Test tïtle\n")
+    @patch("gitlint.cli.get_stdin_data", return_value="Test tïtle\n")
     def test_extra_path(self, _):
-        """ Test for --extra-path flag """
+        """Test for --extra-path flag"""
         # Test extra-path pointing to a directory
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             extra_path = self.get_sample_path("user_rules")
             result = self.cli.invoke(cli.cli, ["--extra-path", extra_path])
-            expected_output = "1: UC1 Commit violåtion 1: \"Contënt 1\"\n" + \
-                              "3: B6 Body message is missing\n"
+            expected_output = '1: UC1 Commit violåtion 1: "Contënt 1"\n' + "3: B6 Body message is missing\n"
             self.assertEqual(stderr.getvalue(), expected_output)
             self.assertEqual(result.exit_code, 2)
 
         # Test extra-path pointing to a file
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             extra_path = self.get_sample_path(os.path.join("user_rules", "my_commit_rules.py"))
             result = self.cli.invoke(cli.cli, ["--extra-path", extra_path])
-            expected_output = "1: UC1 Commit violåtion 1: \"Contënt 1\"\n" + \
-                              "3: B6 Body message is missing\n"
+            expected_output = '1: UC1 Commit violåtion 1: "Contënt 1"\n' + "3: B6 Body message is missing\n"
             self.assertEqual(stderr.getvalue(), expected_output)
             self.assertEqual(result.exit_code, 2)
 
-    @patch('gitlint.cli.get_stdin_data', return_value="Test tïtle\n")
+    @patch("gitlint.cli.get_stdin_data", return_value="Test tïtle\n")
     def test_extra_path_environment(self, _):
-        """ Test for GITLINT_EXTRA_PATH environment variable """
+        """Test for GITLINT_EXTRA_PATH environment variable"""
         # Test setting extra-path to a directory from an environment variable
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             extra_path = self.get_sample_path("user_rules")
             result = self.cli.invoke(cli.cli, env={"GITLINT_EXTRA_PATH": extra_path})
 
-            expected_output = "1: UC1 Commit violåtion 1: \"Contënt 1\"\n" + \
-                              "3: B6 Body message is missing\n"
+            expected_output = '1: UC1 Commit violåtion 1: "Contënt 1"\n' + "3: B6 Body message is missing\n"
             self.assertEqual(stderr.getvalue(), expected_output)
             self.assertEqual(result.exit_code, 2)
 
         # Test extra-path pointing to a file from an environment variable
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             extra_path = self.get_sample_path(os.path.join("user_rules", "my_commit_rules.py"))
             result = self.cli.invoke(cli.cli, env={"GITLINT_EXTRA_PATH": extra_path})
-            expected_output = "1: UC1 Commit violåtion 1: \"Contënt 1\"\n" + \
-                              "3: B6 Body message is missing\n"
+            expected_output = '1: UC1 Commit violåtion 1: "Contënt 1"\n' + "3: B6 Body message is missing\n"
             self.assertEqual(stderr.getvalue(), expected_output)
             self.assertEqual(result.exit_code, 2)
 
-    @patch('gitlint.cli.get_stdin_data', return_value="Test tïtle\n\nMy body that is long enough")
+    @patch("gitlint.cli.get_stdin_data", return_value="Test tïtle\n\nMy body that is long enough")
     def test_contrib(self, _):
         # Test enabled contrib rules
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--contrib", "contrib-title-conventional-commits,CC1"])
-            expected_output = self.get_expected('cli/test_cli/test_contrib_1')
+            expected_output = self.get_expected("cli/test_cli/test_contrib_1")
             self.assertEqual(stderr.getvalue(), expected_output)
             self.assertEqual(result.exit_code, 2)
 
-    @patch('gitlint.cli.get_stdin_data', return_value="Test tïtle\n")
+    @patch("gitlint.cli.get_stdin_data", return_value="Test tïtle\n")
     def test_contrib_negative(self, _):
         result = self.cli.invoke(cli.cli, ["--contrib", "föobar,CC1"])
         self.assertEqual(result.output, "Config Error: No contrib rule with id or name 'föobar' found.\n")
         self.assertEqual(result.exit_code, self.CONFIG_ERROR_CODE)
 
-    @patch('gitlint.cli.get_stdin_data', return_value="WIP: tëst")
+    @patch("gitlint.cli.get_stdin_data", return_value="WIP: tëst")
     def test_config_file(self, _):
-        """ Test for --config option """
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        """Test for --config option"""
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             config_path = self.get_sample_path(os.path.join("config", "gitlintconfig"))
             result = self.cli.invoke(cli.cli, ["--config", config_path])
             self.assertEqual(result.output, "")
             self.assertEqual(stderr.getvalue(), "1: T5\n3: B6\n")
             self.assertEqual(result.exit_code, 2)
 
-    @patch('gitlint.cli.get_stdin_data', return_value="WIP: tëst")
+    @patch("gitlint.cli.get_stdin_data", return_value="WIP: tëst")
     def test_config_file_environment(self, _):
-        """ Test for GITLINT_CONFIG environment variable """
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        """Test for GITLINT_CONFIG environment variable"""
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             config_path = self.get_sample_path(os.path.join("config", "gitlintconfig"))
             result = self.cli.invoke(cli.cli, env={"GITLINT_CONFIG": config_path})
             self.assertEqual(result.output, "")
@@ -514,7 +523,7 @@ class CLITests(BaseTestCase):
             self.assertEqual(result.exit_code, 2)
 
     def test_config_file_negative(self):
-        """ Negative test for --config option """
+        """Negative test for --config option"""
         # Directory as config file
         config_path = self.get_sample_path("config")
         result = self.cli.invoke(cli.cli, ["--config", config_path])
@@ -535,7 +544,7 @@ class CLITests(BaseTestCase):
         self.assertEqual(result.exit_code, self.CONFIG_ERROR_CODE)
 
     def test_config_file_negative_environment(self):
-        """ Negative test for GITLINT_CONFIG environment variable """
+        """Negative test for GITLINT_CONFIG environment variable"""
         # Directory as config file
         config_path = self.get_sample_path("config")
         result = self.cli.invoke(cli.cli, env={"GITLINT_CONFIG": config_path})
@@ -555,9 +564,9 @@ class CLITests(BaseTestCase):
         result = self.cli.invoke(cli.cli, env={"GITLINT_CONFIG": config_path})
         self.assertEqual(result.exit_code, self.CONFIG_ERROR_CODE)
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
     def test_target(self, _):
-        """ Test for the --target option """
+        """Test for the --target option"""
         with self.tempdir() as tmpdir:
             tmpdir_path = os.path.realpath(tmpdir)
             os.environ["LANGUAGE"] = "C"  # Force language to english so we can check for error message
@@ -568,7 +577,7 @@ class CLITests(BaseTestCase):
             self.assertEqual(result.exit_code, self.GIT_CONTEXT_ERROR_CODE)
 
     def test_target_negative(self):
-        """ Negative test for the --target option """
+        """Negative test for the --target option"""
         # try setting a non-existing target
         result = self.cli.invoke(cli.cli, ["--target", "/föo/bar"])
         self.assertEqual(result.exit_code, self.USAGE_ERROR_CODE)
@@ -582,57 +591,63 @@ class CLITests(BaseTestCase):
         expected_msg = f"Error: Invalid value for '--target': Directory '{target_path}' is a file."
         self.assertEqual(result.output.split("\n")[3], expected_msg)
 
-    @patch('gitlint.config.LintConfigGenerator.generate_config')
+    @patch("gitlint.config.LintConfigGenerator.generate_config")
     def test_generate_config(self, generate_config):
-        """ Test for the generate-config subcommand """
+        """Test for the generate-config subcommand"""
         result = self.cli.invoke(cli.cli, ["generate-config"], input="tëstfile\n")
         self.assertEqual(result.exit_code, self.GITLINT_SUCCESS_CODE)
-        expected_msg = "Please specify a location for the sample gitlint config file [.gitlint]: tëstfile\n" + \
-                       f"Successfully generated {os.path.realpath('tëstfile')}\n"
+        expected_msg = (
+            "Please specify a location for the sample gitlint config file [.gitlint]: tëstfile\n"
+            f"Successfully generated {os.path.realpath('tëstfile')}\n"
+        )
         self.assertEqual(result.output, expected_msg)
         generate_config.assert_called_once_with(os.path.realpath("tëstfile"))
 
     def test_generate_config_negative(self):
-        """ Negative test for the generate-config subcommand """
+        """Negative test for the generate-config subcommand"""
         # Non-existing directory
         fake_dir = os.path.abspath("/föo")
         fake_path = os.path.join(fake_dir, "bar")
         result = self.cli.invoke(cli.cli, ["generate-config"], input=fake_path)
         self.assertEqual(result.exit_code, self.USAGE_ERROR_CODE)
-        expected_msg = f"Please specify a location for the sample gitlint config file [.gitlint]: {fake_path}\n" + \
-                       f"Error: Directory '{fake_dir}' does not exist.\n"
+        expected_msg = (
+            f"Please specify a location for the sample gitlint config file [.gitlint]: {fake_path}\n"
+            f"Error: Directory '{fake_dir}' does not exist.\n"
+        )
         self.assertEqual(result.output, expected_msg)
 
         # Existing file
         sample_path = self.get_sample_path(os.path.join("config", "gitlintconfig"))
         result = self.cli.invoke(cli.cli, ["generate-config"], input=sample_path)
         self.assertEqual(result.exit_code, self.USAGE_ERROR_CODE)
-        expected_msg = "Please specify a location for the sample gitlint " + \
-                       f"config file [.gitlint]: {sample_path}\n" + \
-                       f"Error: File \"{sample_path}\" already exists.\n"
+        expected_msg = (
+            "Please specify a location for the sample gitlint "
+            f"config file [.gitlint]: {sample_path}\n"
+            f'Error: File "{sample_path}" already exists.\n'
+        )
         self.assertEqual(result.output, expected_msg)
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
-    @patch('gitlint.git.sh')
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
+    @patch("gitlint.git.sh")
     def test_git_error(self, sh, _):
-        """ Tests that the cli handles git errors properly """
+        """Tests that the cli handles git errors properly"""
         sh.git.side_effect = CommandNotFound("git")
         result = self.cli.invoke(cli.cli)
         self.assertEqual(result.exit_code, self.GIT_CONTEXT_ERROR_CODE)
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
-    @patch('gitlint.git.sh')
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
+    @patch("gitlint.git.sh")
     def test_no_commits_in_range(self, sh, _):
-        """ Test for --commits with the specified range being empty. """
+        """Test for --commits with the specified range being empty."""
         sh.git.side_effect = lambda *_args, **_kwargs: ""
         result = self.cli.invoke(cli.cli, ["--commits", "master...HEAD"])
 
-        self.assert_log_contains("DEBUG: gitlint.cli No commits in range \"master...HEAD\"")
+        self.assert_log_contains('DEBUG: gitlint.cli No commits in range "master...HEAD"')
         self.assertEqual(result.exit_code, self.GITLINT_SUCCESS_CODE)
 
-    @patch('gitlint.cli.get_stdin_data', return_value="WIP: tëst tïtle")
+    @patch("gitlint.cli.get_stdin_data", return_value="WIP: tëst tïtle")
     def test_named_rules(self, _):
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             config_path = self.get_sample_path(os.path.join("config", "named-rules"))
             result = self.cli.invoke(cli.cli, ["--config", config_path, "--debug"])
             self.assertEqual(result.output, "")
@@ -641,6 +656,6 @@ class CLITests(BaseTestCase):
 
             # Assert debug logs are correct
             expected_kwargs = self.get_system_info_dict()
-            expected_kwargs.update({'config_path': config_path})
-            expected_logs = self.get_expected('cli/test_cli/test_named_rules_2', expected_kwargs)
+            expected_kwargs.update({"config_path": config_path})
+            expected_logs = self.get_expected("cli/test_cli/test_named_rules_2", expected_kwargs)
             self.assert_logged(expected_logs)

--- a/gitlint-core/gitlint/tests/cli/test_cli.py
+++ b/gitlint-core/gitlint/tests/cli/test_cli.py
@@ -63,7 +63,7 @@ class CLITests(BaseTestCase):
         """Test for basic simple linting functionality"""
         sh.git.side_effect = [
             "6f29bf81a8322a04071bb794666e48c443a90360",
-            "test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "commït-title\n\ncommït-body",
+            "test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\ncommït-title\n\ncommït-body",
             "#",  # git config --get core.commentchar
             "commit-1-branch-1\ncommit-1-branch-2\n",
             "file1.txt\npåth/to/file2.txt\n",
@@ -79,24 +79,29 @@ class CLITests(BaseTestCase):
     def test_lint_multiple_commits(self, sh, _):
         """Test for --commits option"""
 
+        # fmt: off
         sh.git.side_effect = [
-            "6f29bf81a8322a04071bb794666e48c443a90360\n"
-            "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n"  # git rev-list <SHA>
+            "6f29bf81a8322a04071bb794666e48c443a90360\n" +  # git rev-list <SHA>
+            "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n" +
             "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
             # git log --pretty <FORMAT> <SHA>
-            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "commït-title1\n\ncommït-body1",
-            "#",  # git config --get core.commentchar
-            "commit-1-branch-1\ncommit-1-branch-2\n",  # git branch --contains <sha>
-            "commit-1/file-1\ncommit-1/file-2\n",  # git diff-tree
-            # git log --pretty <FORMAT> <SHA>
-            "test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 +0100\x00åbc\n" "commït-title2\n\ncommït-body2",
-            "commit-2-branch-1\ncommit-2-branch-2\n",  # git branch --contains <sha>
-            "commit-2/file-1\ncommit-2/file-2\n",  # git diff-tree
-            # git log --pretty <FORMAT> <SHA>
-            "test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 +0100\x00åbc\n" "commït-title3\n\ncommït-body3",
-            "commit-3-branch-1\ncommit-3-branch-2\n",  # git branch --contains <sha>
-            "commit-3/file-1\ncommit-3/file-2\n",  # git diff-tree
+            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
+            "commït-title1\n\ncommït-body1",
+            "#",                                           # git config --get core.commentchar
+            "commit-1-branch-1\ncommit-1-branch-2\n",      # git branch --contains <sha>
+            "commit-1/file-1\ncommit-1/file-2\n",          # git diff-tree
+                                                            # git log --pretty <FORMAT> <SHA>
+            "test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 +0100\x00åbc\n"
+            "commït-title2\n\ncommït-body2",
+            "commit-2-branch-1\ncommit-2-branch-2\n",      # git branch --contains <sha>
+            "commit-2/file-1\ncommit-2/file-2\n",          # git diff-tree
+                                                            # git log --pretty <FORMAT> <SHA>
+            "test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 +0100\x00åbc\n"
+            "commït-title3\n\ncommït-body3",
+            "commit-3-branch-1\ncommit-3-branch-2\n",      # git branch --contains <sha>
+            "commit-3/file-1\ncommit-3/file-2\n",          # git diff-tree
         ]
+        # fmt: on
 
         with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--commits", "foo...bar"])
@@ -108,27 +113,30 @@ class CLITests(BaseTestCase):
     def test_lint_multiple_commits_config(self, sh, _):
         """Test for --commits option where some of the commits have gitlint config in the commit message"""
 
+        # fmt: off
         # Note that the second commit title has a trailing period that is being ignored by gitlint-ignore: T3
         sh.git.side_effect = [
-            "6f29bf81a8322a04071bb794666e48c443a90360\n"
-            + "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n"  # git rev-list <SHA>
-            + "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
+            "6f29bf81a8322a04071bb794666e48c443a90360\n" +  # git rev-list <SHA>
+            "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n" +
+            "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
             # git log --pretty <FORMAT> <SHA>
-            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "commït-title1\n\ncommït-body1",
-            "#",  # git config --get core.commentchar
-            "commit-1-branch-1\ncommit-1-branch-2\n",  # git branch --contains <sha>
-            "commit-1/file-1\ncommit-1/file-2\n",  # git diff-tree
-            # git log --pretty <FORMAT> <SHA>
+            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
+            "commït-title1\n\ncommït-body1",
+            "#",                                           # git config --get core.commentchar
+            "commit-1-branch-1\ncommit-1-branch-2\n",      # git branch --contains <sha>
+            "commit-1/file-1\ncommit-1/file-2\n",          # git diff-tree
+                                                            # git log --pretty <FORMAT> <SHA>
             "test åuthor2\x00test-email2@föo.com\x002016-12-04 15:28:15 +0100\x00åbc\n"
             "commït-title2.\n\ncommït-body2\ngitlint-ignore: T3\n",
-            "commit-2-branch-1\ncommit-2-branch-2\n",  # git branch --contains <sha>
-            "commit-2/file-1\ncommit-2/file-2\n",  # git diff-tree
-            # git log --pretty <FORMAT> <SHA>
+            "commit-2-branch-1\ncommit-2-branch-2\n",      # git branch --contains <sha>
+            "commit-2/file-1\ncommit-2/file-2\n",          # git diff-tree
+                                                            # git log --pretty <FORMAT> <SHA>
             "test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 +0100\x00åbc\n"
             "commït-title3.\n\ncommït-body3",
-            "commit-3-branch-1\ncommit-3-branch-2\n",  # git branch --contains <sha>
-            "commit-3/file-1\ncommit-3/file-2\n",  # git diff-tree
+            "commit-3-branch-1\ncommit-3-branch-2\n",      # git branch --contains <sha>
+            "commit-3/file-1\ncommit-3/file-2\n",          # git diff-tree
         ]
+        # fmt: on
 
         with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--commits", "foo...bar"])
@@ -141,30 +149,33 @@ class CLITests(BaseTestCase):
     def test_lint_multiple_commits_configuration_rules(self, sh, _):
         """Test for --commits option where where we have configured gitlint to ignore certain rules for certain commits"""
 
+        # fmt: off
         # Note that the second commit
         sh.git.side_effect = [
-            "6f29bf81a8322a04071bb794666e48c443a90360\n"
-            "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n"  # git rev-list <SHA>
+            "6f29bf81a8322a04071bb794666e48c443a90360\n" +  # git rev-list <SHA>
+            "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n" +
             "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
             # git log --pretty <FORMAT> <SHA>
-            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "commït-title1\n\ncommït-body1",
-            "#",  # git config --get core.commentchar
-            "commit-1-branch-1\ncommit-1-branch-2\n",  # git branch --contains <sha>
-            "commit-1/file-1\ncommit-1/file-2\n",  # git diff-tree
-            # git log --pretty <FORMAT> <SHA>
+            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
+            "commït-title1\n\ncommït-body1",
+            "#",                                           # git config --get core.commentchar
+            "commit-1-branch-1\ncommit-1-branch-2\n",      # git branch --contains <sha>
+            "commit-1/file-1\ncommit-1/file-2\n",          # git diff-tree
+                                                            # git log --pretty <FORMAT> <SHA>
             "test åuthor2\x00test-email3@föo.com\x002016-12-04 15:28:15 +0100\x00åbc\n"
             # Normally T3 violation (trailing punctuation), but this commit is ignored because of
             # config below
             "commït-title2.\n\ncommït-body2\n",
-            "commit-2-branch-1\ncommit-2-branch-2\n",  # git branch --contains <sha>
-            "commit-2/file-1\ncommit-2/file-2\n",  # git diff-tree
-            # git log --pretty <FORMAT> <SHA>
+            "commit-2-branch-1\ncommit-2-branch-2\n",      # git branch --contains <sha>
+            "commit-2/file-1\ncommit-2/file-2\n",          # git diff-tree
+                                                            # git log --pretty <FORMAT> <SHA>
             "test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 +0100\x00åbc\n"
             # Normally T1 and B5 violations, now only T1 because we're ignoring B5 in config below
             "commït-title3.\n\ncommït-body3 foo",
-            "commit-3-branch-1\ncommit-3-branch-2\n",  # git branch --contains <sha>
-            "commit-3/file-1\ncommit-3/file-2\n",  # git diff-tree
+            "commit-3-branch-1\ncommit-3-branch-2\n",      # git branch --contains <sha>
+            "commit-3/file-1\ncommit-3/file-2\n",          # git diff-tree
         ]
+        # fmt: on
 
         with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(
@@ -197,15 +208,17 @@ class CLITests(BaseTestCase):
     def test_lint_commit(self, sh, _):
         """Test for --commit option"""
 
+        # fmt: off
         sh.git.side_effect = [
             "6f29bf81a8322a04071bb794666e48c443a90360\n",  # git log -1 <SHA> --pretty=%H
             # git log --pretty <FORMAT> <SHA>
             "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
             "WIP: commït-title1\n\ncommït-body1",
-            "#",  # git config --get core.commentchar
-            "commit-1-branch-1\ncommit-1-branch-2\n",  # git branch --contains <sha>
-            "commit-1/file-1\ncommit-1/file-2\n",  # git diff-tree
+            "#",                                           # git config --get core.commentchar
+            "commit-1-branch-1\ncommit-1-branch-2\n",      # git branch --contains <sha>
+            "commit-1/file-1\ncommit-1/file-2\n",          # git diff-tree
         ]
+        # fmt: on
 
         with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--commit", "foo"])
@@ -253,7 +266,7 @@ class CLITests(BaseTestCase):
         """Test for ignoring stdin when --ignore-stdin flag is enabled"""
         sh.git.side_effect = [
             "6f29bf81a8322a04071bb794666e48c443a90360",
-            "test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "commït-title\n\ncommït-body",
+            "test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\ncommït-title\n\ncommït-body",
             "#",  # git config --get core.commentchar
             "commit-1-branch-1\ncommit-1-branch-2\n",  # git branch --contains <sha>
             "file1.txt\npåth/to/file2.txt\n",  # git diff-tree
@@ -296,13 +309,15 @@ class CLITests(BaseTestCase):
     def test_lint_staged_msg_filename(self, sh, _):
         """Test for ignoring stdin when --ignore-stdin flag is enabled"""
 
+        # fmt: off
         sh.git.side_effect = [
-            "#",  # git config --get core.commentchar
-            "föo user\n",  # git config --get user.name
-            "föo@bar.com\n",  # git config --get user.email
-            "my-branch\n",  # git rev-parse --abbrev-ref HEAD (=current branch)
-            "commit-1/file-1\ncommit-1/file-2\n",  # git diff-tree
+            "#",                                         # git config --get core.commentchar
+            "föo user\n",                                # git config --get user.name
+            "föo@bar.com\n",                             # git config --get user.email
+            "my-branch\n",                               # git rev-parse --abbrev-ref HEAD (=current branch)
+            "commit-1/file-1\ncommit-1/file-2\n",        # git diff-tree
         ]
+        # fmt: on
 
         with self.tempdir() as tmpdir:
             msg_filename = os.path.join(tmpdir, "msg")
@@ -325,10 +340,8 @@ class CLITests(BaseTestCase):
         self.assertEqual(result.exit_code, self.USAGE_ERROR_CODE)
         self.assertEqual(
             result.output,
-            (
-                "Error: The 'staged' option (--staged) can only be used when using "
-                "'--msg-filename' or when piping data to gitlint via stdin.\n"
-            ),
+            "Error: The 'staged' option (--staged) can only be used when using "
+            "'--msg-filename' or when piping data to gitlint via stdin.\n",
         )
 
     @patch("gitlint.cli.get_stdin_data", return_value=False)
@@ -336,7 +349,7 @@ class CLITests(BaseTestCase):
     def test_fail_without_commits(self, sh, _):
         """Test for --debug option"""
 
-        sh.git.side_effect = ["", ""]  # First 2 invocations of git rev-list
+        sh.git.side_effect = ["", ""]  # First invocation of git rev-list  # Second invocation of git rev-list
 
         with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             # By default, gitlint should silently exit with code GITLINT_SUCCESS when there are no commits
@@ -390,8 +403,8 @@ class CLITests(BaseTestCase):
         # -vv
         expected_output = (
             "1: T2 Title has trailing whitespace\n"
-            "1: T5 Title contains the word 'WIP' (case-insensitive)\n"
-            "3: B6 Body message is missing\n"
+            + "1: T5 Title contains the word 'WIP' (case-insensitive)\n"
+            + "3: B6 Body message is missing\n"
         )
 
         with patch("gitlint.display.stderr", new=StringIO()) as stderr:
@@ -412,23 +425,27 @@ class CLITests(BaseTestCase):
     def test_debug(self, sh, _):
         """Test for --debug option"""
 
+        # fmt: off
         sh.git.side_effect = [
             "6f29bf81a8322a04071bb794666e48c443a90360\n"  # git rev-list <SHA>
             "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n"
             "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
             # git log --pretty <FORMAT> <SHA>
-            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00abc\n" "commït-title1\n\ncommït-body1",
-            "#",  # git config --get core.commentchar
-            "commit-1-branch-1\ncommit-1-branch-2\n",  # git branch --contains <sha>
-            "commit-1/file-1\ncommit-1/file-2\n",  # git diff-tree
+            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00abc\n"
+            "commït-title1\n\ncommït-body1",
+            "#",                                         # git config --get core.commentchar
+            "commit-1-branch-1\ncommit-1-branch-2\n",    # git branch --contains <sha>
+            "commit-1/file-1\ncommit-1/file-2\n",        # git diff-tree
             "test åuthor2\x00test-email2@föo.com\x002016-12-04 15:28:15 +0100\x00abc\n"
             "commït-title2.\n\ncommït-body2",
-            "commit-2-branch-1\ncommit-2-branch-2\n",  # git branch --contains <sha>
-            "commit-2/file-1\ncommit-2/file-2\n",  # git diff-tree
-            "test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 +0100\x00abc\n" "föobar\nbar",
-            "commit-3-branch-1\ncommit-3-branch-2\n",  # git branch --contains <sha>
-            "commit-3/file-1\ncommit-3/file-2\n",  # git diff-tree
+            "commit-2-branch-1\ncommit-2-branch-2\n",    # git branch --contains <sha>
+            "commit-2/file-1\ncommit-2/file-2\n",        # git diff-tree
+            "test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 +0100\x00abc\n"
+            "föobar\nbar",
+            "commit-3-branch-1\ncommit-3-branch-2\n",     # git branch --contains <sha>
+            "commit-3/file-1\ncommit-3/file-2\n",         # git diff-tree
         ]
+        # fmt: on
 
         with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             config_path = self.get_sample_path(os.path.join("config", "gitlintconfig"))
@@ -598,7 +615,7 @@ class CLITests(BaseTestCase):
         self.assertEqual(result.exit_code, self.GITLINT_SUCCESS_CODE)
         expected_msg = (
             "Please specify a location for the sample gitlint config file [.gitlint]: tëstfile\n"
-            f"Successfully generated {os.path.realpath('tëstfile')}\n"
+            + f"Successfully generated {os.path.realpath('tëstfile')}\n"
         )
         self.assertEqual(result.output, expected_msg)
         generate_config.assert_called_once_with(os.path.realpath("tëstfile"))
@@ -612,7 +629,7 @@ class CLITests(BaseTestCase):
         self.assertEqual(result.exit_code, self.USAGE_ERROR_CODE)
         expected_msg = (
             f"Please specify a location for the sample gitlint config file [.gitlint]: {fake_path}\n"
-            f"Error: Directory '{fake_dir}' does not exist.\n"
+            + f"Error: Directory '{fake_dir}' does not exist.\n"
         )
         self.assertEqual(result.output, expected_msg)
 

--- a/gitlint-core/gitlint/tests/cli/test_cli_hooks.py
+++ b/gitlint-core/gitlint/tests/cli/test_cli_hooks.py
@@ -27,17 +27,17 @@ class CLIHookTests(BaseTestCase):
         self.cli = CliRunner()
 
         # Patch gitlint.cli.git_version() so that we don't have to patch it separately in every test
-        self.git_version_path = patch('gitlint.cli.git_version')
+        self.git_version_path = patch("gitlint.cli.git_version")
         cli.git_version = self.git_version_path.start()
         cli.git_version.return_value = "git version 1.2.3"
 
     def tearDown(self):
         self.git_version_path.stop()
 
-    @patch('gitlint.hooks.GitHookInstaller.install_commit_msg_hook')
-    @patch('gitlint.hooks.git_hooks_dir', return_value=os.path.join("/hür", "dur"))
+    @patch("gitlint.hooks.GitHookInstaller.install_commit_msg_hook")
+    @patch("gitlint.hooks.git_hooks_dir", return_value=os.path.join("/hür", "dur"))
     def test_install_hook(self, _, install_hook):
-        """ Test for install-hook subcommand """
+        """Test for install-hook subcommand"""
         result = self.cli.invoke(cli.cli, ["install-hook"])
         expected_path = os.path.join("/hür", "dur", hooks.COMMIT_MSG_HOOK_DST_PATH)
         expected = f"Successfully installed gitlint commit-msg hook in {expected_path}\n"
@@ -47,10 +47,10 @@ class CLIHookTests(BaseTestCase):
         expected_config.target = os.path.realpath(os.getcwd())
         install_hook.assert_called_once_with(expected_config)
 
-    @patch('gitlint.hooks.GitHookInstaller.install_commit_msg_hook')
-    @patch('gitlint.hooks.git_hooks_dir', return_value=os.path.join("/hür", "dur"))
+    @patch("gitlint.hooks.GitHookInstaller.install_commit_msg_hook")
+    @patch("gitlint.hooks.git_hooks_dir", return_value=os.path.join("/hür", "dur"))
     def test_install_hook_target(self, _, install_hook):
-        """  Test for install-hook subcommand with a specific --target option specified """
+        """Test for install-hook subcommand with a specific --target option specified"""
         # Specified target
         result = self.cli.invoke(cli.cli, ["--target", self.SAMPLES_DIR, "install-hook"])
         expected_path = os.path.join("/hür", "dur", hooks.COMMIT_MSG_HOOK_DST_PATH)
@@ -62,9 +62,9 @@ class CLIHookTests(BaseTestCase):
         expected_config.target = self.SAMPLES_DIR
         install_hook.assert_called_once_with(expected_config)
 
-    @patch('gitlint.hooks.GitHookInstaller.install_commit_msg_hook', side_effect=hooks.GitHookInstallerError("tëst"))
+    @patch("gitlint.hooks.GitHookInstaller.install_commit_msg_hook", side_effect=hooks.GitHookInstallerError("tëst"))
     def test_install_hook_negative(self, install_hook):
-        """ Negative test for install-hook subcommand """
+        """Negative test for install-hook subcommand"""
         result = self.cli.invoke(cli.cli, ["install-hook"])
         self.assertEqual(result.exit_code, self.GIT_CONTEXT_ERROR_CODE)
         self.assertEqual(result.output, "tëst\n")
@@ -72,10 +72,10 @@ class CLIHookTests(BaseTestCase):
         expected_config.target = os.path.realpath(os.getcwd())
         install_hook.assert_called_once_with(expected_config)
 
-    @patch('gitlint.hooks.GitHookInstaller.uninstall_commit_msg_hook')
-    @patch('gitlint.hooks.git_hooks_dir', return_value=os.path.join("/hür", "dur"))
+    @patch("gitlint.hooks.GitHookInstaller.uninstall_commit_msg_hook")
+    @patch("gitlint.hooks.git_hooks_dir", return_value=os.path.join("/hür", "dur"))
     def test_uninstall_hook(self, _, uninstall_hook):
-        """ Test for uninstall-hook subcommand """
+        """Test for uninstall-hook subcommand"""
         result = self.cli.invoke(cli.cli, ["uninstall-hook"])
         expected_path = os.path.join("/hür", "dur", hooks.COMMIT_MSG_HOOK_DST_PATH)
         expected = f"Successfully uninstalled gitlint commit-msg hook from {expected_path}\n"
@@ -85,9 +85,9 @@ class CLIHookTests(BaseTestCase):
         expected_config.target = os.path.realpath(os.getcwd())
         uninstall_hook.assert_called_once_with(expected_config)
 
-    @patch('gitlint.hooks.GitHookInstaller.uninstall_commit_msg_hook', side_effect=hooks.GitHookInstallerError("tëst"))
+    @patch("gitlint.hooks.GitHookInstaller.uninstall_commit_msg_hook", side_effect=hooks.GitHookInstallerError("tëst"))
     def test_uninstall_hook_negative(self, uninstall_hook):
-        """ Negative test for uninstall-hook subcommand """
+        """Negative test for uninstall-hook subcommand"""
         result = self.cli.invoke(cli.cli, ["uninstall-hook"])
         self.assertEqual(result.exit_code, self.GIT_CONTEXT_ERROR_CODE)
         self.assertEqual(result.output, "tëst\n")
@@ -96,8 +96,8 @@ class CLIHookTests(BaseTestCase):
         uninstall_hook.assert_called_once_with(expected_config)
 
     def test_run_hook_no_tty(self):
-        """ Test for run-hook subcommand.
-            When no TTY is available (like is the case for this test), the hook will abort after the first check.
+        """Test for run-hook subcommand.
+        When no TTY is available (like is the case for this test), the hook will abort after the first check.
         """
 
         # No need to patch git as we're passing a msg-filename to run-hook, so no git calls are made.
@@ -110,20 +110,20 @@ class CLIHookTests(BaseTestCase):
 
         with self.tempdir() as tmpdir:
             msg_filename = os.path.join(tmpdir, "hür")
-            with io.open(msg_filename, 'w', encoding=DEFAULT_ENCODING) as f:
+            with io.open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
                 f.write("WIP: tïtle\n")
 
-            with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+            with patch("gitlint.display.stderr", new=StringIO()) as stderr:
                 result = self.cli.invoke(cli.cli, ["--msg-filename", msg_filename, "run-hook"])
-                self.assertEqual(result.output, self.get_expected('cli/test_cli_hooks/test_hook_no_tty_1_stdout'))
+                self.assertEqual(result.output, self.get_expected("cli/test_cli_hooks/test_hook_no_tty_1_stdout"))
                 self.assertEqual(stderr.getvalue(), self.get_expected("cli/test_cli_hooks/test_hook_no_tty_1_stderr"))
 
                 # exit code is 1 because aborted (no stdin available)
                 self.assertEqual(result.exit_code, 1)
 
-    @patch('gitlint.cli.shell')
+    @patch("gitlint.cli.shell")
     def test_run_hook_edit(self, shell):
-        """ Test for run-hook subcommand, answering 'e(dit)' after commit-hook """
+        """Test for run-hook subcommand, answering 'e(dit)' after commit-hook"""
 
         set_editors = [None, "myeditor"]
         expected_editors = ["vim -n", "myeditor"]
@@ -131,23 +131,28 @@ class CLIHookTests(BaseTestCase):
 
         for i in range(0, len(set_editors)):
             if set_editors[i]:
-                os.environ['EDITOR'] = set_editors[i]
+                os.environ["EDITOR"] = set_editors[i]
             else:
                 # When set_editors[i] == None, ensure we don't fallback to EDITOR set in shell invocating the tests
-                os.environ.pop('EDITOR', None)
+                os.environ.pop("EDITOR", None)
 
-            with self.patch_input(['e', 'e', 'n']):
+            with self.patch_input(["e", "e", "n"]):
                 with self.tempdir() as tmpdir:
                     msg_filename = os.path.realpath(os.path.join(tmpdir, "hür"))
-                    with io.open(msg_filename, 'w', encoding=DEFAULT_ENCODING) as f:
+                    with io.open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
                         f.write(commit_messages[i] + "\n")
 
-                    with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+                    with patch("gitlint.display.stderr", new=StringIO()) as stderr:
                         result = self.cli.invoke(cli.cli, ["--msg-filename", msg_filename, "run-hook"])
-                        self.assertEqual(result.output, self.get_expected('cli/test_cli_hooks/test_hook_edit_1_stdout',
-                                                                          {"commit_msg": commit_messages[i]}))
-                        expected = self.get_expected("cli/test_cli_hooks/test_hook_edit_1_stderr",
-                                                     {"commit_msg": commit_messages[i]})
+                        self.assertEqual(
+                            result.output,
+                            self.get_expected(
+                                "cli/test_cli_hooks/test_hook_edit_1_stdout", {"commit_msg": commit_messages[i]}
+                            ),
+                        )
+                        expected = self.get_expected(
+                            "cli/test_cli_hooks/test_hook_edit_1_stderr", {"commit_msg": commit_messages[i]}
+                        )
                         self.assertEqual(stderr.getvalue(), expected)
 
                         # exit code = number of violations
@@ -158,17 +163,17 @@ class CLIHookTests(BaseTestCase):
                         self.assert_log_contains(f"DEBUG: gitlint.cli run-hook: {expected_editors[i]} {msg_filename}")
 
     def test_run_hook_no(self):
-        """ Test for run-hook subcommand, answering 'n(o)' after commit-hook """
+        """Test for run-hook subcommand, answering 'n(o)' after commit-hook"""
 
-        with self.patch_input(['n']):
+        with self.patch_input(["n"]):
             with self.tempdir() as tmpdir:
                 msg_filename = os.path.join(tmpdir, "hür")
-                with io.open(msg_filename, 'w', encoding=DEFAULT_ENCODING) as f:
+                with io.open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
                     f.write("WIP: höok no\n")
 
-                with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+                with patch("gitlint.display.stderr", new=StringIO()) as stderr:
                     result = self.cli.invoke(cli.cli, ["--msg-filename", msg_filename, "run-hook"])
-                    self.assertEqual(result.output, self.get_expected('cli/test_cli_hooks/test_hook_no_1_stdout'))
+                    self.assertEqual(result.output, self.get_expected("cli/test_cli_hooks/test_hook_no_1_stdout"))
                     self.assertEqual(stderr.getvalue(), self.get_expected("cli/test_cli_hooks/test_hook_no_1_stderr"))
 
                     # We decided not to keep the commit message: hook returns number of violations (>0)
@@ -177,16 +182,16 @@ class CLIHookTests(BaseTestCase):
                     self.assert_log_contains("DEBUG: gitlint.cli run-hook: commit message declined")
 
     def test_run_hook_yes(self):
-        """ Test for run-hook subcommand, answering 'y(es)' after commit-hook """
-        with self.patch_input(['y']):
+        """Test for run-hook subcommand, answering 'y(es)' after commit-hook"""
+        with self.patch_input(["y"]):
             with self.tempdir() as tmpdir:
                 msg_filename = os.path.join(tmpdir, "hür")
-                with io.open(msg_filename, 'w', encoding=DEFAULT_ENCODING) as f:
+                with io.open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
                     f.write("WIP: höok yes\n")
 
-                with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+                with patch("gitlint.display.stderr", new=StringIO()) as stderr:
                     result = self.cli.invoke(cli.cli, ["--msg-filename", msg_filename, "run-hook"])
-                    self.assertEqual(result.output, self.get_expected('cli/test_cli_hooks/test_hook_yes_1_stdout'))
+                    self.assertEqual(result.output, self.get_expected("cli/test_cli_hooks/test_hook_yes_1_stdout"))
                     self.assertEqual(stderr.getvalue(), self.get_expected("cli/test_cli_hooks/test_hook_yes_1_stderr"))
 
                     # Exit code is 0 because we decide to keep the commit message
@@ -194,23 +199,23 @@ class CLIHookTests(BaseTestCase):
                     self.assertEqual(result.exit_code, 0)
                     self.assert_log_contains("DEBUG: gitlint.cli run-hook: commit message accepted")
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
-    @patch('gitlint.git.sh')
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
+    @patch("gitlint.git.sh")
     def test_run_hook_negative(self, sh, _):
-        """ Negative test for the run-hook subcommand: testing whether exceptions are correctly handled when
+        """Negative test for the run-hook subcommand: testing whether exceptions are correctly handled when
         running `gitlint run-hook`.
         """
         # GIT_CONTEXT_ERROR_CODE: git error
         error_msg = b"fatal: not a git repository (or any of the parent directories): .git"
         sh.git.side_effect = ErrorReturnCode("full command", b"stdout", error_msg)
         result = self.cli.invoke(cli.cli, ["run-hook"])
-        expected = self.get_expected('cli/test_cli_hooks/test_run_hook_negative_1', {'git_repo': os.getcwd()})
+        expected = self.get_expected("cli/test_cli_hooks/test_run_hook_negative_1", {"git_repo": os.getcwd()})
         self.assertEqual(result.output, expected)
         self.assertEqual(result.exit_code, self.GIT_CONTEXT_ERROR_CODE)
 
         # USAGE_ERROR_CODE: incorrect use of gitlint
         result = self.cli.invoke(cli.cli, ["--staged", "run-hook"])
-        self.assertEqual(result.output, self.get_expected('cli/test_cli_hooks/test_run_hook_negative_2'))
+        self.assertEqual(result.output, self.get_expected("cli/test_cli_hooks/test_run_hook_negative_2"))
         self.assertEqual(result.exit_code, self.USAGE_ERROR_CODE)
 
         # CONFIG_ERROR_CODE: incorrect config. Note that this is handled before the hook even runs
@@ -218,52 +223,52 @@ class CLIHookTests(BaseTestCase):
         self.assertEqual(result.output, "Config Error: No such rule 'föo'\n")
         self.assertEqual(result.exit_code, self.CONFIG_ERROR_CODE)
 
-    @patch('gitlint.cli.get_stdin_data', return_value="WIP: Test hook stdin tïtle\n")
+    @patch("gitlint.cli.get_stdin_data", return_value="WIP: Test hook stdin tïtle\n")
     def test_run_hook_stdin_violations(self, _):
-        """ Test for passing stdin data to run-hook, expecting some violations. Equivalent of:
-            $ echo "WIP: Test hook stdin tïtle" | gitlint run-hook
+        """Test for passing stdin data to run-hook, expecting some violations. Equivalent of:
+        $ echo "WIP: Test hook stdin tïtle" | gitlint run-hook
         """
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["run-hook"])
-            expected_stderr = self.get_expected('cli/test_cli_hooks/test_hook_stdin_violations_1_stderr')
+            expected_stderr = self.get_expected("cli/test_cli_hooks/test_hook_stdin_violations_1_stderr")
             self.assertEqual(stderr.getvalue(), expected_stderr)
-            self.assertEqual(result.output, self.get_expected('cli/test_cli_hooks/test_hook_stdin_violations_1_stdout'))
+            self.assertEqual(result.output, self.get_expected("cli/test_cli_hooks/test_hook_stdin_violations_1_stdout"))
             # Hook will auto-abort because we're using stdin. Abort = exit code 1
             self.assertEqual(result.exit_code, 1)
 
-    @patch('gitlint.cli.get_stdin_data', return_value="Test tïtle\n\nTest bödy that is long enough")
+    @patch("gitlint.cli.get_stdin_data", return_value="Test tïtle\n\nTest bödy that is long enough")
     def test_run_hook_stdin_no_violations(self, _):
-        """ Test for passing stdin data to run-hook, expecting *NO* violations, Equivalent of:
-            $ echo -e "Test tïtle\n\nTest bödy that is long enough" | gitlint run-hook
+        """Test for passing stdin data to run-hook, expecting *NO* violations, Equivalent of:
+        $ echo -e "Test tïtle\n\nTest bödy that is long enough" | gitlint run-hook
         """
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["run-hook"])
             self.assertEqual(stderr.getvalue(), "")  # no errors = no stderr output
-            expected_stdout = self.get_expected('cli/test_cli_hooks/test_hook_stdin_no_violations_1_stdout')
+            expected_stdout = self.get_expected("cli/test_cli_hooks/test_hook_stdin_no_violations_1_stdout")
             self.assertEqual(result.output, expected_stdout)
             self.assertEqual(result.exit_code, 0)
 
-    @patch('gitlint.cli.get_stdin_data', return_value="WIP: Test hook config tïtle\n")
+    @patch("gitlint.cli.get_stdin_data", return_value="WIP: Test hook config tïtle\n")
     def test_run_hook_config(self, _):
-        """ Test that gitlint still respects config when running run-hook, equivalent of:
-            $ echo "WIP: Test hook config tïtle" | gitlint -c title-max-length.line-length=5 --ignore B6 run-hook
+        """Test that gitlint still respects config when running run-hook, equivalent of:
+        $ echo "WIP: Test hook config tïtle" | gitlint -c title-max-length.line-length=5 --ignore B6 run-hook
         """
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["-c", "title-max-length.line-length=5", "--ignore", "B6", "run-hook"])
-            self.assertEqual(stderr.getvalue(), self.get_expected('cli/test_cli_hooks/test_hook_config_1_stderr'))
-            self.assertEqual(result.output, self.get_expected('cli/test_cli_hooks/test_hook_config_1_stdout'))
+            self.assertEqual(stderr.getvalue(), self.get_expected("cli/test_cli_hooks/test_hook_config_1_stderr"))
+            self.assertEqual(result.output, self.get_expected("cli/test_cli_hooks/test_hook_config_1_stdout"))
             # Hook will auto-abort because we're using stdin. Abort = exit code 1
             self.assertEqual(result.exit_code, 1)
 
-    @patch('gitlint.cli.get_stdin_data', return_value=False)
-    @patch('gitlint.git.sh')
+    @patch("gitlint.cli.get_stdin_data", return_value=False)
+    @patch("gitlint.git.sh")
     def test_run_hook_local_commit(self, sh, _):
-        """ Test running the hook on the last commit-msg from the local repo, equivalent of:
-            $ gitlint run-hook
-            and then choosing 'e'
+        """Test running the hook on the last commit-msg from the local repo, equivalent of:
+        $ gitlint run-hook
+        and then choosing 'e'
         """
         sh.git.side_effect = [
             "6f29bf81a8322a04071bb794666e48c443a90360",
@@ -271,14 +276,14 @@ class CLIHookTests(BaseTestCase):
             "WIP: commït-title\n\ncommït-body",
             "#",  # git config --get core.commentchar
             "commit-1-branch-1\ncommit-1-branch-2\n",
-            "file1.txt\npåth/to/file2.txt\n"
+            "file1.txt\npåth/to/file2.txt\n",
         ]
 
-        with self.patch_input(['e']):
-            with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with self.patch_input(["e"]):
+            with patch("gitlint.display.stderr", new=StringIO()) as stderr:
                 result = self.cli.invoke(cli.cli, ["run-hook"])
-                expected = self.get_expected('cli/test_cli_hooks/test_hook_local_commit_1_stderr')
+                expected = self.get_expected("cli/test_cli_hooks/test_hook_local_commit_1_stderr")
                 self.assertEqual(stderr.getvalue(), expected)
-                self.assertEqual(result.output, self.get_expected('cli/test_cli_hooks/test_hook_local_commit_1_stdout'))
+                self.assertEqual(result.output, self.get_expected("cli/test_cli_hooks/test_hook_local_commit_1_stdout"))
                 # If we can't edit the message, run-hook follows regular gitlint behavior and exit code = # violations
                 self.assertEqual(result.exit_code, 2)

--- a/gitlint-core/gitlint/tests/cli/test_cli_hooks.py
+++ b/gitlint-core/gitlint/tests/cli/test_cli_hooks.py
@@ -272,8 +272,7 @@ class CLIHookTests(BaseTestCase):
         """
         sh.git.side_effect = [
             "6f29bf81a8322a04071bb794666e48c443a90360",
-            "test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
-            "WIP: commït-title\n\ncommït-body",
+            "test åuthor\x00test-email@föo.com\x002016-12-03 15:28:15 +0100\x00åbc\nWIP: commït-title\n\ncommït-body",
             "#",  # git config --get core.commentchar
             "commit-1-branch-1\ncommit-1-branch-2\n",
             "file1.txt\npåth/to/file2.txt\n",

--- a/gitlint-core/gitlint/tests/config/test_config.py
+++ b/gitlint-core/gitlint/tests/config/test_config.py
@@ -35,7 +35,7 @@ class LintConfigTests(BaseTestCase):
         # invalid option value
         expected_error_msg = (
             "'föo' is not a valid value for option 'title-max-length.line-length'. "
-            + "Option 'line-length' must be a positive integer (current value: 'föo')."
+            "Option 'line-length' must be a positive integer (current value: 'föo')."
         )
         with self.assertRaisesMessage(LintConfigError, expected_error_msg):
             config.set_rule_option("title-max-length", "line-length", "föo")

--- a/gitlint-core/gitlint/tests/config/test_config.py
+++ b/gitlint-core/gitlint/tests/config/test_config.py
@@ -9,16 +9,15 @@ from gitlint.tests.base import BaseTestCase
 
 
 class LintConfigTests(BaseTestCase):
-
     def test_set_rule_option(self):
         config = LintConfig()
 
         # assert default title line-length
-        self.assertEqual(config.get_rule_option('title-max-length', 'line-length'), 72)
+        self.assertEqual(config.get_rule_option("title-max-length", "line-length"), 72)
 
         # change line length and assert it is set
-        config.set_rule_option('title-max-length', 'line-length', 60)
-        self.assertEqual(config.get_rule_option('title-max-length', 'line-length'), 60)
+        config.set_rule_option("title-max-length", "line-length", 60)
+        self.assertEqual(config.get_rule_option("title-max-length", "line-length"), 60)
 
     def test_set_rule_option_negative(self):
         config = LintConfig()
@@ -26,18 +25,20 @@ class LintConfigTests(BaseTestCase):
         # non-existing rule
         expected_error_msg = "No such rule 'föobar'"
         with self.assertRaisesMessage(LintConfigError, expected_error_msg):
-            config.set_rule_option(u'föobar', u'lïne-length', 60)
+            config.set_rule_option("föobar", "lïne-length", 60)
 
         # non-existing option
         expected_error_msg = "Rule 'title-max-length' has no option 'föobar'"
         with self.assertRaisesMessage(LintConfigError, expected_error_msg):
-            config.set_rule_option('title-max-length', u'föobar', 60)
+            config.set_rule_option("title-max-length", "föobar", 60)
 
         # invalid option value
-        expected_error_msg = "'föo' is not a valid value for option 'title-max-length.line-length'. " + \
-                             "Option 'line-length' must be a positive integer (current value: 'föo')."
+        expected_error_msg = (
+            "'föo' is not a valid value for option 'title-max-length.line-length'. "
+            + "Option 'line-length' must be a positive integer (current value: 'föo')."
+        )
         with self.assertRaisesMessage(LintConfigError, expected_error_msg):
-            config.set_rule_option('title-max-length', 'line-length', "föo")
+            config.set_rule_option("title-max-length", "line-length", "föo")
 
     def test_set_general_option(self):
         config = LintConfig()
@@ -123,8 +124,8 @@ class LintConfigTests(BaseTestCase):
         self.assertTrue(actual_rule.is_contrib)
 
         self.assertEqual(str(type(actual_rule)), "<class 'conventional_commit.ConventionalCommit'>")
-        self.assertEqual(actual_rule.id, 'CT1')
-        self.assertEqual(actual_rule.name, u'contrib-title-conventional-commits')
+        self.assertEqual(actual_rule.id, "CT1")
+        self.assertEqual(actual_rule.name, "contrib-title-conventional-commits")
         self.assertEqual(actual_rule.target, rules.CommitMessageTitle)
 
         expected_rule_option = options.ListOption(
@@ -134,15 +135,15 @@ class LintConfigTests(BaseTestCase):
         )
 
         self.assertListEqual(actual_rule.options_spec, [expected_rule_option])
-        self.assertDictEqual(actual_rule.options, {'types': expected_rule_option})
+        self.assertDictEqual(actual_rule.options, {"types": expected_rule_option})
 
         # Check contrib-body-requires-signed-off-by contrib rule
         actual_rule = config.rules.find_rule("contrib-body-requires-signed-off-by")
         self.assertTrue(actual_rule.is_contrib)
 
         self.assertEqual(str(type(actual_rule)), "<class 'signedoff_by.SignedOffBy'>")
-        self.assertEqual(actual_rule.id, 'CC1')
-        self.assertEqual(actual_rule.name, u'contrib-body-requires-signed-off-by')
+        self.assertEqual(actual_rule.id, "CC1")
+        self.assertEqual(actual_rule.name, "contrib-body-requires-signed-off-by")
 
         # reset value (this is a different code path)
         config.set_general_option("contrib", "contrib-body-requires-signed-off-by")
@@ -162,7 +163,7 @@ class LintConfigTests(BaseTestCase):
         # UserRuleError, RuleOptionError should be re-raised as LintConfigErrors
         side_effects = [rules.UserRuleError("üser-rule"), options.RuleOptionError("rüle-option")]
         for side_effect in side_effects:
-            with patch('gitlint.config.rule_finder.find_rule_classes', side_effect=side_effect):
+            with patch("gitlint.config.rule_finder.find_rule_classes", side_effect=side_effect):
                 with self.assertRaisesMessage(LintConfigError, str(side_effect)):
                     config.contrib = "contrib-title-conventional-commits"
 
@@ -171,15 +172,15 @@ class LintConfigTests(BaseTestCase):
 
         config.set_general_option("extra-path", self.get_user_rules_path())
         self.assertEqual(config.extra_path, self.get_user_rules_path())
-        actual_rule = config.rules.find_rule('UC1')
+        actual_rule = config.rules.find_rule("UC1")
         self.assertTrue(actual_rule.is_user_defined)
         self.assertEqual(str(type(actual_rule)), "<class 'my_commit_rules.MyUserCommitRule'>")
-        self.assertEqual(actual_rule.id, 'UC1')
-        self.assertEqual(actual_rule.name, u'my-üser-commit-rule')
+        self.assertEqual(actual_rule.id, "UC1")
+        self.assertEqual(actual_rule.name, "my-üser-commit-rule")
         self.assertEqual(actual_rule.target, None)
-        expected_rule_option = options.IntOption('violation-count', 1, "Number of violåtions to return")
+        expected_rule_option = options.IntOption("violation-count", 1, "Number of violåtions to return")
         self.assertListEqual(actual_rule.options_spec, [expected_rule_option])
-        self.assertDictEqual(actual_rule.options, {'violation-count': expected_rule_option})
+        self.assertDictEqual(actual_rule.options, {"violation-count": expected_rule_option})
 
         # reset value (this is a different code path)
         config.set_general_option("extra-path", self.SAMPLES_DIR)
@@ -194,8 +195,9 @@ class LintConfigTests(BaseTestCase):
             config.extra_path = "föo/bar"
 
         # extra path contains classes with errors
-        with self.assertRaisesMessage(LintConfigError,
-                                      "User-defined rule class 'MyUserLineRule' must have a 'validate' method"):
+        with self.assertRaisesMessage(
+            LintConfigError, "User-defined rule class 'MyUserLineRule' must have a 'validate' method"
+        ):
             config.extra_path = self.get_sample_path("user_rules/incorrect_linerule")
 
     def test_set_general_option_negative(self):
@@ -223,31 +225,37 @@ class LintConfigTests(BaseTestCase):
                 config.verbosity = value
 
         # invalid ignore_xxx_commits
-        ignore_attributes = ["ignore_merge_commits", "ignore_fixup_commits", "ignore_fixup_amend_commits",
-                             "ignore_squash_commits", "ignore_revert_commits"]
+        ignore_attributes = [
+            "ignore_merge_commits",
+            "ignore_fixup_commits",
+            "ignore_fixup_amend_commits",
+            "ignore_squash_commits",
+            "ignore_revert_commits",
+        ]
         incorrect_values = [-1, 4, "föo"]
         for attribute in ignore_attributes:
             for value in incorrect_values:
                 option_name = attribute.replace("_", "-")
-                with self.assertRaisesMessage(LintConfigError,
-                                              f"Option '{option_name}' must be either 'true' or 'false'"):
+                with self.assertRaisesMessage(
+                    LintConfigError, f"Option '{option_name}' must be either 'true' or 'false'"
+                ):
                     setattr(config, attribute, value)
 
         # invalid ignore -> not here because ignore is a ListOption which converts everything to a string before
         # splitting which means it it will accept just about everything
 
         # invalid boolean options
-        for attribute in ['debug', 'staged', 'ignore_stdin', 'fail_without_commits']:
+        for attribute in ["debug", "staged", "ignore_stdin", "fail_without_commits"]:
             option_name = attribute.replace("_", "-")
-            with self.assertRaisesMessage(LintConfigError,
-                                          f"Option '{option_name}' must be either 'true' or 'false'"):
+            with self.assertRaisesMessage(LintConfigError, f"Option '{option_name}' must be either 'true' or 'false'"):
                 setattr(config, attribute, "föobar")
 
         # extra-path has its own negative test
 
         # invalid target
-        with self.assertRaisesMessage(LintConfigError,
-                                      "Option target must be an existing directory (current value: 'föo/bar')"):
+        with self.assertRaisesMessage(
+            LintConfigError, "Option target must be an existing directory (current value: 'föo/bar')"
+        ):
             config.target = "föo/bar"
 
     def test_ignore_independent_from_rules(self):
@@ -264,13 +272,23 @@ class LintConfigTests(BaseTestCase):
         self.assertNotEqual(LintConfig(), LintConfigGenerator())
 
         # Ensure LintConfig are not equal if they differ on their attributes
-        attrs = [("verbosity", 1), ("rules", []), ("ignore_stdin", True), ("debug", True),
-                 ("ignore", ["T1"]), ("staged", True), ("_config_path", self.get_sample_path()),
-                 ("ignore_merge_commits", False), ("ignore_fixup_commits", False),
-                 ("ignore_fixup_amend_commits", False),
-                 ("ignore_squash_commits", False), ("ignore_revert_commits", False),
-                 ("extra_path", self.get_sample_path("user_rules")), ("target", self.get_sample_path()),
-                 ("contrib", ["CC1"])]
+        attrs = [
+            ("verbosity", 1),
+            ("rules", []),
+            ("ignore_stdin", True),
+            ("debug", True),
+            ("ignore", ["T1"]),
+            ("staged", True),
+            ("_config_path", self.get_sample_path()),
+            ("ignore_merge_commits", False),
+            ("ignore_fixup_commits", False),
+            ("ignore_fixup_amend_commits", False),
+            ("ignore_squash_commits", False),
+            ("ignore_revert_commits", False),
+            ("extra_path", self.get_sample_path("user_rules")),
+            ("target", self.get_sample_path()),
+            ("contrib", ["CC1"]),
+        ]
         for attr, val in attrs:
             config = LintConfig()
             setattr(config, attr, val)
@@ -287,7 +305,7 @@ class LintConfigTests(BaseTestCase):
 
 class LintConfigGeneratorTests(BaseTestCase):
     @staticmethod
-    @patch('gitlint.config.shutil.copyfile')
+    @patch("gitlint.config.shutil.copyfile")
     def test_install_commit_msg_hook_negative(copy):
         LintConfigGenerator.generate_config("föo/bar/test")
         copy.assert_called_with(GITLINT_CONFIG_TEMPLATE_SRC_PATH, "föo/bar/test")

--- a/gitlint-core/gitlint/tests/config/test_config_builder.py
+++ b/gitlint-core/gitlint/tests/config/test_config_builder.py
@@ -14,24 +14,27 @@ class LintConfigBuilderTests(BaseTestCase):
         config = config_builder.build()
 
         # assert some defaults
-        self.assertEqual(config.get_rule_option('title-max-length', 'line-length'), 72)
-        self.assertEqual(config.get_rule_option('body-max-line-length', 'line-length'), 80)
-        self.assertListEqual(config.get_rule_option('title-must-not-contain-word', 'words'), ["WIP"])
+        self.assertEqual(config.get_rule_option("title-max-length", "line-length"), 72)
+        self.assertEqual(config.get_rule_option("body-max-line-length", "line-length"), 80)
+        self.assertListEqual(config.get_rule_option("title-must-not-contain-word", "words"), ["WIP"])
         self.assertEqual(config.verbosity, 3)
 
         # Make some changes and check blueprint
-        config_builder.set_option('title-max-length', 'line-length', 100)
-        config_builder.set_option('general', 'verbosity', 2)
-        config_builder.set_option('title-must-not-contain-word', 'words', ["foo", "bar"])
-        expected_blueprint = {'title-must-not-contain-word': {'words': ['foo', 'bar']},
-                              'title-max-length': {'line-length': 100}, 'general': {'verbosity': 2}}
+        config_builder.set_option("title-max-length", "line-length", 100)
+        config_builder.set_option("general", "verbosity", 2)
+        config_builder.set_option("title-must-not-contain-word", "words", ["foo", "bar"])
+        expected_blueprint = {
+            "title-must-not-contain-word": {"words": ["foo", "bar"]},
+            "title-max-length": {"line-length": 100},
+            "general": {"verbosity": 2},
+        }
         self.assertDictEqual(config_builder._config_blueprint, expected_blueprint)
 
         # Build config and verify that the changes have occurred and no other changes
         config = config_builder.build()
-        self.assertEqual(config.get_rule_option('title-max-length', 'line-length'), 100)
-        self.assertEqual(config.get_rule_option('body-max-line-length', 'line-length'), 80)  # should be unchanged
-        self.assertListEqual(config.get_rule_option('title-must-not-contain-word', 'words'), ["foo", "bar"])
+        self.assertEqual(config.get_rule_option("title-max-length", "line-length"), 100)
+        self.assertEqual(config.get_rule_option("body-max-line-length", "line-length"), 80)  # should be unchanged
+        self.assertListEqual(config.get_rule_option("title-must-not-contain-word", "words"), ["foo", "bar"])
         self.assertEqual(config.verbosity, 2)
 
     def test_set_from_commit_ignore_all(self):
@@ -82,8 +85,8 @@ class LintConfigBuilderTests(BaseTestCase):
         self.assertIsNone(config.extra_path)
         self.assertEqual(config.ignore, ["title-trailing-whitespace", "B2"])
 
-        self.assertEqual(config.get_rule_option('title-max-length', 'line-length'), 20)
-        self.assertEqual(config.get_rule_option('body-max-line-length', 'line-length'), 30)
+        self.assertEqual(config.get_rule_option("title-max-length", "line-length"), 20)
+        self.assertEqual(config.get_rule_option("body-max-line-length", "line-length"), 30)
 
     def test_set_from_config_file_negative(self):
         config_builder = LintConfigBuilder()
@@ -129,8 +132,10 @@ class LintConfigBuilderTests(BaseTestCase):
         path = self.get_sample_path("config/invalid-option-value")
         config_builder = LintConfigBuilder()
         config_builder.set_from_config_file(path)
-        expected_error_msg = "'föo' is not a valid value for option 'title-max-length.line-length'. " + \
-                             "Option 'line-length' must be a positive integer (current value: 'föo')."
+        expected_error_msg = (
+            "'föo' is not a valid value for option 'title-max-length.line-length'. "
+            "Option 'line-length' must be a positive integer (current value: 'föo')."
+        )
         with self.assertRaisesMessage(LintConfigError, expected_error_msg):
             config_builder.build()
 
@@ -139,14 +144,19 @@ class LintConfigBuilderTests(BaseTestCase):
 
         # change and assert changes
         config_builder = LintConfigBuilder()
-        config_builder.set_config_from_string_list(['general.verbosity=1', 'title-max-length.line-length=60',
-                                                    'body-max-line-length.line-length=120',
-                                                    "title-must-not-contain-word.words=håha"])
+        config_builder.set_config_from_string_list(
+            [
+                "general.verbosity=1",
+                "title-max-length.line-length=60",
+                "body-max-line-length.line-length=120",
+                "title-must-not-contain-word.words=håha",
+            ]
+        )
 
         config = config_builder.build()
-        self.assertEqual(config.get_rule_option('title-max-length', 'line-length'), 60)
-        self.assertEqual(config.get_rule_option('body-max-line-length', 'line-length'), 120)
-        self.assertListEqual(config.get_rule_option('title-must-not-contain-word', 'words'), ["håha"])
+        self.assertEqual(config.get_rule_option("title-max-length", "line-length"), 60)
+        self.assertEqual(config.get_rule_option("body-max-line-length", "line-length"), 120)
+        self.assertListEqual(config.get_rule_option("title-must-not-contain-word", "words"), ["håha"])
         self.assertEqual(config.verbosity, 1)
 
     def test_set_config_from_string_list_negative(self):
@@ -175,12 +185,12 @@ class LintConfigBuilderTests(BaseTestCase):
         # no period between rule and option names
         expected_msg = "'föobar=1' is an invalid configuration option. Use '<rule>.<option>=<value>'"
         with self.assertRaisesMessage(LintConfigError, expected_msg):
-            config_builder.set_config_from_string_list([u'föobar=1'])
+            config_builder.set_config_from_string_list(["föobar=1"])
 
     def test_rebuild_config(self):
         # normal config build
         config_builder = LintConfigBuilder()
-        config_builder.set_option('general', 'verbosity', 3)
+        config_builder.set_option("general", "verbosity", 3)
         lint_config = config_builder.build()
         self.assertEqual(lint_config.verbosity, 3)
 
@@ -193,9 +203,9 @@ class LintConfigBuilderTests(BaseTestCase):
 
     def test_clone(self):
         config_builder = LintConfigBuilder()
-        config_builder.set_option('general', 'verbosity', 2)
-        config_builder.set_option('title-max-length', 'line-length', 100)
-        expected = {'title-max-length': {'line-length': 100}, 'general': {'verbosity': 2}}
+        config_builder.set_option("general", "verbosity", 2)
+        config_builder.set_option("title-max-length", "line-length", 100)
+        expected = {"title-max-length": {"line-length": 100}, "general": {"verbosity": 2}}
         self.assertDictEqual(config_builder._config_blueprint, expected)
 
         # Clone and verify that the blueprint is the same as the original
@@ -203,7 +213,7 @@ class LintConfigBuilderTests(BaseTestCase):
         self.assertDictEqual(cloned_builder._config_blueprint, expected)
 
         # Modify the original and make sure we're not modifying the clone (i.e. check that the copy is a deep copy)
-        config_builder.set_option('title-max-length', 'line-length', 120)
+        config_builder.set_option("title-max-length", "line-length", 120)
         self.assertDictEqual(cloned_builder._config_blueprint, expected)
 
     def test_named_rules(self):
@@ -215,17 +225,22 @@ class LintConfigBuilderTests(BaseTestCase):
 
         # Add a named rule by setting an option in the config builder that follows the named rule pattern
         # Assert that whitespace in the rule name is stripped
-        rule_qualifiers = [u'T7:my-extra-rüle', u' T7 :   my-extra-rüle  ', u'\tT7:\tmy-extra-rüle\t',
-                           u'T7:\t\n  \tmy-extra-rüle\t\n\n', "title-match-regex:my-extra-rüle"]
+        rule_qualifiers = [
+            "T7:my-extra-rüle",
+            " T7 :   my-extra-rüle  ",
+            "\tT7:\tmy-extra-rüle\t",
+            "T7:\t\n  \tmy-extra-rüle\t\n\n",
+            "title-match-regex:my-extra-rüle",
+        ]
         for rule_qualifier in rule_qualifiers:
             config_builder = LintConfigBuilder()
-            config_builder.set_option(rule_qualifier, 'regex', "föo")
+            config_builder.set_option(rule_qualifier, "regex", "föo")
 
             expected_rules = copy.deepcopy(default_rules)
-            my_rule = rules.TitleRegexMatches({'regex': "föo"})
+            my_rule = rules.TitleRegexMatches({"regex": "föo"})
             my_rule.id = rules.TitleRegexMatches.id + ":my-extra-rüle"
             my_rule.name = rules.TitleRegexMatches.name + ":my-extra-rüle"
-            expected_rules._rules[u'T7:my-extra-rüle'] = my_rule
+            expected_rules._rules["T7:my-extra-rüle"] = my_rule
             self.assertEqual(config_builder.build().rules, expected_rules)
 
             # assert that changing an option on the newly added rule is passed correctly to the RuleCollection
@@ -233,20 +248,20 @@ class LintConfigBuilderTests(BaseTestCase):
             # to the same rule
             for other_rule_qualifier in rule_qualifiers:
                 cb = config_builder.clone()
-                cb.set_option(other_rule_qualifier, 'regex', other_rule_qualifier + "bōr")
+                cb.set_option(other_rule_qualifier, "regex", other_rule_qualifier + "bōr")
                 # before setting the expected rule option value correctly, the RuleCollection should be different
                 self.assertNotEqual(cb.build().rules, expected_rules)
                 # after setting the option on the expected rule, it should be equal
-                my_rule.options['regex'].set(other_rule_qualifier + "bōr")
+                my_rule.options["regex"].set(other_rule_qualifier + "bōr")
                 self.assertEqual(cb.build().rules, expected_rules)
-                my_rule.options['regex'].set("wrong")
+                my_rule.options["regex"].set("wrong")
 
     def test_named_rules_negative(self):
         # T7 = title-match-regex
         # Invalid rule name
         for invalid_name in ["", " ", "    ", "\t", "\n", "å b", "å:b", "åb:", ":åb"]:
             config_builder = LintConfigBuilder()
-            config_builder.set_option(f"T7:{invalid_name}", 'regex', "tëst")
+            config_builder.set_option(f"T7:{invalid_name}", "regex", "tëst")
             expected_msg = f"The rule-name part in 'T7:{invalid_name}' cannot contain whitespace, colons or be empty"
             with self.assertRaisesMessage(LintConfigError, expected_msg):
                 config_builder.build()

--- a/gitlint-core/gitlint/tests/config/test_config_precedence.py
+++ b/gitlint-core/gitlint/tests/config/test_config_precedence.py
@@ -15,7 +15,7 @@ class LintConfigPrecedenceTests(BaseTestCase):
     def setUp(self):
         self.cli = CliRunner()
 
-    @patch('gitlint.cli.get_stdin_data', return_value="WIP:fö\n\nThis is å test message\n")
+    @patch("gitlint.cli.get_stdin_data", return_value="WIP:fö\n\nThis is å test message\n")
     def test_config_precedence(self, _):
         # TODO(jroovers): this test really only test verbosity, we need to do some refactoring to gitlint.cli
         # to more easily test everything
@@ -28,60 +28,63 @@ class LintConfigPrecedenceTests(BaseTestCase):
         config_path = self.get_sample_path("config/gitlintconfig")
 
         # 1. commandline convenience flags
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["-vvv", "-c", "general.verbosity=2", "--config", config_path])
             self.assertEqual(result.output, "")
             self.assertEqual(stderr.getvalue(), "1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP:fö\"\n")
 
         # 2. environment variables
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
-            result = self.cli.invoke(cli.cli, ["-c", "general.verbosity=2", "--config", config_path],
-                                     env={"GITLINT_VERBOSITY": "3"})
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
+            result = self.cli.invoke(
+                cli.cli, ["-c", "general.verbosity=2", "--config", config_path], env={"GITLINT_VERBOSITY": "3"}
+            )
             self.assertEqual(result.output, "")
             self.assertEqual(stderr.getvalue(), "1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP:fö\"\n")
 
         # 3. commandline -c flags
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["-c", "general.verbosity=2", "--config", config_path])
             self.assertEqual(result.output, "")
             self.assertEqual(stderr.getvalue(), "1: T5 Title contains the word 'WIP' (case-insensitive)\n")
 
         # 4. config file
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli, ["--config", config_path])
             self.assertEqual(result.output, "")
             self.assertEqual(stderr.getvalue(), "1: T5\n")
 
         # 5. default config
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             result = self.cli.invoke(cli.cli)
             self.assertEqual(result.output, "")
             self.assertEqual(stderr.getvalue(), "1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP:fö\"\n")
 
-    @patch('gitlint.cli.get_stdin_data', return_value="WIP: This is å test")
+    @patch("gitlint.cli.get_stdin_data", return_value="WIP: This is å test")
     def test_ignore_precedence(self, get_stdin_data):
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             # --ignore takes precedence over -c general.ignore
             result = self.cli.invoke(cli.cli, ["-c", "general.ignore=T5", "--ignore", "B6"])
             self.assertEqual(result.output, "")
             self.assertEqual(result.exit_code, 1)
             # We still expect the T5 violation, but no B6 violation as --ignore overwrites -c general.ignore
-            self.assertEqual(stderr.getvalue(),
-                             "1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP: This is å test\"\n")
+            self.assertEqual(
+                stderr.getvalue(), "1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP: This is å test\"\n"
+            )
 
         # test that we can also still configure a rule that is first ignored but then not
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             get_stdin_data.return_value = "This is å test"
             # --ignore takes precedence over -c general.ignore
-            result = self.cli.invoke(cli.cli, ["-c", "general.ignore=title-max-length",
-                                               "-c", "title-max-length.line-length=5",
-                                               "--ignore", "B6"])
+            result = self.cli.invoke(
+                cli.cli,
+                ["-c", "general.ignore=title-max-length", "-c", "title-max-length.line-length=5", "--ignore", "B6"],
+            )
             self.assertEqual(result.output, "")
             self.assertEqual(result.exit_code, 1)
 
             # We still expect the T1 violation with custom config,
             # but no B6 violation as --ignore overwrites -c general.ignore
-            self.assertEqual(stderr.getvalue(), "1: T1 Title exceeds max length (14>5): \"This is å test\"\n")
+            self.assertEqual(stderr.getvalue(), '1: T1 Title exceeds max length (14>5): "This is å test"\n')
 
     def test_general_option_after_rule_option(self):
         # We used to have a bug where we didn't process general options before setting specific options, this would
@@ -89,10 +92,10 @@ class LintConfigPrecedenceTests(BaseTestCase):
         # This test is here to test for regressions against this.
 
         config_builder = LintConfigBuilder()
-        config_builder.set_option(u'my-üser-commit-rule', 'violation-count', 3)
+        config_builder.set_option("my-üser-commit-rule", "violation-count", 3)
         user_rules_path = self.get_sample_path("user_rules")
-        config_builder.set_option('general', 'extra-path', user_rules_path)
+        config_builder.set_option("general", "extra-path", user_rules_path)
         config = config_builder.build()
 
         self.assertEqual(config.extra_path, user_rules_path)
-        self.assertEqual(config.get_rule_option(u'my-üser-commit-rule', 'violation-count'), 3)
+        self.assertEqual(config.get_rule_option("my-üser-commit-rule", "violation-count"), 3)

--- a/gitlint-core/gitlint/tests/config/test_rule_collection.py
+++ b/gitlint-core/gitlint/tests/config/test_rule_collection.py
@@ -7,7 +7,6 @@ from gitlint.tests.base import BaseTestCase
 
 
 class RuleCollectionTests(BaseTestCase):
-
     def test_add_rule(self):
         collection = RuleCollection()
         collection.add_rule(rules.TitleMaxLength, "my-rüle", {"my_attr": "föo", "my_attr2": 123})
@@ -29,18 +28,18 @@ class RuleCollectionTests(BaseTestCase):
 
         # find by id
         expected = rules.TitleMaxLength()
-        rule = collection.find_rule('T1')
+        rule = collection.find_rule("T1")
         self.assertEqual(rule, expected)
         self.assertEqual(rule.my_attr, "föo")
 
         # find by name
         expected2 = rules.TitleTrailingWhitespace()
-        rule = collection.find_rule('title-trailing-whitespace')
+        rule = collection.find_rule("title-trailing-whitespace")
         self.assertEqual(rule, expected2)
         self.assertEqual(rule.my_attr, "föo")
 
         # find non-existing
-        rule = collection.find_rule(u'föo')
+        rule = collection.find_rule("föo")
         self.assertIsNone(rule)
 
     def test_delete_rules_by_attr(self):

--- a/gitlint-core/gitlint/tests/contrib/rules/test_conventional_commit.py
+++ b/gitlint-core/gitlint/tests/contrib/rules/test_conventional_commit.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 from gitlint.tests.base import BaseTestCase
 from gitlint.rules import RuleViolation
@@ -7,10 +6,9 @@ from gitlint.config import LintConfig
 
 
 class ContribConventionalCommitTests(BaseTestCase):
-
     def test_enable(self):
         # Test that rule can be enabled in config
-        for rule_ref in ['CT1', 'contrib-title-conventional-commits']:
+        for rule_ref in ["CT1", "contrib-title-conventional-commits"]:
             config = LintConfig()
             config.contrib = [rule_ref]
             self.assertIn(ConventionalCommit(), config.rules)
@@ -24,28 +22,41 @@ class ContribConventionalCommitTests(BaseTestCase):
             self.assertListEqual([], violations)
 
         # assert violation on wrong type
-        expected_violation = RuleViolation("CT1", "Title does not start with one of fix, feat, chore, docs,"
-                                                  " style, refactor, perf, test, revert, ci, build", "bår: foo")
+        expected_violation = RuleViolation(
+            "CT1",
+            "Title does not start with one of fix, feat, chore, docs,"
+            " style, refactor, perf, test, revert, ci, build",
+            "bår: foo",
+        )
         violations = rule.validate("bår: foo", None)
         self.assertListEqual([expected_violation], violations)
 
         # assert violation when use strange chars after correct type
-        expected_violation = RuleViolation("CT1", "Title does not start with one of fix, feat, chore, docs,"
-                                                  " style, refactor, perf, test, revert, ci, build",
-                                                  "feat_wrong_chars: föo")
+        expected_violation = RuleViolation(
+            "CT1",
+            "Title does not start with one of fix, feat, chore, docs,"
+            " style, refactor, perf, test, revert, ci, build",
+            "feat_wrong_chars: föo",
+        )
         violations = rule.validate("feat_wrong_chars: föo", None)
         self.assertListEqual([expected_violation], violations)
 
         # assert violation when use strange chars after correct type
-        expected_violation = RuleViolation("CT1", "Title does not start with one of fix, feat, chore, docs,"
-                                                  " style, refactor, perf, test, revert, ci, build",
-                                                  "feat_wrong_chars(scope): föo")
+        expected_violation = RuleViolation(
+            "CT1",
+            "Title does not start with one of fix, feat, chore, docs,"
+            " style, refactor, perf, test, revert, ci, build",
+            "feat_wrong_chars(scope): föo",
+        )
         violations = rule.validate("feat_wrong_chars(scope): föo", None)
         self.assertListEqual([expected_violation], violations)
 
         # assert violation on wrong format
-        expected_violation = RuleViolation("CT1", "Title does not follow ConventionalCommits.org format "
-                                                  "'type(optional-scope): description'", "fix föo")
+        expected_violation = RuleViolation(
+            "CT1",
+            "Title does not follow ConventionalCommits.org format " "'type(optional-scope): description'",
+            "fix föo",
+        )
         violations = rule.validate("fix föo", None)
         self.assertListEqual([expected_violation], violations)
 
@@ -58,7 +69,7 @@ class ContribConventionalCommitTests(BaseTestCase):
         self.assertListEqual([], violations)
 
         # assert no violation when adding new type
-        rule = ConventionalCommit({'types': ["föo", "bär"]})
+        rule = ConventionalCommit({"types": ["föo", "bär"]})
         for typ in ["föo", "bär"]:
             violations = rule.validate(typ + ": hür dur", None)
             self.assertListEqual([], violations)
@@ -69,7 +80,7 @@ class ContribConventionalCommitTests(BaseTestCase):
         self.assertListEqual([expected_violation], violations)
 
         # assert no violation when adding new type named with numbers
-        rule = ConventionalCommit({'types': ["föo123", "123bär"]})
+        rule = ConventionalCommit({"types": ["föo123", "123bär"]})
         for typ in ["föo123", "123bär"]:
             violations = rule.validate(typ + ": hür dur", None)
             self.assertListEqual([], violations)

--- a/gitlint-core/gitlint/tests/contrib/rules/test_conventional_commit.py
+++ b/gitlint-core/gitlint/tests/contrib/rules/test_conventional_commit.py
@@ -24,8 +24,7 @@ class ContribConventionalCommitTests(BaseTestCase):
         # assert violation on wrong type
         expected_violation = RuleViolation(
             "CT1",
-            "Title does not start with one of fix, feat, chore, docs,"
-            " style, refactor, perf, test, revert, ci, build",
+            "Title does not start with one of fix, feat, chore, docs, style, refactor, perf, test, revert, ci, build",
             "bår: foo",
         )
         violations = rule.validate("bår: foo", None)
@@ -34,8 +33,7 @@ class ContribConventionalCommitTests(BaseTestCase):
         # assert violation when use strange chars after correct type
         expected_violation = RuleViolation(
             "CT1",
-            "Title does not start with one of fix, feat, chore, docs,"
-            " style, refactor, perf, test, revert, ci, build",
+            "Title does not start with one of fix, feat, chore, docs, style, refactor, perf, test, revert, ci, build",
             "feat_wrong_chars: föo",
         )
         violations = rule.validate("feat_wrong_chars: föo", None)
@@ -44,8 +42,7 @@ class ContribConventionalCommitTests(BaseTestCase):
         # assert violation when use strange chars after correct type
         expected_violation = RuleViolation(
             "CT1",
-            "Title does not start with one of fix, feat, chore, docs,"
-            " style, refactor, perf, test, revert, ci, build",
+            "Title does not start with one of fix, feat, chore, docs, style, refactor, perf, test, revert, ci, build",
             "feat_wrong_chars(scope): föo",
         )
         violations = rule.validate("feat_wrong_chars(scope): föo", None)
@@ -54,7 +51,7 @@ class ContribConventionalCommitTests(BaseTestCase):
         # assert violation on wrong format
         expected_violation = RuleViolation(
             "CT1",
-            "Title does not follow ConventionalCommits.org format " "'type(optional-scope): description'",
+            "Title does not follow ConventionalCommits.org format 'type(optional-scope): description'",
             "fix föo",
         )
         violations = rule.validate("fix föo", None)

--- a/gitlint-core/gitlint/tests/contrib/rules/test_disallow_cleanup_commits.py
+++ b/gitlint-core/gitlint/tests/contrib/rules/test_disallow_cleanup_commits.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 from gitlint.tests.base import BaseTestCase
 from gitlint.rules import RuleViolation
@@ -8,10 +7,9 @@ from gitlint.config import LintConfig
 
 
 class ContribDisallowCleanupCommitsTest(BaseTestCase):
-
     def test_enable(self):
         # Test that rule can be enabled in config
-        for rule_ref in ['CC2', 'contrib-disallow-cleanup-commits']:
+        for rule_ref in ["CC2", "contrib-disallow-cleanup-commits"]:
             config = LintConfig()
             config.contrib = [rule_ref]
             self.assertIn(DisallowCleanupCommits(), config.rules)

--- a/gitlint-core/gitlint/tests/contrib/rules/test_signedoff_by.py
+++ b/gitlint-core/gitlint/tests/contrib/rules/test_signedoff_by.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 from gitlint.tests.base import BaseTestCase
 from gitlint.rules import RuleViolation
@@ -8,10 +7,9 @@ from gitlint.config import LintConfig
 
 
 class ContribSignedOffByTests(BaseTestCase):
-
     def test_enable(self):
         # Test that rule can be enabled in config
-        for rule_ref in ['CC1', 'contrib-body-requires-signed-off-by']:
+        for rule_ref in ["CC1", "contrib-body-requires-signed-off-by"]:
             config = LintConfig()
             config.contrib = [rule_ref]
             self.assertIn(SignedOffBy(), config.rules)

--- a/gitlint-core/gitlint/tests/contrib/test_contrib_rules.py
+++ b/gitlint-core/gitlint/tests/contrib/test_contrib_rules.py
@@ -12,9 +12,9 @@ class ContribRuleTests(BaseTestCase):
     CONTRIB_DIR = os.path.dirname(os.path.realpath(contrib_rules.__file__))
 
     def test_contrib_tests_exist(self):
-        """ Tests that every contrib rule file has an associated test file.
-            While this doesn't guarantee that every contrib rule has associated tests (as we don't check the content
-            of the tests file), it's a good leading indicator. """
+        """Tests that every contrib rule file has an associated test file.
+        While this doesn't guarantee that every contrib rule has associated tests (as we don't check the content
+        of the tests file), it's a good leading indicator."""
 
         contrib_tests_dir = os.path.dirname(os.path.realpath(contrib_tests.__file__))
         contrib_test_files = os.listdir(contrib_tests_dir)
@@ -23,15 +23,17 @@ class ContribRuleTests(BaseTestCase):
         for filename in os.listdir(self.CONTRIB_DIR):
             if filename.endswith(".py") and filename not in ["__init__.py"]:
                 expected_test_file = "test_" + filename
-                error_msg = "Every Contrib Rule must have associated tests. " + \
-                            f"Expected test file {os.path.join(contrib_tests_dir, expected_test_file)} not found."
+                error_msg = (
+                    "Every Contrib Rule must have associated tests. "
+                    + f"Expected test file {os.path.join(contrib_tests_dir, expected_test_file)} not found."
+                )
                 self.assertIn(expected_test_file, contrib_test_files, error_msg)
 
     def test_contrib_rule_naming_conventions(self):
-        """ Tests that contrib rules follow certain naming conventions.
-            We can test for this at test time (and not during runtime like rule_finder.assert_valid_rule_class does)
-            because these are contrib rules: once they're part of gitlint they can't change unless they pass this test
-            again.
+        """Tests that contrib rules follow certain naming conventions.
+        We can test for this at test time (and not during runtime like rule_finder.assert_valid_rule_class does)
+        because these are contrib rules: once they're part of gitlint they can't change unless they pass this test
+        again.
         """
         rule_classes = rule_finder.find_rule_classes(self.CONTRIB_DIR)
 
@@ -47,10 +49,10 @@ class ContribRuleTests(BaseTestCase):
                     self.assertTrue(clazz.id.startswith("CB"))
 
     def test_contrib_rule_uniqueness(self):
-        """ Tests that all contrib rules have unique identifiers.
-            We can test for this at test time (and not during runtime like rule_finder.assert_valid_rule_class does)
-            because these are contrib rules: once they're part of gitlint they can't change unless they pass this test
-            again.
+        """Tests that all contrib rules have unique identifiers.
+        We can test for this at test time (and not during runtime like rule_finder.assert_valid_rule_class does)
+        because these are contrib rules: once they're part of gitlint they can't change unless they pass this test
+        again.
         """
         rule_classes = rule_finder.find_rule_classes(self.CONTRIB_DIR)
 
@@ -61,7 +63,7 @@ class ContribRuleTests(BaseTestCase):
         self.assertEqual(len(set(class_ids)), len(class_ids))
 
     def test_contrib_rule_instantiated(self):
-        """ Tests that all contrib rules can be instantiated without errors. """
+        """Tests that all contrib rules can be instantiated without errors."""
         rule_classes = rule_finder.find_rule_classes(self.CONTRIB_DIR)
 
         # No exceptions = what we want :-)

--- a/gitlint-core/gitlint/tests/contrib/test_contrib_rules.py
+++ b/gitlint-core/gitlint/tests/contrib/test_contrib_rules.py
@@ -8,7 +8,6 @@ from gitlint import rule_finder, rules
 
 
 class ContribRuleTests(BaseTestCase):
-
     CONTRIB_DIR = os.path.dirname(os.path.realpath(contrib_rules.__file__))
 
     def test_contrib_tests_exist(self):
@@ -22,10 +21,10 @@ class ContribRuleTests(BaseTestCase):
         # Find all python files in the contrib dir and assert there's a corresponding test file
         for filename in os.listdir(self.CONTRIB_DIR):
             if filename.endswith(".py") and filename not in ["__init__.py"]:
-                expected_test_file = "test_" + filename
+                expected_test_file = f"test_{filename}"
                 error_msg = (
                     "Every Contrib Rule must have associated tests. "
-                    + f"Expected test file {os.path.join(contrib_tests_dir, expected_test_file)} not found."
+                    f"Expected test file {os.path.join(contrib_tests_dir, expected_test_file)} not found."
                 )
                 self.assertIn(expected_test_file, contrib_test_files, error_msg)
 

--- a/gitlint-core/gitlint/tests/git/test_git.py
+++ b/gitlint-core/gitlint/tests/git/test_git.py
@@ -10,7 +10,6 @@ from gitlint.git import GitContext, GitContextError, GitNotInstalledError, git_c
 
 
 class GitTests(BaseTestCase):
-
     # Expected special_args passed to 'sh'
     expected_sh_special_args = {"_tty_out": False, "_cwd": "fåke/path"}
 

--- a/gitlint-core/gitlint/tests/git/test_git.py
+++ b/gitlint-core/gitlint/tests/git/test_git.py
@@ -12,23 +12,22 @@ from gitlint.git import GitContext, GitContextError, GitNotInstalledError, git_c
 class GitTests(BaseTestCase):
 
     # Expected special_args passed to 'sh'
-    expected_sh_special_args = {
-        '_tty_out': False,
-        '_cwd': "fåke/path"
-    }
+    expected_sh_special_args = {"_tty_out": False, "_cwd": "fåke/path"}
 
-    @patch('gitlint.git.sh')
+    @patch("gitlint.git.sh")
     def test_get_latest_commit_command_not_found(self, sh):
         sh.git.side_effect = CommandNotFound("git")
-        expected_msg = "'git' command not found. You need to install git to use gitlint on a local repository. " + \
-                       "See https://git-scm.com/book/en/v2/Getting-Started-Installing-Git on how to install git."
+        expected_msg = (
+            "'git' command not found. You need to install git to use gitlint on a local repository. "
+            + "See https://git-scm.com/book/en/v2/Getting-Started-Installing-Git on how to install git."
+        )
         with self.assertRaisesMessage(GitNotInstalledError, expected_msg):
             GitContext.from_local_repository("fåke/path")
 
         # assert that commit message was read using git command
         sh.git.assert_called_once_with("log", "-1", "--pretty=%H", **self.expected_sh_special_args)
 
-    @patch('gitlint.git.sh')
+    @patch("gitlint.git.sh")
     def test_get_latest_commit_git_error(self, sh):
         # Current directory not a git repo
         err = b"fatal: Not a git repository (or any of the parent directories): .git"
@@ -51,7 +50,7 @@ class GitTests(BaseTestCase):
         # assert that commit message was read using git command
         sh.git.assert_called_once_with("log", "-1", "--pretty=%H", **self.expected_sh_special_args)
 
-    @patch('gitlint.git.sh')
+    @patch("gitlint.git.sh")
     def test_git_no_commits_error(self, sh):
         # No commits: returned by 'git log'
         err = b"fatal: your current branch 'master' does not have any commits yet"
@@ -65,32 +64,34 @@ class GitTests(BaseTestCase):
         # assert that commit message was read using git command
         sh.git.assert_called_once_with("log", "-1", "--pretty=%H", **self.expected_sh_special_args)
 
-    @patch('gitlint.git.sh')
+    @patch("gitlint.git.sh")
     def test_git_no_commits_get_branch(self, sh):
-        """ Check that we can still read the current branch name when there's no commits. This is useful when
-            when trying to lint the first commit using the --staged flag.
+        """Check that we can still read the current branch name when there's no commits. This is useful when
+        when trying to lint the first commit using the --staged flag.
         """
         # Unknown reference 'HEAD' commits: returned by 'git rev-parse'
-        err = (b"HEAD"
-               b"fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree."
-               b"Use '--' to separate paths from revisions, like this:"
-               b"'git <command> [<revision>...] -- [<file>...]'")
+        err = (
+            b"HEAD"
+            b"fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree."
+            b"Use '--' to separate paths from revisions, like this:"
+            b"'git <command> [<revision>...] -- [<file>...]'"
+        )
 
         sh.git.side_effect = [
             "#\n",  # git config --get core.commentchar
             ErrorReturnCode("rev-parse --abbrev-ref HEAD", b"", err),
-            'test-branch',  # git branch --show-current
+            "test-branch",  # git branch --show-current
         ]
 
         context = GitContext.from_commit_msg("test")
-        self.assertEqual(context.current_branch, 'test-branch')
+        self.assertEqual(context.current_branch, "test-branch")
 
         # assert that we try using `git rev-parse` first, and if that fails (as will be the case with the first commit),
         #  we fallback to `git branch --show-current` to determine the current branch name.
         expected_calls = [
             call("config", "--get", "core.commentchar", _tty_out=False, _cwd=None, _ok_code=[0, 1]),
             call("rev-parse", "--abbrev-ref", "HEAD", _tty_out=False, _cwd=None),
-            call("branch", "--show-current", _tty_out=False, _cwd=None)
+            call("branch", "--show-current", _tty_out=False, _cwd=None),
         ]
 
         self.assertEqual(sh.git.mock_calls, expected_calls)
@@ -104,11 +105,10 @@ class GitTests(BaseTestCase):
         git.return_value = "ä"
         self.assertEqual(git_commentchar(), "ä")
 
-        git.return_value = ';\n'
-        self.assertEqual(git_commentchar(os.path.join("/föo", "bar")), ';')
+        git.return_value = ";\n"
+        self.assertEqual(git_commentchar(os.path.join("/föo", "bar")), ";")
 
-        git.assert_called_with("config", "--get", "core.commentchar", _ok_code=[0, 1],
-                               _cwd=os.path.join("/föo", "bar"))
+        git.assert_called_with("config", "--get", "core.commentchar", _ok_code=[0, 1], _cwd=os.path.join("/föo", "bar"))
 
     @patch("gitlint.git._git")
     def test_git_hooks_dir(self, git):

--- a/gitlint-core/gitlint/tests/git/test_git_commit.py
+++ b/gitlint-core/gitlint/tests/git/test_git_commit.py
@@ -16,22 +16,18 @@ from gitlint.shell import ErrorReturnCode
 class GitCommitTests(BaseTestCase):
 
     # Expected special_args passed to 'sh'
-    expected_sh_special_args = {
-        '_tty_out': False,
-        '_cwd': "fåke/path"
-    }
+    expected_sh_special_args = {"_tty_out": False, "_cwd": "fåke/path"}
 
-    @patch('gitlint.git.sh')
+    @patch("gitlint.git.sh")
     def test_get_latest_commit(self, sh):
         sample_sha = "d8ac47e9f2923c7f22d8668e3a1ed04eb4cdbca9"
 
         sh.git.side_effect = [
             sample_sha,
-            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
-            "cömmit-title\n\ncömmit-body",
+            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "cömmit-title\n\ncömmit-body",
             "#",  # git config --get core.commentchar
             "file1.txt\npåth/to/file2.txt\n",
-            "foöbar\n* hürdur\n"
+            "foöbar\n* hürdur\n",
         ]
 
         context = GitContext.from_local_repository("fåke/path")
@@ -39,10 +35,17 @@ class GitCommitTests(BaseTestCase):
         expected_calls = [
             call("log", "-1", "--pretty=%H", **self.expected_sh_special_args),
             call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
-            call('config', '--get', 'core.commentchar', _ok_code=[0, 1], **self.expected_sh_special_args),
-            call('diff-tree', '--no-commit-id', '--name-only', '-r', '--root', sample_sha,
-                 **self.expected_sh_special_args),
-            call('branch', '--contains', sample_sha, **self.expected_sh_special_args)
+            call("config", "--get", "core.commentchar", _ok_code=[0, 1], **self.expected_sh_special_args),
+            call(
+                "diff-tree",
+                "--no-commit-id",
+                "--name-only",
+                "-r",
+                "--root",
+                sample_sha,
+                **self.expected_sh_special_args,
+            ),
+            call("branch", "--contains", sample_sha, **self.expected_sh_special_args),
         ]
 
         # Only first 'git log' call should've happened at this point
@@ -55,8 +58,9 @@ class GitCommitTests(BaseTestCase):
         self.assertEqual(last_commit.message.body, ["", "cömmit-body"])
         self.assertEqual(last_commit.author_name, "test åuthor")
         self.assertEqual(last_commit.author_email, "test-emåil@foo.com")
-        self.assertEqual(last_commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15,
-                                                             tzinfo=dateutil.tz.tzoffset("+0100", 3600)))
+        self.assertEqual(
+            last_commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15, tzinfo=dateutil.tz.tzoffset("+0100", 3600))
+        )
         self.assertListEqual(last_commit.parents, ["åbc"])
         self.assertFalse(last_commit.is_merge_commit)
         self.assertFalse(last_commit.is_fixup_commit)
@@ -75,18 +79,17 @@ class GitCommitTests(BaseTestCase):
         # All expected calls should've happened at this point
         self.assertListEqual(sh.git.mock_calls, expected_calls)
 
-    @patch('gitlint.git.sh')
+    @patch("gitlint.git.sh")
     def test_from_local_repository_specific_refspec(self, sh):
         sample_refspec = "åbc123..def456"
         sample_sha = "åbc123"
 
         sh.git.side_effect = [
             sample_sha,  # git rev-list <sample_refspec>
-            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
-            "cömmit-title\n\ncömmit-body",
+            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "cömmit-title\n\ncömmit-body",
             "#",  # git config --get core.commentchar
             "file1.txt\npåth/to/file2.txt\n",
-            "foöbar\n* hürdur\n"
+            "foöbar\n* hürdur\n",
         ]
 
         context = GitContext.from_local_repository("fåke/path", refspec=sample_refspec)
@@ -94,10 +97,17 @@ class GitCommitTests(BaseTestCase):
         expected_calls = [
             call("rev-list", sample_refspec, **self.expected_sh_special_args),
             call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
-            call('config', '--get', 'core.commentchar', _ok_code=[0, 1], **self.expected_sh_special_args),
-            call('diff-tree', '--no-commit-id', '--name-only', '-r', '--root', sample_sha,
-                 **self.expected_sh_special_args),
-            call('branch', '--contains', sample_sha, **self.expected_sh_special_args)
+            call("config", "--get", "core.commentchar", _ok_code=[0, 1], **self.expected_sh_special_args),
+            call(
+                "diff-tree",
+                "--no-commit-id",
+                "--name-only",
+                "-r",
+                "--root",
+                sample_sha,
+                **self.expected_sh_special_args,
+            ),
+            call("branch", "--contains", sample_sha, **self.expected_sh_special_args),
         ]
 
         # Only first 'git log' call should've happened at this point
@@ -110,8 +120,9 @@ class GitCommitTests(BaseTestCase):
         self.assertEqual(last_commit.message.body, ["", "cömmit-body"])
         self.assertEqual(last_commit.author_name, "test åuthor")
         self.assertEqual(last_commit.author_email, "test-emåil@foo.com")
-        self.assertEqual(last_commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15,
-                                                             tzinfo=dateutil.tz.tzoffset("+0100", 3600)))
+        self.assertEqual(
+            last_commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15, tzinfo=dateutil.tz.tzoffset("+0100", 3600))
+        )
         self.assertListEqual(last_commit.parents, ["åbc"])
         self.assertFalse(last_commit.is_merge_commit)
         self.assertFalse(last_commit.is_fixup_commit)
@@ -130,28 +141,34 @@ class GitCommitTests(BaseTestCase):
         # All expected calls should've happened at this point
         self.assertListEqual(sh.git.mock_calls, expected_calls)
 
-    @patch('gitlint.git.sh')
+    @patch("gitlint.git.sh")
     def test_from_local_repository_specific_commit_hash(self, sh):
         sample_hash = "åbc123"
 
         sh.git.side_effect = [
             sample_hash,  # git log -1 <sample_hash>
-            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
-            "cömmit-title\n\ncömmit-body",
+            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "cömmit-title\n\ncömmit-body",
             "#",  # git config --get core.commentchar
             "file1.txt\npåth/to/file2.txt\n",
-            "foöbar\n* hürdur\n"
+            "foöbar\n* hürdur\n",
         ]
 
         context = GitContext.from_local_repository("fåke/path", commit_hashes=[sample_hash])
         # assert that commit info was read using git command
         expected_calls = [
-            call("log", "-1", sample_hash, "--pretty=%H",  **self.expected_sh_special_args),
+            call("log", "-1", sample_hash, "--pretty=%H", **self.expected_sh_special_args),
             call("log", sample_hash, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
-            call('config', '--get', 'core.commentchar', _ok_code=[0, 1], **self.expected_sh_special_args),
-            call('diff-tree', '--no-commit-id', '--name-only', '-r', '--root', sample_hash,
-                 **self.expected_sh_special_args),
-            call('branch', '--contains', sample_hash, **self.expected_sh_special_args)
+            call("config", "--get", "core.commentchar", _ok_code=[0, 1], **self.expected_sh_special_args),
+            call(
+                "diff-tree",
+                "--no-commit-id",
+                "--name-only",
+                "-r",
+                "--root",
+                sample_hash,
+                **self.expected_sh_special_args,
+            ),
+            call("branch", "--contains", sample_hash, **self.expected_sh_special_args),
         ]
 
         # Only first 'git log' call should've happened at this point
@@ -164,8 +181,9 @@ class GitCommitTests(BaseTestCase):
         self.assertEqual(last_commit.message.body, ["", "cömmit-body"])
         self.assertEqual(last_commit.author_name, "test åuthor")
         self.assertEqual(last_commit.author_email, "test-emåil@foo.com")
-        self.assertEqual(last_commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15,
-                                                             tzinfo=dateutil.tz.tzoffset("+0100", 3600)))
+        self.assertEqual(
+            last_commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15, tzinfo=dateutil.tz.tzoffset("+0100", 3600))
+        )
         self.assertListEqual(last_commit.parents, ["åbc"])
         self.assertFalse(last_commit.is_merge_commit)
         self.assertFalse(last_commit.is_fixup_commit)
@@ -184,7 +202,7 @@ class GitCommitTests(BaseTestCase):
         # All expected calls should've happened at this point
         self.assertListEqual(sh.git.mock_calls, expected_calls)
 
-    @patch('gitlint.git.sh')
+    @patch("gitlint.git.sh")
     def test_from_local_repository_multiple_commit_hashes(self, sh):
 
         hashes = ["åbc123", "dęf456", "ghí789"]
@@ -202,26 +220,29 @@ class GitCommitTests(BaseTestCase):
             f"file1-{hashes[2]}.txt\npåth/to/file2.txt\n",
             f"foöbar-{hashes[0]}\n* hürdur\n",
             f"foöbar-{hashes[1]}\n* hürdur\n",
-            f"foöbar-{hashes[2]}\n* hürdur\n"
+            f"foöbar-{hashes[2]}\n* hürdur\n",
         ]
 
         expected_calls = [
-            call("log", "-1", hashes[0], "--pretty=%H",  **self.expected_sh_special_args),
-            call("log", "-1", hashes[1], "--pretty=%H",  **self.expected_sh_special_args),
-            call("log", "-1", hashes[2], "--pretty=%H",  **self.expected_sh_special_args),
+            call("log", "-1", hashes[0], "--pretty=%H", **self.expected_sh_special_args),
+            call("log", "-1", hashes[1], "--pretty=%H", **self.expected_sh_special_args),
+            call("log", "-1", hashes[2], "--pretty=%H", **self.expected_sh_special_args),
             call("log", hashes[0], "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
-            call('config', '--get', 'core.commentchar', _ok_code=[0, 1], **self.expected_sh_special_args),
+            call("config", "--get", "core.commentchar", _ok_code=[0, 1], **self.expected_sh_special_args),
             call("log", hashes[1], "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
             call("log", hashes[2], "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
-            call('diff-tree', '--no-commit-id', '--name-only', '-r', '--root', hashes[0],
-                 **self.expected_sh_special_args),
-            call('diff-tree', '--no-commit-id', '--name-only', '-r', '--root', hashes[1],
-                 **self.expected_sh_special_args),
-            call('diff-tree', '--no-commit-id', '--name-only', '-r', '--root', hashes[2],
-                 **self.expected_sh_special_args),
-            call('branch', '--contains', hashes[0], **self.expected_sh_special_args),
-            call('branch', '--contains', hashes[1], **self.expected_sh_special_args),
-            call('branch', '--contains', hashes[2], **self.expected_sh_special_args)
+            call(
+                "diff-tree", "--no-commit-id", "--name-only", "-r", "--root", hashes[0], **self.expected_sh_special_args
+            ),
+            call(
+                "diff-tree", "--no-commit-id", "--name-only", "-r", "--root", hashes[1], **self.expected_sh_special_args
+            ),
+            call(
+                "diff-tree", "--no-commit-id", "--name-only", "-r", "--root", hashes[2], **self.expected_sh_special_args
+            ),
+            call("branch", "--contains", hashes[0], **self.expected_sh_special_args),
+            call("branch", "--contains", hashes[1], **self.expected_sh_special_args),
+            call("branch", "--contains", hashes[2], **self.expected_sh_special_args),
         ]
 
         context = GitContext.from_local_repository("fåke/path", commit_hashes=hashes)
@@ -237,8 +258,9 @@ class GitCommitTests(BaseTestCase):
             self.assertEqual(commit.message.body, ["", f"cömmit-body {expected_hash}"])
             self.assertEqual(commit.author_name, f"test åuthor {expected_hash}")
             self.assertEqual(commit.author_email, f"test-emåil-{expected_hash}@foo.com")
-            self.assertEqual(commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15,
-                                                            tzinfo=dateutil.tz.tzoffset("+0100", 3600)))
+            self.assertEqual(
+                commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15, tzinfo=dateutil.tz.tzoffset("+0100", 3600))
+            )
             self.assertListEqual(commit.parents, ["åbc"])
             self.assertFalse(commit.is_merge_commit)
             self.assertFalse(commit.is_fixup_commit)
@@ -263,17 +285,16 @@ class GitCommitTests(BaseTestCase):
         # All expected calls should've happened at this point
         self.assertListEqual(sh.git.mock_calls, expected_calls)
 
-    @patch('gitlint.git.sh')
+    @patch("gitlint.git.sh")
     def test_get_latest_commit_merge_commit(self, sh):
         sample_sha = "d8ac47e9f2923c7f22d8668e3a1ed04eb4cdbca9"
 
         sh.git.side_effect = [
             sample_sha,
-            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc def\n"
-            "Merge \"foo bår commit\"",
+            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc def\n" 'Merge "foo bår commit"',
             "#",  # git config --get core.commentchar
             "file1.txt\npåth/to/file2.txt\n",
-            "foöbar\n* hürdur\n"
+            "foöbar\n* hürdur\n",
         ]
 
         context = GitContext.from_local_repository("fåke/path")
@@ -281,10 +302,17 @@ class GitCommitTests(BaseTestCase):
         expected_calls = [
             call("log", "-1", "--pretty=%H", **self.expected_sh_special_args),
             call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
-            call('config', '--get', 'core.commentchar', _ok_code=[0, 1], **self.expected_sh_special_args),
-            call('diff-tree', '--no-commit-id', '--name-only', '-r', '--root', sample_sha,
-                 **self.expected_sh_special_args),
-            call('branch', '--contains', sample_sha, **self.expected_sh_special_args)
+            call("config", "--get", "core.commentchar", _ok_code=[0, 1], **self.expected_sh_special_args),
+            call(
+                "diff-tree",
+                "--no-commit-id",
+                "--name-only",
+                "-r",
+                "--root",
+                sample_sha,
+                **self.expected_sh_special_args,
+            ),
+            call("branch", "--contains", sample_sha, **self.expected_sh_special_args),
         ]
 
         # Only first 'git log' call should've happened at this point
@@ -293,12 +321,13 @@ class GitCommitTests(BaseTestCase):
         last_commit = context.commits[-1]
         self.assertIsInstance(last_commit, LocalGitCommit)
         self.assertEqual(last_commit.sha, sample_sha)
-        self.assertEqual(last_commit.message.title, "Merge \"foo bår commit\"")
+        self.assertEqual(last_commit.message.title, 'Merge "foo bår commit"')
         self.assertEqual(last_commit.message.body, [])
         self.assertEqual(last_commit.author_name, "test åuthor")
         self.assertEqual(last_commit.author_email, "test-emåil@foo.com")
-        self.assertEqual(last_commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15,
-                                                             tzinfo=dateutil.tz.tzoffset("+0100", 3600)))
+        self.assertEqual(
+            last_commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15, tzinfo=dateutil.tz.tzoffset("+0100", 3600))
+        )
         self.assertListEqual(last_commit.parents, ["åbc", "def"])
         self.assertTrue(last_commit.is_merge_commit)
         self.assertFalse(last_commit.is_fixup_commit)
@@ -317,7 +346,7 @@ class GitCommitTests(BaseTestCase):
         # All expected calls should've happened at this point
         self.assertListEqual(sh.git.mock_calls, expected_calls)
 
-    @patch('gitlint.git.sh')
+    @patch("gitlint.git.sh")
     def test_get_latest_commit_fixup_squash_commit(self, sh):
         commit_prefixes = {"fixup": "is_fixup_commit", "squash": "is_squash_commit", "amend": "is_fixup_amend_commit"}
         for commit_type in commit_prefixes.keys():
@@ -326,10 +355,10 @@ class GitCommitTests(BaseTestCase):
             sh.git.side_effect = [
                 sample_sha,
                 "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc\n"
-                f"{commit_type}! \"foo bår commit\"",
+                f'{commit_type}! "foo bår commit"',
                 "#",  # git config --get core.commentchar
                 "file1.txt\npåth/to/file2.txt\n",
-                "foöbar\n* hürdur\n"
+                "foöbar\n* hürdur\n",
             ]
 
             context = GitContext.from_local_repository("fåke/path")
@@ -337,10 +366,17 @@ class GitCommitTests(BaseTestCase):
             expected_calls = [
                 call("log", "-1", "--pretty=%H", **self.expected_sh_special_args),
                 call("log", sample_sha, "-1", "--pretty=%aN%x00%aE%x00%ai%x00%P%n%B", **self.expected_sh_special_args),
-                call('config', '--get', 'core.commentchar', _ok_code=[0, 1], **self.expected_sh_special_args),
-                call('diff-tree', '--no-commit-id', '--name-only', '-r', '--root', sample_sha,
-                     **self.expected_sh_special_args),
-                call('branch', '--contains', sample_sha, **self.expected_sh_special_args)
+                call("config", "--get", "core.commentchar", _ok_code=[0, 1], **self.expected_sh_special_args),
+                call(
+                    "diff-tree",
+                    "--no-commit-id",
+                    "--name-only",
+                    "-r",
+                    "--root",
+                    sample_sha,
+                    **self.expected_sh_special_args,
+                ),
+                call("branch", "--contains", sample_sha, **self.expected_sh_special_args),
             ]
 
             # Only first 'git log' call should've happened at this point
@@ -349,12 +385,13 @@ class GitCommitTests(BaseTestCase):
             last_commit = context.commits[-1]
             self.assertIsInstance(last_commit, LocalGitCommit)
             self.assertEqual(last_commit.sha, sample_sha)
-            self.assertEqual(last_commit.message.title, f"{commit_type}! \"foo bår commit\"")
+            self.assertEqual(last_commit.message.title, f'{commit_type}! "foo bår commit"')
             self.assertEqual(last_commit.message.body, [])
             self.assertEqual(last_commit.author_name, "test åuthor")
             self.assertEqual(last_commit.author_email, "test-emåil@foo.com")
-            self.assertEqual(last_commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15,
-                                                                 tzinfo=dateutil.tz.tzoffset("+0100", 3600)))
+            self.assertEqual(
+                last_commit.date, datetime.datetime(2016, 12, 3, 15, 28, 15, tzinfo=dateutil.tz.tzoffset("+0100", 3600))
+            )
             self.assertListEqual(last_commit.parents, ["åbc"])
 
             # First 2 'git log' calls should've happened at this point
@@ -384,11 +421,13 @@ class GitCommitTests(BaseTestCase):
         gitcontext = GitContext.from_commit_msg(self.get_sample("commit_message/sample1"))
 
         expected_title = "Commit title contåining 'WIP', as well as trailing punctuation."
-        expected_body = ["This line should be empty",
-                         "This is the first line of the commit message body and it is meant to test a " +
-                         "line that exceeds the maximum line length of 80 characters.",
-                         "This line has a tråiling space. ",
-                         "This line has a trailing tab.\t"]
+        expected_body = [
+            "This line should be empty",
+            "This is the first line of the commit message body and it is meant to test a "
+            + "line that exceeds the maximum line length of 80 characters.",
+            "This line has a tråiling space. ",
+            "This line has a trailing tab.\t",
+        ]
         expected_full = expected_title + "\n" + "\n".join(expected_body)
         expected_original = expected_full + (
             "\n# This is a cömmented  line\n"
@@ -513,13 +552,13 @@ class GitCommitTests(BaseTestCase):
         self.assertEqual(len(gitcontext.commits), 1)
 
     def test_from_commit_msg_revert_commit(self):
-        commit_msg = "Revert \"Prev commit message\"\n\nThis reverts commit a8ad67e04164a537198dea94a4fde81c5592ae9c."
+        commit_msg = 'Revert "Prev commit message"\n\nThis reverts commit a8ad67e04164a537198dea94a4fde81c5592ae9c.'
         gitcontext = GitContext.from_commit_msg(commit_msg)
         commit = gitcontext.commits[-1]
 
         self.assertIsInstance(commit, GitCommit)
         self.assertFalse(isinstance(commit, LocalGitCommit))
-        self.assertEqual(commit.message.title, "Revert \"Prev commit message\"")
+        self.assertEqual(commit.message.title, 'Revert "Prev commit message"')
         self.assertEqual(commit.message.body, ["", "This reverts commit a8ad67e04164a537198dea94a4fde81c5592ae9c."])
         self.assertEqual(commit.message.full, commit_msg)
         self.assertEqual(commit.message.original, commit_msg)
@@ -562,16 +601,16 @@ class GitCommitTests(BaseTestCase):
             for type, commit_attr_name in commit_prefixes.items():
                 self.assertEqual(getattr(commit, commit_attr_name), commit_type == type)
 
-    @patch('gitlint.git.sh')
-    @patch('arrow.now')
+    @patch("gitlint.git.sh")
+    @patch("arrow.now")
     def test_staged_commit(self, now, sh):
         # StagedLocalGitCommit()
 
         sh.git.side_effect = [
-            "#",                               # git config --get core.commentchar
-            "test åuthor\n",                   # git config --get user.name
-            "test-emåil@foo.com\n",            # git config --get user.email
-            "my-brånch\n",                     # git rev-parse --abbrev-ref HEAD
+            "#",  # git config --get core.commentchar
+            "test åuthor\n",  # git config --get user.name
+            "test-emåil@foo.com\n",  # git config --get user.email
+            "my-brånch\n",  # git rev-parse --abbrev-ref HEAD
             "file1.txt\npåth/to/file2.txt\n",
         ]
         now.side_effect = [arrow.get("2020-02-19T12:18:46.675182+01:00")]
@@ -581,11 +620,11 @@ class GitCommitTests(BaseTestCase):
 
         # git calls we're expecting
         expected_calls = [
-            call('config', '--get', 'core.commentchar', _ok_code=[0, 1], **self.expected_sh_special_args),
-            call('config', '--get', 'user.name', **self.expected_sh_special_args),
-            call('config', '--get', 'user.email', **self.expected_sh_special_args),
+            call("config", "--get", "core.commentchar", _ok_code=[0, 1], **self.expected_sh_special_args),
+            call("config", "--get", "user.name", **self.expected_sh_special_args),
+            call("config", "--get", "user.email", **self.expected_sh_special_args),
             call("rev-parse", "--abbrev-ref", "HEAD", **self.expected_sh_special_args),
-            call("diff", "--staged", "--name-only", "-r", **self.expected_sh_special_args)
+            call("diff", "--staged", "--name-only", "-r", **self.expected_sh_special_args),
         ]
 
         last_commit = context.commits[-1]
@@ -602,8 +641,9 @@ class GitCommitTests(BaseTestCase):
         self.assertEqual(last_commit.author_email, "test-emåil@foo.com")
         self.assertListEqual(sh.git.mock_calls, expected_calls[0:3])
 
-        self.assertEqual(last_commit.date, datetime.datetime(2020, 2, 19, 12, 18, 46,
-                                                             tzinfo=dateutil.tz.tzoffset("+0100", 3600)))
+        self.assertEqual(
+            last_commit.date, datetime.datetime(2020, 2, 19, 12, 18, 46, tzinfo=dateutil.tz.tzoffset("+0100", 3600))
+        )
         now.assert_called_once()
 
         self.assertListEqual(last_commit.parents, [])
@@ -619,13 +659,13 @@ class GitCommitTests(BaseTestCase):
         self.assertListEqual(last_commit.changed_files, ["file1.txt", "påth/to/file2.txt"])
         self.assertListEqual(sh.git.mock_calls, expected_calls[0:5])
 
-    @patch('gitlint.git.sh')
+    @patch("gitlint.git.sh")
     def test_staged_commit_with_missing_username(self, sh):
         # StagedLocalGitCommit()
 
         sh.git.side_effect = [
-            "#",                               # git config --get core.commentchar
-            ErrorReturnCode('git config --get user.name', b"", b""),
+            "#",  # git config --get core.commentchar
+            ErrorReturnCode("git config --get user.name", b"", b""),
         ]
 
         expected_msg = "Missing git configuration: please set user.name"
@@ -633,14 +673,14 @@ class GitCommitTests(BaseTestCase):
             ctx = GitContext.from_staged_commit("Foōbar 123\n\ncömmit-body\n", "fåke/path")
             [str(commit) for commit in ctx.commits]
 
-    @patch('gitlint.git.sh')
+    @patch("gitlint.git.sh")
     def test_staged_commit_with_missing_email(self, sh):
         # StagedLocalGitCommit()
 
         sh.git.side_effect = [
-            "#",                               # git config --get core.commentchar
-            "test åuthor\n",                   # git config --get user.name
-            ErrorReturnCode('git config --get user.name', b"", b""),
+            "#",  # git config --get core.commentchar
+            "test åuthor\n",  # git config --get user.name
+            ErrorReturnCode("git config --get user.name", b"", b""),
         ]
 
         expected_msg = "Missing git configuration: please set user.email"
@@ -650,7 +690,7 @@ class GitCommitTests(BaseTestCase):
 
     def test_gitcommitmessage_equality(self):
         commit_message1 = GitCommitMessage(GitContext(), "tëst\n\nfoo", "tëst\n\nfoo", "tēst", ["", "föo"])
-        attrs = ['original', 'full', 'title', 'body']
+        attrs = ["original", "full", "title", "body"]
         self.object_equality_test(commit_message1, attrs, {"context": commit_message1.context})
 
     @patch("gitlint.git._git")
@@ -663,14 +703,32 @@ class GitCommitTests(BaseTestCase):
         now = datetime.datetime.utcnow()
         context1 = GitContext()
         commit_message1 = GitCommitMessage(context1, "tëst\n\nfoo", "tëst\n\nfoo", "tēst", ["", "föo"])
-        commit1 = GitCommit(context1, commit_message1, "shä", now, "Jöhn Smith", "jöhn.smith@test.com", None,
-                            ["föo/bar"], ["brånch1", "brånch2"])
+        commit1 = GitCommit(
+            context1,
+            commit_message1,
+            "shä",
+            now,
+            "Jöhn Smith",
+            "jöhn.smith@test.com",
+            None,
+            ["föo/bar"],
+            ["brånch1", "brånch2"],
+        )
         context1.commits = [commit1]
 
         context2 = GitContext()
         commit_message2 = GitCommitMessage(context2, "tëst\n\nfoo", "tëst\n\nfoo", "tēst", ["", "föo"])
-        commit2 = GitCommit(context2, commit_message1, "shä", now, "Jöhn Smith", "jöhn.smith@test.com", None,
-                            ["föo/bar"], ["brånch1", "brånch2"])
+        commit2 = GitCommit(
+            context2,
+            commit_message1,
+            "shä",
+            now,
+            "Jöhn Smith",
+            "jöhn.smith@test.com",
+            None,
+            ["föo/bar"],
+            ["brånch1", "brånch2"],
+        )
         context2.commits = [commit2]
 
         self.assertEqual(context1, context2)
@@ -678,15 +736,26 @@ class GitCommitTests(BaseTestCase):
         self.assertEqual(commit1, commit2)
 
         # Check that objects are unequal when changing a single attribute
-        kwargs = {'message': commit1.message, 'sha': commit1.sha, 'date': commit1.date,
-                  'author_name': commit1.author_name, 'author_email': commit1.author_email, 'parents': commit1.parents,
-                  'changed_files': commit1.changed_files, 'branches': commit1.branches}
+        kwargs = {
+            "message": commit1.message,
+            "sha": commit1.sha,
+            "date": commit1.date,
+            "author_name": commit1.author_name,
+            "author_email": commit1.author_email,
+            "parents": commit1.parents,
+            "changed_files": commit1.changed_files,
+            "branches": commit1.branches,
+        }
 
         self.object_equality_test(commit1, kwargs.keys(), {"context": commit1.context})
 
         # Check that the is_* attributes that are affected by the commit message affect equality
-        special_messages = {'is_merge_commit': "Merge: foöbar", 'is_fixup_commit': "fixup! foöbar",
-                            'is_squash_commit': "squash! foöbar", 'is_revert_commit': "Revert: foöbar"}
+        special_messages = {
+            "is_merge_commit": "Merge: foöbar",
+            "is_fixup_commit": "fixup! foöbar",
+            "is_squash_commit": "squash! foöbar",
+            "is_revert_commit": "Revert: foöbar",
+        }
         for key in special_messages:
             kwargs_copy = copy.deepcopy(kwargs)
             clone1 = GitCommit(context=commit1.context, **kwargs_copy)

--- a/gitlint-core/gitlint/tests/git/test_git_commit.py
+++ b/gitlint-core/gitlint/tests/git/test_git_commit.py
@@ -14,7 +14,6 @@ from gitlint.shell import ErrorReturnCode
 
 
 class GitCommitTests(BaseTestCase):
-
     # Expected special_args passed to 'sh'
     expected_sh_special_args = {"_tty_out": False, "_cwd": "fåke/path"}
 
@@ -24,7 +23,7 @@ class GitCommitTests(BaseTestCase):
 
         sh.git.side_effect = [
             sample_sha,
-            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "cömmit-title\n\ncömmit-body",
+            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc\ncömmit-title\n\ncömmit-body",
             "#",  # git config --get core.commentchar
             "file1.txt\npåth/to/file2.txt\n",
             "foöbar\n* hürdur\n",
@@ -86,7 +85,7 @@ class GitCommitTests(BaseTestCase):
 
         sh.git.side_effect = [
             sample_sha,  # git rev-list <sample_refspec>
-            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "cömmit-title\n\ncömmit-body",
+            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc\ncömmit-title\n\ncömmit-body",
             "#",  # git config --get core.commentchar
             "file1.txt\npåth/to/file2.txt\n",
             "foöbar\n* hürdur\n",
@@ -147,7 +146,7 @@ class GitCommitTests(BaseTestCase):
 
         sh.git.side_effect = [
             sample_hash,  # git log -1 <sample_hash>
-            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc\n" "cömmit-title\n\ncömmit-body",
+            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc\ncömmit-title\n\ncömmit-body",
             "#",  # git config --get core.commentchar
             "file1.txt\npåth/to/file2.txt\n",
             "foöbar\n* hürdur\n",
@@ -204,7 +203,6 @@ class GitCommitTests(BaseTestCase):
 
     @patch("gitlint.git.sh")
     def test_from_local_repository_multiple_commit_hashes(self, sh):
-
         hashes = ["åbc123", "dęf456", "ghí789"]
         sh.git.side_effect = [
             *hashes,
@@ -291,7 +289,7 @@ class GitCommitTests(BaseTestCase):
 
         sh.git.side_effect = [
             sample_sha,
-            "test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc def\n" 'Merge "foo bår commit"',
+            'test åuthor\x00test-emåil@foo.com\x002016-12-03 15:28:15 +0100\x00åbc def\nMerge "foo bår commit"',
             "#",  # git config --get core.commentchar
             "file1.txt\npåth/to/file2.txt\n",
             "foöbar\n* hürdur\n",
@@ -429,8 +427,8 @@ class GitCommitTests(BaseTestCase):
             "This line has a trailing tab.\t",
         ]
         expected_full = expected_title + "\n" + "\n".join(expected_body)
-        expected_original = expected_full + (
-            "\n# This is a cömmented  line\n"
+        expected_original = (
+            expected_full + "\n# This is a cömmented  line\n"
             "# ------------------------ >8 ------------------------\n"
             "# Anything after this line should be cleaned up\n"
             "# this line appears on `git commit -v` command\n"

--- a/gitlint-core/gitlint/tests/git/test_git_context.py
+++ b/gitlint-core/gitlint/tests/git/test_git_context.py
@@ -9,22 +9,16 @@ from gitlint.git import GitContext
 class GitContextTests(BaseTestCase):
 
     # Expected special_args passed to 'sh'
-    expected_sh_special_args = {
-        '_tty_out': False,
-        '_cwd': "fåke/path"
-    }
+    expected_sh_special_args = {"_tty_out": False, "_cwd": "fåke/path"}
 
-    @patch('gitlint.git.sh')
+    @patch("gitlint.git.sh")
     def test_gitcontext(self, sh):
 
-        sh.git.side_effect = [
-            "#",  # git config --get core.commentchar
-            "\nfoöbar\n"
-        ]
+        sh.git.side_effect = ["#", "\nfoöbar\n"]  # git config --get core.commentchar
 
         expected_calls = [
             call("config", "--get", "core.commentchar", _ok_code=[0, 1], **self.expected_sh_special_args),
-            call("rev-parse", "--abbrev-ref", "HEAD", **self.expected_sh_special_args)
+            call("rev-parse", "--abbrev-ref", "HEAD", **self.expected_sh_special_args),
         ]
 
         context = GitContext("fåke/path")
@@ -38,12 +32,12 @@ class GitContextTests(BaseTestCase):
         self.assertEqual(context.current_branch, "foöbar")
         self.assertEqual(sh.git.mock_calls, expected_calls)
 
-    @patch('gitlint.git.sh')
+    @patch("gitlint.git.sh")
     def test_gitcontext_equality(self, sh):
 
         sh.git.side_effect = [
-            "û\n",          # context1: git config --get core.commentchar
-            "û\n",          # context2: git config --get core.commentchar
+            "û\n",  # context1: git config --get core.commentchar
+            "û\n",  # context2: git config --get core.commentchar
             "my-brånch\n",  # context1: git rev-parse --abbrev-ref HEAD
             "my-brånch\n",  # context2: git rev-parse --abbrev-ref HEAD
         ]
@@ -68,17 +62,17 @@ class GitContextTests(BaseTestCase):
         # Different comment_char
         context3 = GitContext("fåke/path")
         context3.commits = ["fōo", "bår"]
-        sh.git.side_effect = ([
-            "ç\n",                      # context3: git config --get core.commentchar
-            "my-brånch\n"               # context3: git rev-parse --abbrev-ref HEAD
-        ])
+        sh.git.side_effect = [
+            "ç\n",  # context3: git config --get core.commentchar
+            "my-brånch\n",  # context3: git rev-parse --abbrev-ref HEAD
+        ]
         self.assertNotEqual(context1, context3)
 
         # Different current_branch
         context4 = GitContext("fåke/path")
         context4.commits = ["fōo", "bår"]
-        sh.git.side_effect = ([
-            "û\n",                      # context4: git config --get core.commentchar
-            "different-brånch\n"        # context4: git rev-parse --abbrev-ref HEAD
-        ])
+        sh.git.side_effect = [
+            "û\n",  # context4: git config --get core.commentchar
+            "different-brånch\n",  # context4: git rev-parse --abbrev-ref HEAD
+        ]
         self.assertNotEqual(context1, context4)

--- a/gitlint-core/gitlint/tests/git/test_git_context.py
+++ b/gitlint-core/gitlint/tests/git/test_git_context.py
@@ -7,13 +7,11 @@ from gitlint.git import GitContext
 
 
 class GitContextTests(BaseTestCase):
-
     # Expected special_args passed to 'sh'
     expected_sh_special_args = {"_tty_out": False, "_cwd": "fåke/path"}
 
     @patch("gitlint.git.sh")
     def test_gitcontext(self, sh):
-
         sh.git.side_effect = ["#", "\nfoöbar\n"]  # git config --get core.commentchar
 
         expected_calls = [
@@ -34,7 +32,6 @@ class GitContextTests(BaseTestCase):
 
     @patch("gitlint.git.sh")
     def test_gitcontext_equality(self, sh):
-
         sh.git.side_effect = [
             "û\n",  # context1: git config --get core.commentchar
             "û\n",  # context2: git config --get core.commentchar

--- a/gitlint-core/gitlint/tests/rules/test_body_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_body_rules.py
@@ -17,7 +17,7 @@ class BodyRuleTests(BaseTestCase):
         self.assertListEqual(violations, [expected_violation])
 
         # set line length to 120, and check no violation on length 73
-        rule = rules.BodyMaxLineLength({'line-length': 120})
+        rule = rules.BodyMaxLineLength({"line-length": 120})
         violations = rule.validate("å" * 73, None)
         self.assertIsNone(violations)
 
@@ -100,13 +100,13 @@ class BodyRuleTests(BaseTestCase):
         # set line length to 120, and check violation on length 21
         expected_violation = rules.RuleViolation("B5", "Body message is too short (21<120)", "å" * 21, 3)
 
-        rule = rules.BodyMinLength({'min-length': 120})
+        rule = rules.BodyMinLength({"min-length": 120})
         commit = self.gitcommit("Title\n\n{0}\n".format("å" * 21))  # pylint: disable=consider-using-f-string
         violations = rule.validate(commit)
         self.assertListEqual(violations, [expected_violation])
 
         # Make sure we don't get the error if the body-length is exactly the min-length
-        rule = rules.BodyMinLength({'min-length': 8})
+        rule = rules.BodyMinLength({"min-length": 8})
         commit = self.gitcommit("Tïtle\n\n{0}\n".format("å" * 8))  # pylint: disable=consider-using-f-string
         violations = rule.validate(commit)
         self.assertIsNone(violations)
@@ -145,7 +145,7 @@ class BodyRuleTests(BaseTestCase):
         self.assertIsNone(violations)
 
         # assert error for merge commits if ignore-merge-commits is disabled
-        rule = rules.BodyMissing({'ignore-merge-commits': False})
+        rule = rules.BodyMissing({"ignore-merge-commits": False})
         violations = rule.validate(commit)
         expected_violation = rules.RuleViolation("B6", "Body message is missing", None, 3)
         self.assertListEqual(violations, [expected_violation])
@@ -159,7 +159,7 @@ class BodyRuleTests(BaseTestCase):
         self.assertIsNone(violations)
 
         # assert no error when no files have changed but certain files need to be mentioned on change
-        rule = rules.BodyChangedFileMention({'files': "bar.txt,föo/test.py"})
+        rule = rules.BodyChangedFileMention({"files": "bar.txt,föo/test.py"})
         commit = self.gitcommit("This is a test\n\nHere is a mention of föo/test.py")
         violations = rule.validate(commit)
         self.assertIsNone(violations)
@@ -201,29 +201,29 @@ class BodyRuleTests(BaseTestCase):
 
         # assert no violation on matching regex
         # (also note that first body line - in between title and rest of body - is ignored)
-        rule = rules.BodyRegexMatches({'regex': "^Bödy(.*)"})
+        rule = rules.BodyRegexMatches({"regex": "^Bödy(.*)"})
         violations = rule.validate(commit)
         self.assertIsNone(violations)
 
         # assert we can do end matching (and last empty line is ignored)
         # (also note that first body line - in between title and rest of body - is ignored)
-        rule = rules.BodyRegexMatches({'regex': "My-Commit-Tag: föo$"})
+        rule = rules.BodyRegexMatches({"regex": "My-Commit-Tag: föo$"})
         violations = rule.validate(commit)
         self.assertIsNone(violations)
 
         # common use-case: matching that a given line is present
-        rule = rules.BodyRegexMatches({'regex': "(.*)Föo(.*)"})
+        rule = rules.BodyRegexMatches({"regex": "(.*)Föo(.*)"})
         violations = rule.validate(commit)
         self.assertIsNone(violations)
 
         # assert violation on non-matching body
-        rule = rules.BodyRegexMatches({'regex': "^Tëst(.*)Foo"})
+        rule = rules.BodyRegexMatches({"regex": "^Tëst(.*)Foo"})
         violations = rule.validate(commit)
         expected_violation = rules.RuleViolation("B8", "Body does not match regex (^Tëst(.*)Foo)", None, 6)
         self.assertListEqual(violations, [expected_violation])
 
         # assert no violation on None regex
-        rule = rules.BodyRegexMatches({'regex': None})
+        rule = rules.BodyRegexMatches({"regex": None})
         violations = rule.validate(commit)
         self.assertIsNone(violations)
 
@@ -231,6 +231,6 @@ class BodyRuleTests(BaseTestCase):
         bodies = ["åbc", "åbc\n", "åbc\nföo\n", "åbc\n\n", "åbc\nföo\nblå", "åbc\nföo\nblå\n"]
         for body in bodies:
             commit = self.gitcommit(body)
-            rule = rules.BodyRegexMatches({'regex': ".*"})
+            rule = rules.BodyRegexMatches({"regex": ".*"})
             violations = rule.validate(commit)
             self.assertIsNone(violations)

--- a/gitlint-core/gitlint/tests/rules/test_configuration_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_configuration_rules.py
@@ -22,20 +22,23 @@ class ConfigurationRuleTests(BaseTestCase):
         rule.apply(config, commit)
         self.assertEqual(config, expected_config)
 
-        expected_log_message = "DEBUG: gitlint.rules Ignoring commit because of rule 'I1': " + \
+        expected_log_message = (
+            "DEBUG: gitlint.rules Ignoring commit because of rule 'I1': "
             "Commit title 'Releäse' matches the regex '^Releäse(.*)', ignoring rules: all"
+        )
         self.assert_log_contains(expected_log_message)
 
         # Matching regex with specific ignore
-        rule = rules.IgnoreByTitle({"regex": "^Releäse(.*)",
-                                    "ignore": "T1,B2"})
+        rule = rules.IgnoreByTitle({"regex": "^Releäse(.*)", "ignore": "T1,B2"})
         expected_config = LintConfig()
         expected_config.ignore = "T1,B2"
         rule.apply(config, commit)
         self.assertEqual(config, expected_config)
 
-        expected_log_message = "DEBUG: gitlint.rules Ignoring commit because of rule 'I1': " + \
+        expected_log_message = (
+            "DEBUG: gitlint.rules Ignoring commit because of rule 'I1': "
             "Commit title 'Releäse' matches the regex '^Releäse(.*)', ignoring rules: T1,B2"
+        )
 
     def test_ignore_by_body(self):
         commit = self.gitcommit("Tïtle\n\nThis is\n a relëase body\n line")
@@ -54,21 +57,24 @@ class ConfigurationRuleTests(BaseTestCase):
         rule.apply(config, commit)
         self.assertEqual(config, expected_config)
 
-        expected_log_message = "DEBUG: gitlint.rules Ignoring commit because of rule 'I2': " + \
-                               "Commit message line ' a relëase body' matches the regex '(.*)relëase(.*)'," + \
-                               " ignoring rules: all"
+        expected_log_message = (
+            "DEBUG: gitlint.rules Ignoring commit because of rule 'I2': "
+            "Commit message line ' a relëase body' matches the regex '(.*)relëase(.*)',"
+            " ignoring rules: all"
+        )
         self.assert_log_contains(expected_log_message)
 
         # Matching regex with specific ignore
-        rule = rules.IgnoreByBody({"regex": "(.*)relëase(.*)",
-                                   "ignore": "T1,B2"})
+        rule = rules.IgnoreByBody({"regex": "(.*)relëase(.*)", "ignore": "T1,B2"})
         expected_config = LintConfig()
         expected_config.ignore = "T1,B2"
         rule.apply(config, commit)
         self.assertEqual(config, expected_config)
 
-        expected_log_message = "DEBUG: gitlint.rules Ignoring commit because of rule 'I2': " + \
+        expected_log_message = (
+            "DEBUG: gitlint.rules Ignoring commit because of rule 'I2': "
             "Commit message line ' a relëase body' matches the regex '(.*)relëase(.*)', ignoring rules: T1,B2"
+        )
         self.assert_log_contains(expected_log_message)
 
     def test_ignore_by_author_name(self):
@@ -88,9 +94,11 @@ class ConfigurationRuleTests(BaseTestCase):
         rule.apply(config, commit)
         self.assertEqual(config, expected_config)
 
-        expected_log_message = ("DEBUG: gitlint.rules Ignoring commit because of rule 'I4': "
-                                "Commit Author Name 'Tëst nåme' matches the regex '(.*)ëst(.*)',"
-                                " ignoring rules: all")
+        expected_log_message = (
+            "DEBUG: gitlint.rules Ignoring commit because of rule 'I4': "
+            "Commit Author Name 'Tëst nåme' matches the regex '(.*)ëst(.*)',"
+            " ignoring rules: all"
+        )
         self.assert_log_contains(expected_log_message)
 
         # Matching regex with specific ignore
@@ -100,8 +108,10 @@ class ConfigurationRuleTests(BaseTestCase):
         rule.apply(config, commit)
         self.assertEqual(config, expected_config)
 
-        expected_log_message = ("DEBUG: gitlint.rules Ignoring commit because of rule 'I4': "
-                                "Commit Author Name 'Tëst nåme' matches the regex '(.*)nåme', ignoring rules: T1,B2")
+        expected_log_message = (
+            "DEBUG: gitlint.rules Ignoring commit because of rule 'I4': "
+            "Commit Author Name 'Tëst nåme' matches the regex '(.*)nåme', ignoring rules: T1,B2"
+        )
         self.assert_log_contains(expected_log_message)
 
     def test_ignore_body_lines(self):
@@ -128,8 +138,9 @@ class ConfigurationRuleTests(BaseTestCase):
         expected_commit.message.original = commit1.message.original
         self.assertEqual(commit1, expected_commit)
         self.assertEqual(config, LintConfig())  # config shouldn't have been modified
-        self.assert_log_contains("DEBUG: gitlint.rules Ignoring line ' a relëase body' because it " +
-                                 "matches '(.*)relëase(.*)'")
+        self.assert_log_contains(
+            "DEBUG: gitlint.rules Ignoring line ' a relëase body' because it " + "matches '(.*)relëase(.*)'"
+        )
 
         # Non-Matching regex: no changes expected
         commit1 = self.gitcommit("Tïtle\n\nThis is\n a relëase body\n line")

--- a/gitlint-core/gitlint/tests/rules/test_meta_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_meta_rules.py
@@ -8,8 +8,13 @@ class MetaRuleTests(BaseTestCase):
         rule = AuthorValidEmail()
 
         # valid email addresses
-        valid_email_addresses = ["föo@bar.com", "Jöhn.Doe@bar.com", "jöhn+doe@bar.com", "jöhn/doe@bar.com",
-                                 "jöhn.doe@subdomain.bar.com"]
+        valid_email_addresses = [
+            "föo@bar.com",
+            "Jöhn.Doe@bar.com",
+            "jöhn+doe@bar.com",
+            "jöhn/doe@bar.com",
+            "jöhn.doe@subdomain.bar.com",
+        ]
         for email in valid_email_addresses:
             commit = self.gitcommit("", author_email=email)
             violations = rule.validate(commit)
@@ -22,19 +27,27 @@ class MetaRuleTests(BaseTestCase):
         self.assertIsNone(violations)
 
         # Invalid email addresses: no TLD, no domain, no @, space anywhere (=valid but not allowed by gitlint)
-        invalid_email_addresses = ["föo@bar", "JöhnDoe", "Jöhn Doe", "Jöhn Doe@foo.com", " JöhnDoe@foo.com",
-                                   "JöhnDoe@ foo.com", "JöhnDoe@foo. com", "JöhnDoe@foo. com", "@bår.com",
-                                   "föo@.com"]
+        invalid_email_addresses = [
+            "föo@bar",
+            "JöhnDoe",
+            "Jöhn Doe",
+            "Jöhn Doe@foo.com",
+            " JöhnDoe@foo.com",
+            "JöhnDoe@ foo.com",
+            "JöhnDoe@foo. com",
+            "JöhnDoe@foo. com",
+            "@bår.com",
+            "föo@.com",
+        ]
         for email in invalid_email_addresses:
             commit = self.gitcommit("", author_email=email)
             violations = rule.validate(commit)
-            self.assertListEqual(violations,
-                                 [RuleViolation("M1", "Author email for commit is invalid", email)])
+            self.assertListEqual(violations, [RuleViolation("M1", "Author email for commit is invalid", email)])
 
     def test_author_valid_email_rule_custom_regex(self):
         # regex=None -> the rule isn't applied
         rule = AuthorValidEmail()
-        rule.options['regex'].set(None)
+        rule.options["regex"].set(None)
         emailadresses = ["föo", None, "hür dür"]
         for email in emailadresses:
             commit = self.gitcommit("", author_email=email)
@@ -42,9 +55,8 @@ class MetaRuleTests(BaseTestCase):
             self.assertIsNone(violations)
 
         # Custom domain
-        rule = AuthorValidEmail({'regex': "[^@]+@bår.com"})
-        valid_email_addresses = [
-            "föo@bår.com", "Jöhn.Doe@bår.com", "jöhn+doe@bår.com", "jöhn/doe@bår.com"]
+        rule = AuthorValidEmail({"regex": "[^@]+@bår.com"})
+        valid_email_addresses = ["föo@bår.com", "Jöhn.Doe@bår.com", "jöhn+doe@bår.com", "jöhn/doe@bår.com"]
         for email in valid_email_addresses:
             commit = self.gitcommit("", author_email=email)
             violations = rule.validate(commit)
@@ -55,5 +67,4 @@ class MetaRuleTests(BaseTestCase):
         for email in invalid_email_addresses:
             commit = self.gitcommit("", author_email=email)
             violations = rule.validate(commit)
-            self.assertListEqual(violations,
-                                 [RuleViolation("M1", "Author email for commit is invalid", email)])
+            self.assertListEqual(violations, [RuleViolation("M1", "Author email for commit is invalid", email)])

--- a/gitlint-core/gitlint/tests/rules/test_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_rules.py
@@ -4,7 +4,6 @@ from gitlint.rules import Rule, RuleViolation
 
 
 class RuleTests(BaseTestCase):
-
     def test_rule_equality(self):
         self.assertEqual(Rule(), Rule())
         # Ensure rules are not equal if they differ on their attributes

--- a/gitlint-core/gitlint/tests/rules/test_title_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_title_rules.py
@@ -1,7 +1,16 @@
 # -*- coding: utf-8 -*-
 from gitlint.tests.base import BaseTestCase
-from gitlint.rules import TitleMaxLength, TitleTrailingWhitespace, TitleHardTab, TitleMustNotContainWord, \
-    TitleTrailingPunctuation, TitleLeadingWhitespace, TitleRegexMatches, RuleViolation, TitleMinLength
+from gitlint.rules import (
+    TitleMaxLength,
+    TitleTrailingWhitespace,
+    TitleHardTab,
+    TitleMustNotContainWord,
+    TitleTrailingPunctuation,
+    TitleLeadingWhitespace,
+    TitleRegexMatches,
+    RuleViolation,
+    TitleMinLength,
+)
 
 
 class TitleRuleTests(BaseTestCase):
@@ -18,7 +27,7 @@ class TitleRuleTests(BaseTestCase):
         self.assertListEqual(violations, [expected_violation])
 
         # set line length to 120, and check no violation on length 73
-        rule = TitleMaxLength({'line-length': 120})
+        rule = TitleMaxLength({"line-length": 120})
         violations = rule.validate("å" * 73, None)
         self.assertIsNone(violations)
 
@@ -85,31 +94,37 @@ class TitleRuleTests(BaseTestCase):
 
         # match literally
         violations = rule.validate("WIP This is å test", None)
-        expected_violation = RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)",
-                                           "WIP This is å test")
+        expected_violation = RuleViolation(
+            "T5", "Title contains the word 'WIP' (case-insensitive)", "WIP This is å test"
+        )
         self.assertListEqual(violations, [expected_violation])
 
         # match case insensitive
         violations = rule.validate("wip This is å test", None)
-        expected_violation = RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)",
-                                           "wip This is å test")
+        expected_violation = RuleViolation(
+            "T5", "Title contains the word 'WIP' (case-insensitive)", "wip This is å test"
+        )
         self.assertListEqual(violations, [expected_violation])
 
         # match if there is a colon after the word
         violations = rule.validate("WIP:This is å test", None)
-        expected_violation = RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)",
-                                           "WIP:This is å test")
+        expected_violation = RuleViolation(
+            "T5", "Title contains the word 'WIP' (case-insensitive)", "WIP:This is å test"
+        )
         self.assertListEqual(violations, [expected_violation])
 
         # match multiple words
-        rule = TitleMustNotContainWord({'words': "wip,test,å"})
+        rule = TitleMustNotContainWord({"words": "wip,test,å"})
         violations = rule.validate("WIP:This is å test", None)
-        expected_violation = RuleViolation("T5", "Title contains the word 'wip' (case-insensitive)",
-                                           "WIP:This is å test")
-        expected_violation2 = RuleViolation("T5", "Title contains the word 'test' (case-insensitive)",
-                                            "WIP:This is å test")
-        expected_violation3 = RuleViolation("T5", "Title contains the word 'å' (case-insensitive)",
-                                            "WIP:This is å test")
+        expected_violation = RuleViolation(
+            "T5", "Title contains the word 'wip' (case-insensitive)", "WIP:This is å test"
+        )
+        expected_violation2 = RuleViolation(
+            "T5", "Title contains the word 'test' (case-insensitive)", "WIP:This is å test"
+        )
+        expected_violation3 = RuleViolation(
+            "T5", "Title contains the word 'å' (case-insensitive)", "WIP:This is å test"
+        )
         self.assertListEqual(violations, [expected_violation, expected_violation2, expected_violation3])
 
     def test_leading_whitespace(self):
@@ -143,12 +158,12 @@ class TitleRuleTests(BaseTestCase):
         self.assertIsNone(violations)
 
         # assert no violation on matching regex
-        rule = TitleRegexMatches({'regex': "^US[0-9]*: å"})
+        rule = TitleRegexMatches({"regex": "^US[0-9]*: å"})
         violations = rule.validate(commit.message.title, commit)
         self.assertIsNone(violations)
 
         # assert violation when no matching regex
-        rule = TitleRegexMatches({'regex': "^UÅ[0-9]*"})
+        rule = TitleRegexMatches({"regex": "^UÅ[0-9]*"})
         violations = rule.validate(commit.message.title, commit)
         expected_violation = RuleViolation("T7", "Title does not match regex (^UÅ[0-9]*)", "US1234: åbc")
         self.assertListEqual(violations, [expected_violation])
@@ -166,12 +181,12 @@ class TitleRuleTests(BaseTestCase):
         self.assertListEqual(violations, [expected_violation])
 
         # set line length to 3, and check no violation on length 4
-        rule = TitleMinLength({'min-length': 3})
+        rule = TitleMinLength({"min-length": 3})
         violations = rule.validate("å" * 4, None)
         self.assertIsNone(violations)
 
         # assert no violations on length 3 (this asserts we've implemented a *strict* less than)
-        rule = TitleMinLength({'min-length': 3})
+        rule = TitleMinLength({"min-length": 3})
         violations = rule.validate("å" * 3, None)
         self.assertIsNone(violations)
 

--- a/gitlint-core/gitlint/tests/rules/test_user_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_user_rules.py
@@ -148,7 +148,6 @@ class UserRuleTests(BaseTestCase):
             assert_valid_rule_class(MyRuleClass)
 
     def test_assert_valid_rule_class_negative_id(self):
-
         for parent_class in [rules.LineRule, rules.CommitRule]:
 
             class MyRuleClass(parent_class):
@@ -190,7 +189,6 @@ class UserRuleTests(BaseTestCase):
                 assert_valid_rule_class(MyRuleClass)
 
     def test_assert_valid_rule_class_negative_option_spec(self):
-
         for parent_class in [rules.LineRule, rules.CommitRule]:
 
             class MyRuleClass(parent_class):
@@ -212,7 +210,6 @@ class UserRuleTests(BaseTestCase):
                 assert_valid_rule_class(MyRuleClass)
 
     def test_assert_valid_rule_class_negative_validate(self):
-
         baseclasses = [rules.LineRule, rules.CommitRule]
         for clazz in baseclasses:
 

--- a/gitlint-core/gitlint/tests/rules/test_user_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_user_rules.py
@@ -33,7 +33,7 @@ class UserRuleTests(BaseTestCase):
         # Do some basic asserts on our user rule
         self.assertEqual(classes[0].id, "UC1")
         self.assertEqual(classes[0].name, "my-üser-commit-rule")
-        expected_option = options.IntOption('violation-count', 1, "Number of violåtions to return")
+        expected_option = options.IntOption("violation-count", 1, "Number of violåtions to return")
         self.assertListEqual(classes[0].options_spec, [expected_option])
         self.assertTrue(hasattr(classes[0], "validate"))
 
@@ -44,10 +44,15 @@ class UserRuleTests(BaseTestCase):
         self.assertListEqual(violations, [rules.RuleViolation("UC1", "Commit violåtion 1", "Contënt 1", 1)])
 
         # Have it return more violations
-        rule_class.options['violation-count'].value = 2
+        rule_class.options["violation-count"].value = 2
         violations = rule_class.validate("false-commit-object (ignored)")
-        self.assertListEqual(violations, [rules.RuleViolation("UC1", "Commit violåtion 1", "Contënt 1", 1),
-                                          rules.RuleViolation("UC1", "Commit violåtion 2", "Contënt 2", 2)])
+        self.assertListEqual(
+            violations,
+            [
+                rules.RuleViolation("UC1", "Commit violåtion 1", "Contënt 1", 1),
+                rules.RuleViolation("UC1", "Commit violåtion 2", "Contënt 2", 2),
+            ],
+        )
 
     def test_extra_path_specified_by_file(self):
         # Test that find_rule_classes can handle an extra path given as a file name instead of a directory
@@ -96,23 +101,23 @@ class UserRuleTests(BaseTestCase):
 
     def test_assert_valid_rule_class(self):
         class MyLineRuleClass(rules.LineRule):
-            id = 'UC1'
-            name = 'my-lïne-rule'
+            id = "UC1"
+            name = "my-lïne-rule"
             target = rules.CommitMessageTitle
 
             def validate(self):
                 pass
 
         class MyCommitRuleClass(rules.CommitRule):
-            id = 'UC2'
-            name = 'my-cömmit-rule'
+            id = "UC2"
+            name = "my-cömmit-rule"
 
             def validate(self):
                 pass
 
         class MyConfigurationRuleClass(rules.ConfigurationRule):
-            id = 'UC3'
-            name = 'my-cönfiguration-rule'
+            id = "UC3"
+            name = "my-cönfiguration-rule"
 
             def apply(self):
                 pass
@@ -125,8 +130,9 @@ class UserRuleTests(BaseTestCase):
     def test_assert_valid_rule_class_negative(self):
         # general test to make sure that incorrect rules will raise an exception
         user_rule_path = self.get_sample_path("user_rules/incorrect_linerule")
-        with self.assertRaisesMessage(UserRuleError,
-                                      "User-defined rule class 'MyUserLineRule' must have a 'validate' method"):
+        with self.assertRaisesMessage(
+            UserRuleError, "User-defined rule class 'MyUserLineRule' must have a 'validate' method"
+        ):
             find_rule_classes(user_rule_path)
 
     def test_assert_valid_rule_class_negative_parent(self):
@@ -134,8 +140,10 @@ class UserRuleTests(BaseTestCase):
         class MyRuleClass:
             pass
 
-        expected_msg = "User-defined rule class 'MyRuleClass' must extend from gitlint.rules.LineRule, " + \
-                       "gitlint.rules.CommitRule or gitlint.rules.ConfigurationRule"
+        expected_msg = (
+            "User-defined rule class 'MyRuleClass' must extend from gitlint.rules.LineRule, "
+            "gitlint.rules.CommitRule or gitlint.rules.ConfigurationRule"
+        )
         with self.assertRaisesMessage(UserRuleError, expected_msg):
             assert_valid_rule_class(MyRuleClass)
 
@@ -159,8 +167,9 @@ class UserRuleTests(BaseTestCase):
             # Rule ids must not start with one of the reserved id letters
             for letter in ["T", "R", "B", "M", "I"]:
                 MyRuleClass.id = letter + "1"
-                expected_msg = f"The id '{letter}' of 'MyRuleClass' is invalid. " + \
-                               "Gitlint reserves ids starting with R,T,B,M,I"
+                expected_msg = (
+                    f"The id '{letter}' of 'MyRuleClass' is invalid. Gitlint reserves ids starting with R,T,B,M,I"
+                )
                 with self.assertRaisesMessage(UserRuleError, expected_msg):
                     assert_valid_rule_class(MyRuleClass)
 
@@ -190,8 +199,10 @@ class UserRuleTests(BaseTestCase):
 
             # if set, option_spec must be a list of gitlint options
             MyRuleClass.options_spec = "föo"
-            expected_msg = "The options_spec attribute of user-defined rule class 'MyRuleClass' must be a list " + \
+            expected_msg = (
+                "The options_spec attribute of user-defined rule class 'MyRuleClass' must be a list "
                 "of gitlint.options.RuleOption"
+            )
             with self.assertRaisesMessage(UserRuleError, expected_msg):
                 assert_valid_rule_class(MyRuleClass)
 
@@ -204,18 +215,21 @@ class UserRuleTests(BaseTestCase):
 
         baseclasses = [rules.LineRule, rules.CommitRule]
         for clazz in baseclasses:
+
             class MyRuleClass(clazz):
                 id = "UC1"
                 name = "my-rüle-class"
 
-            with self.assertRaisesMessage(UserRuleError,
-                                          "User-defined rule class 'MyRuleClass' must have a 'validate' method"):
+            with self.assertRaisesMessage(
+                UserRuleError, "User-defined rule class 'MyRuleClass' must have a 'validate' method"
+            ):
                 assert_valid_rule_class(MyRuleClass)
 
             # validate attribute - not a method
             MyRuleClass.validate = "föo"
-            with self.assertRaisesMessage(UserRuleError,
-                                          "User-defined rule class 'MyRuleClass' must have a 'validate' method"):
+            with self.assertRaisesMessage(
+                UserRuleError, "User-defined rule class 'MyRuleClass' must have a 'validate' method"
+            ):
                 assert_valid_rule_class(MyRuleClass)
 
     def test_assert_valid_rule_class_negative_apply(self):
@@ -241,8 +255,10 @@ class UserRuleTests(BaseTestCase):
                 pass
 
         # no target
-        expected_msg = "The target attribute of the user-defined LineRule class 'MyRuleClass' must be either " + \
-                       "gitlint.rules.CommitMessageTitle or gitlint.rules.CommitMessageBody"
+        expected_msg = (
+            "The target attribute of the user-defined LineRule class 'MyRuleClass' must be either "
+            "gitlint.rules.CommitMessageTitle or gitlint.rules.CommitMessageBody"
+        )
         with self.assertRaisesMessage(UserRuleError, expected_msg):
             assert_valid_rule_class(MyRuleClass)
 

--- a/gitlint-core/gitlint/tests/samples/user_rules/my_commit_rules.py
+++ b/gitlint-core/gitlint/tests/samples/user_rules/my_commit_rules.py
@@ -7,17 +7,18 @@ from gitlint.options import IntOption
 class MyUserCommitRule(CommitRule):
     name = "my-üser-commit-rule"
     id = "UC1"
-    options_spec = [IntOption('violation-count', 1, "Number of violåtions to return")]
+    options_spec = [IntOption("violation-count", 1, "Number of violåtions to return")]
 
     def validate(self, _commit):
         violations = []
-        for i in range(1, self.options['violation-count'].value + 1):
+        for i in range(1, self.options["violation-count"].value + 1):
             violations.append(RuleViolation(self.id, "Commit violåtion %d" % i, "Contënt %d" % i, i))
 
         return violations
 
 
 # The below code is present so that we can test that we actually ignore it
+
 
 def func_should_be_ignored():
     pass

--- a/gitlint-core/gitlint/tests/test_cache.py
+++ b/gitlint-core/gitlint/tests/test_cache.py
@@ -4,9 +4,8 @@ from gitlint.cache import PropertyCache, cache
 
 
 class CacheTests(BaseTestCase):
-
     class MyClass(PropertyCache):
-        """ Simple class that has cached properties, used for testing. """
+        """Simple class that has cached properties, used for testing."""
 
         def __init__(self):
             PropertyCache.__init__(self)

--- a/gitlint-core/gitlint/tests/test_display.py
+++ b/gitlint-core/gitlint/tests/test_display.py
@@ -14,9 +14,9 @@ class DisplayTests(BaseTestCase):
         display = Display(LintConfig())
         display.config.verbosity = 2
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             # Non exact outputting, should output both v and vv output
-            with patch('gitlint.display.stdout', new=StringIO()) as stdout:
+            with patch("gitlint.display.stdout", new=StringIO()) as stdout:
                 display.v("tëst")
                 display.vv("tëst2")
                 # vvvv should be ignored regardless
@@ -25,7 +25,7 @@ class DisplayTests(BaseTestCase):
                 self.assertEqual("tëst\ntëst2\n", stdout.getvalue())
 
             # exact outputting, should only output v
-            with patch('gitlint.display.stdout', new=StringIO()) as stdout:
+            with patch("gitlint.display.stdout", new=StringIO()) as stdout:
                 display.v("tëst", exact=True)
                 display.vv("tëst2", exact=True)
                 # vvvv should be ignored regardless
@@ -34,15 +34,15 @@ class DisplayTests(BaseTestCase):
                 self.assertEqual("tëst2\n", stdout.getvalue())
 
             # standard error should be empty throughout all of this
-            self.assertEqual('', stderr.getvalue())
+            self.assertEqual("", stderr.getvalue())
 
     def test_e(self):
         display = Display(LintConfig())
         display.config.verbosity = 2
 
-        with patch('gitlint.display.stdout', new=StringIO()) as stdout:
+        with patch("gitlint.display.stdout", new=StringIO()) as stdout:
             # Non exact outputting, should output both v and vv output
-            with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+            with patch("gitlint.display.stderr", new=StringIO()) as stderr:
                 display.e("tëst")
                 display.ee("tëst2")
                 # vvvv should be ignored regardless
@@ -51,7 +51,7 @@ class DisplayTests(BaseTestCase):
                 self.assertEqual("tëst\ntëst2\n", stderr.getvalue())
 
             # exact outputting, should only output v
-            with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+            with patch("gitlint.display.stderr", new=StringIO()) as stderr:
                 display.e("tëst", exact=True)
                 display.ee("tëst2", exact=True)
                 # vvvv should be ignored regardless
@@ -60,4 +60,4 @@ class DisplayTests(BaseTestCase):
                 self.assertEqual("tëst2\n", stderr.getvalue())
 
             # standard output should be empty throughout all of this
-            self.assertEqual('', stdout.getvalue())
+            self.assertEqual("", stdout.getvalue())

--- a/gitlint-core/gitlint/tests/test_hooks.py
+++ b/gitlint-core/gitlint/tests/test_hooks.py
@@ -6,13 +6,17 @@ from unittest.mock import patch, ANY, mock_open
 
 from gitlint.tests.base import BaseTestCase
 from gitlint.config import LintConfig
-from gitlint.hooks import GitHookInstaller, GitHookInstallerError, COMMIT_MSG_HOOK_SRC_PATH, COMMIT_MSG_HOOK_DST_PATH, \
-    GITLINT_HOOK_IDENTIFIER
+from gitlint.hooks import (
+    GitHookInstaller,
+    GitHookInstallerError,
+    COMMIT_MSG_HOOK_SRC_PATH,
+    COMMIT_MSG_HOOK_DST_PATH,
+    GITLINT_HOOK_IDENTIFIER,
+)
 
 
 class HookTests(BaseTestCase):
-
-    @patch('gitlint.hooks.git_hooks_dir')
+    @patch("gitlint.hooks.git_hooks_dir")
     def test_commit_msg_hook_path(self, git_hooks_dir):
         git_hooks_dir.return_value = os.path.join("/föo", "bar")
         lint_config = LintConfig()
@@ -24,12 +28,12 @@ class HookTests(BaseTestCase):
         self.assertEqual(path, expected_path)
 
     @staticmethod
-    @patch('os.chmod')
-    @patch('os.stat')
-    @patch('gitlint.hooks.shutil.copy')
-    @patch('os.path.exists', return_value=False)
-    @patch('os.path.isdir', return_value=True)
-    @patch('gitlint.hooks.git_hooks_dir')
+    @patch("os.chmod")
+    @patch("os.stat")
+    @patch("gitlint.hooks.shutil.copy")
+    @patch("os.path.exists", return_value=False)
+    @patch("os.path.isdir", return_value=True)
+    @patch("gitlint.hooks.git_hooks_dir")
     def test_install_commit_msg_hook(git_hooks_dir, isdir, path_exists, copy, stat, chmod):
         lint_config = LintConfig()
         lint_config.target = os.path.join("/hür", "dur")
@@ -43,10 +47,10 @@ class HookTests(BaseTestCase):
         chmod.assert_called_once_with(expected_dst, ANY)
         git_hooks_dir.assert_called_with(lint_config.target)
 
-    @patch('gitlint.hooks.shutil.copy')
-    @patch('os.path.exists', return_value=False)
-    @patch('os.path.isdir', return_value=True)
-    @patch('gitlint.hooks.git_hooks_dir')
+    @patch("gitlint.hooks.shutil.copy")
+    @patch("os.path.exists", return_value=False)
+    @patch("os.path.isdir", return_value=True)
+    @patch("gitlint.hooks.git_hooks_dir")
     def test_install_commit_msg_hook_negative(self, git_hooks_dir, isdir, path_exists, copy):
         lint_config = LintConfig()
         lint_config.target = os.path.join("/hür", "dur")
@@ -64,22 +68,24 @@ class HookTests(BaseTestCase):
         isdir.return_value = True
         path_exists.return_value = True
         expected_dst = os.path.join(git_hooks_dir.return_value, COMMIT_MSG_HOOK_DST_PATH)
-        expected_msg = f"There is already a commit-msg hook file present in {expected_dst}.\n" + \
-                       "gitlint currently does not support appending to an existing commit-msg file."
+        expected_msg = (
+            f"There is already a commit-msg hook file present in {expected_dst}.\n"
+            "gitlint currently does not support appending to an existing commit-msg file."
+        )
         with self.assertRaisesMessage(GitHookInstallerError, expected_msg):
             GitHookInstaller.install_commit_msg_hook(lint_config)
 
     @staticmethod
-    @patch('os.remove')
-    @patch('os.path.exists', return_value=True)
-    @patch('os.path.isdir', return_value=True)
-    @patch('gitlint.hooks.git_hooks_dir')
+    @patch("os.remove")
+    @patch("os.path.exists", return_value=True)
+    @patch("os.path.isdir", return_value=True)
+    @patch("gitlint.hooks.git_hooks_dir")
     def test_uninstall_commit_msg_hook(git_hooks_dir, isdir, path_exists, remove):
         lint_config = LintConfig()
         git_hooks_dir.return_value = os.path.join("/föo", "bar", ".git", "hooks")
         lint_config.target = os.path.join("/hür", "dur")
         read_data = "#!/bin/sh\n" + GITLINT_HOOK_IDENTIFIER
-        with patch('gitlint.hooks.io.open', mock_open(read_data=read_data), create=True):
+        with patch("gitlint.hooks.io.open", mock_open(read_data=read_data), create=True):
             GitHookInstaller.uninstall_commit_msg_hook(lint_config)
 
         expected_dst = os.path.join(git_hooks_dir.return_value, COMMIT_MSG_HOOK_DST_PATH)
@@ -88,10 +94,10 @@ class HookTests(BaseTestCase):
         remove.assert_called_with(expected_dst)
         git_hooks_dir.assert_called_with(lint_config.target)
 
-    @patch('os.remove')
-    @patch('os.path.exists', return_value=True)
-    @patch('os.path.isdir', return_value=True)
-    @patch('gitlint.hooks.git_hooks_dir')
+    @patch("os.remove")
+    @patch("os.path.exists", return_value=True)
+    @patch("os.path.isdir", return_value=True)
+    @patch("gitlint.hooks.git_hooks_dir")
     def test_uninstall_commit_msg_hook_negative(self, git_hooks_dir, isdir, path_exists, remove):
         lint_config = LintConfig()
         lint_config.target = os.path.join("/hür", "dur")
@@ -122,10 +128,12 @@ class HookTests(BaseTestCase):
         path_exists.return_value = True
         read_data = "#!/bin/sh\nfoo"
         expected_dst = os.path.join(git_hooks_dir.return_value, COMMIT_MSG_HOOK_DST_PATH)
-        expected_msg = f"The commit-msg hook in {expected_dst} was not installed by gitlint " + \
-                       "(or it was modified).\nUninstallation of 3th party or modified gitlint hooks " + \
-                       "is not supported."
-        with patch('gitlint.hooks.io.open', mock_open(read_data=read_data), create=True):
+        expected_msg = (
+            f"The commit-msg hook in {expected_dst} was not installed by gitlint "
+            "(or it was modified).\nUninstallation of 3th party or modified gitlint hooks "
+            "is not supported."
+        )
+        with patch("gitlint.hooks.io.open", mock_open(read_data=read_data), create=True):
             with self.assertRaisesMessage(GitHookInstallerError, expected_msg):
                 GitHookInstaller.uninstall_commit_msg_hook(lint_config)
             remove.assert_not_called()

--- a/gitlint-core/gitlint/tests/test_lint.py
+++ b/gitlint-core/gitlint/tests/test_lint.py
@@ -11,23 +11,35 @@ from gitlint.config import LintConfig, LintConfigBuilder
 
 
 class LintTests(BaseTestCase):
-
     def test_lint_sample1(self):
         linter = GitLinter(LintConfig())
         gitcontext = self.gitcontext(self.get_sample("commit_message/sample1"))
         violations = linter.lint(gitcontext.commits[-1])
-        expected_errors = [RuleViolation("T3", "Title has trailing punctuation (.)",
-                                         "Commit title contåining 'WIP', as well as trailing punctuation.", 1),
-                           RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)",
-                                         "Commit title contåining 'WIP', as well as trailing punctuation.", 1),
-                           RuleViolation("B4", "Second line is not empty", "This line should be empty", 2),
-                           RuleViolation("B1", "Line exceeds max length (135>80)",
-                                         "This is the first line of the commit message body and it is meant to test " +
-                                         "a line that exceeds the maximum line length of 80 characters.", 3),
-                           RuleViolation("B2", "Line has trailing whitespace", "This line has a tråiling space. ", 4),
-                           RuleViolation("B2", "Line has trailing whitespace", "This line has a trailing tab.\t", 5),
-                           RuleViolation("B3", "Line contains hard tab characters (\\t)",
-                                         "This line has a trailing tab.\t", 5)]
+        expected_errors = [
+            RuleViolation(
+                "T3",
+                "Title has trailing punctuation (.)",
+                "Commit title contåining 'WIP', as well as trailing punctuation.",
+                1,
+            ),
+            RuleViolation(
+                "T5",
+                "Title contains the word 'WIP' (case-insensitive)",
+                "Commit title contåining 'WIP', as well as trailing punctuation.",
+                1,
+            ),
+            RuleViolation("B4", "Second line is not empty", "This line should be empty", 2),
+            RuleViolation(
+                "B1",
+                "Line exceeds max length (135>80)",
+                "This is the first line of the commit message body and it is meant to test "
+                "a line that exceeds the maximum line length of 80 characters.",
+                3,
+            ),
+            RuleViolation("B2", "Line has trailing whitespace", "This line has a tråiling space. ", 4),
+            RuleViolation("B2", "Line has trailing whitespace", "This line has a trailing tab.\t", 5),
+            RuleViolation("B3", "Line contains hard tab characters (\\t)", "This line has a trailing tab.\t", 5),
+        ]
 
         self.assertListEqual(violations, expected_errors)
 
@@ -35,9 +47,10 @@ class LintTests(BaseTestCase):
         linter = GitLinter(LintConfig())
         gitcontext = self.gitcontext(self.get_sample("commit_message/sample2"))
         violations = linter.lint(gitcontext.commits[-1])
-        expected = [RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)",
-                                  "Just a title contåining WIP", 1),
-                    RuleViolation("B6", "Body message is missing", None, 3)]
+        expected = [
+            RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)", "Just a title contåining WIP", 1),
+            RuleViolation("B6", "Body message is missing", None, 3),
+        ]
 
         self.assertListEqual(violations, expected)
 
@@ -47,19 +60,24 @@ class LintTests(BaseTestCase):
         violations = linter.lint(gitcontext.commits[-1])
 
         title = " Commit title containing 'WIP', \tleading and tråiling whitespace and longer than 72 characters."
-        expected = [RuleViolation("T1", "Title exceeds max length (95>72)", title, 1),
-                    RuleViolation("T3", "Title has trailing punctuation (.)", title, 1),
-                    RuleViolation("T4", "Title contains hard tab characters (\\t)", title, 1),
-                    RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)", title, 1),
-                    RuleViolation("T6", "Title has leading whitespace", title, 1),
-                    RuleViolation("B4", "Second line is not empty", "This line should be empty", 2),
-                    RuleViolation("B1", "Line exceeds max length (101>80)",
-                                  "This is the first line is meånt to test a line that exceeds the maximum line " +
-                                  "length of 80 characters.", 3),
-                    RuleViolation("B2", "Line has trailing whitespace", "This line has a trailing space. ", 4),
-                    RuleViolation("B2", "Line has trailing whitespace", "This line has a tråiling tab.\t", 5),
-                    RuleViolation("B3", "Line contains hard tab characters (\\t)",
-                                  "This line has a tråiling tab.\t", 5)]
+        expected = [
+            RuleViolation("T1", "Title exceeds max length (95>72)", title, 1),
+            RuleViolation("T3", "Title has trailing punctuation (.)", title, 1),
+            RuleViolation("T4", "Title contains hard tab characters (\\t)", title, 1),
+            RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)", title, 1),
+            RuleViolation("T6", "Title has leading whitespace", title, 1),
+            RuleViolation("B4", "Second line is not empty", "This line should be empty", 2),
+            RuleViolation(
+                "B1",
+                "Line exceeds max length (101>80)",
+                "This is the first line is meånt to test a line that exceeds the maximum line "
+                "length of 80 characters.",
+                3,
+            ),
+            RuleViolation("B2", "Line has trailing whitespace", "This line has a trailing space. ", 4),
+            RuleViolation("B2", "Line has trailing whitespace", "This line has a tråiling tab.\t", 5),
+            RuleViolation("B3", "Line contains hard tab characters (\\t)", "This line has a tråiling tab.\t", 5),
+        ]
 
         self.assertListEqual(violations, expected)
 
@@ -82,26 +100,28 @@ class LintTests(BaseTestCase):
 
         title = " Commit title containing 'WIP', \tleading and tråiling whitespace and longer than 72 characters."
         # expect only certain violations because sample5 has a 'gitlint-ignore: T3, T6, body-max-line-length'
-        expected = [RuleViolation("T1", "Title exceeds max length (95>72)", title, 1),
-                    RuleViolation("T4", "Title contains hard tab characters (\\t)", title, 1),
-                    RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)", title, 1),
-                    RuleViolation("B4", "Second line is not empty", "This line should be ëmpty", 2),
-                    RuleViolation("B2", "Line has trailing whitespace", "This line has a tråiling space. ", 4),
-                    RuleViolation("B2", "Line has trailing whitespace", "This line has a trailing tab.\t", 5),
-                    RuleViolation("B3", "Line contains hard tab characters (\\t)",
-                                  "This line has a trailing tab.\t", 5)]
+        expected = [
+            RuleViolation("T1", "Title exceeds max length (95>72)", title, 1),
+            RuleViolation("T4", "Title contains hard tab characters (\\t)", title, 1),
+            RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)", title, 1),
+            RuleViolation("B4", "Second line is not empty", "This line should be ëmpty", 2),
+            RuleViolation("B2", "Line has trailing whitespace", "This line has a tråiling space. ", 4),
+            RuleViolation("B2", "Line has trailing whitespace", "This line has a trailing tab.\t", 5),
+            RuleViolation("B3", "Line contains hard tab characters (\\t)", "This line has a trailing tab.\t", 5),
+        ]
         self.assertListEqual(violations, expected)
 
     def test_lint_meta(self):
-        """ Lint sample2 but also add some metadata to the commit so we that gets linted as well """
+        """Lint sample2 but also add some metadata to the commit so we that gets linted as well"""
         linter = GitLinter(LintConfig())
         gitcontext = self.gitcontext(self.get_sample("commit_message/sample2"))
         gitcontext.commits[0].author_email = "foo bår"
         violations = linter.lint(gitcontext.commits[-1])
-        expected = [RuleViolation("M1", "Author email for commit is invalid", "foo bår", None),
-                    RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)",
-                                  "Just a title contåining WIP", 1),
-                    RuleViolation("B6", "Body message is missing", None, 3)]
+        expected = [
+            RuleViolation("M1", "Author email for commit is invalid", "foo bår", None),
+            RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)", "Just a title contåining WIP", 1),
+            RuleViolation("B6", "Body message is missing", None, 3),
+        ]
 
         self.assertListEqual(violations, expected)
 
@@ -111,9 +131,10 @@ class LintTests(BaseTestCase):
         linter = GitLinter(lint_config)
         violations = linter.lint(self.gitcommit(self.get_sample("commit_message/sample3")))
 
-        expected = [RuleViolation("B4", "Second line is not empty", "This line should be empty", 2),
-                    RuleViolation("B3", "Line contains hard tab characters (\\t)",
-                                  "This line has a tråiling tab.\t", 5)]
+        expected = [
+            RuleViolation("B4", "Second line is not empty", "This line should be empty", 2),
+            RuleViolation("B3", "Line contains hard tab characters (\\t)", "This line has a tråiling tab.\t", 5),
+        ]
 
         self.assertListEqual(violations, expected)
 
@@ -135,8 +156,9 @@ class LintTests(BaseTestCase):
         violations = linter.lint(self.gitcommit(self.get_sample("commit_message/sample2")))
 
         # Normally we'd expect a B6 violation, but that one is skipped because of the specific ignore set above
-        expected = [RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)",
-                                  "Just a title contåining WIP", 1)]
+        expected = [
+            RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)", "Just a title contåining WIP", 1)
+        ]
 
         self.assertListEqual(violations, expected)
 
@@ -145,17 +167,30 @@ class LintTests(BaseTestCase):
         linter = GitLinter(lint_config)
         lint_config.set_rule_option("I3", "regex", "(.*)tråiling(.*)")
         violations = linter.lint(self.gitcommit(self.get_sample("commit_message/sample1")))
-        expected_errors = [RuleViolation("T3", "Title has trailing punctuation (.)",
-                                         "Commit title contåining 'WIP', as well as trailing punctuation.", 1),
-                           RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)",
-                                         "Commit title contåining 'WIP', as well as trailing punctuation.", 1),
-                           RuleViolation("B4", "Second line is not empty", "This line should be empty", 2),
-                           RuleViolation("B1", "Line exceeds max length (135>80)",
-                                         "This is the first line of the commit message body and it is meant to test " +
-                                         "a line that exceeds the maximum line length of 80 characters.", 3),
-                           RuleViolation("B2", "Line has trailing whitespace", "This line has a trailing tab.\t", 4),
-                           RuleViolation("B3", "Line contains hard tab characters (\\t)",
-                                         "This line has a trailing tab.\t", 4)]
+        expected_errors = [
+            RuleViolation(
+                "T3",
+                "Title has trailing punctuation (.)",
+                "Commit title contåining 'WIP', as well as trailing punctuation.",
+                1,
+            ),
+            RuleViolation(
+                "T5",
+                "Title contains the word 'WIP' (case-insensitive)",
+                "Commit title contåining 'WIP', as well as trailing punctuation.",
+                1,
+            ),
+            RuleViolation("B4", "Second line is not empty", "This line should be empty", 2),
+            RuleViolation(
+                "B1",
+                "Line exceeds max length (135>80)",
+                "This is the first line of the commit message body and it is meant to test "
+                "a line that exceeds the maximum line length of 80 characters.",
+                3,
+            ),
+            RuleViolation("B2", "Line has trailing whitespace", "This line has a trailing tab.\t", 4),
+            RuleViolation("B3", "Line contains hard tab characters (\\t)", "This line has a trailing tab.\t", 4),
+        ]
 
         self.assertListEqual(violations, expected_errors)
 
@@ -176,7 +211,7 @@ class LintTests(BaseTestCase):
             self.assertTrue(len(violations) > 0)
 
     def test_lint_regex_rules(self):
-        """ Additional test for title-match-regex, body-match-regex """
+        """Additional test for title-match-regex, body-match-regex"""
         commit = self.gitcommit(self.get_sample("commit_message/no-violations"))
         lintconfig = LintConfig()
         linter = GitLinter(lintconfig)
@@ -192,46 +227,52 @@ class LintTests(BaseTestCase):
             self.assertListEqual(violations, [])
 
         # Non-matching regexes should return violations
-        rule_regexes = [("title-match-regex", ), ("body-match-regex",)]
+        rule_regexes = [("title-match-regex",), ("body-match-regex",)]
         lintconfig.set_rule_option("title-match-regex", "regex", "^Tïtle")
         lintconfig.set_rule_option("body-match-regex", "regex", "Sügned-Off-By: (.*)$")
-        expected_violations = [RuleViolation("T7", "Title does not match regex (^Tïtle)", "Normal Commit Tïtle", 1),
-                               RuleViolation("B8", "Body does not match regex (Sügned-Off-By: (.*)$)", None, 6)]
+        expected_violations = [
+            RuleViolation("T7", "Title does not match regex (^Tïtle)", "Normal Commit Tïtle", 1),
+            RuleViolation("B8", "Body does not match regex (Sügned-Off-By: (.*)$)", None, 6),
+        ]
         violations = linter.lint(commit)
         self.assertListEqual(violations, expected_violations)
 
     def test_print_violations(self):
-        violations = [RuleViolation("RULE_ID_1", "Error Messåge 1", "Violating Content 1", None),
-                      RuleViolation("RULE_ID_2", "Error Message 2", "Violåting Content 2", 2)]
+        violations = [
+            RuleViolation("RULE_ID_1", "Error Messåge 1", "Violating Content 1", None),
+            RuleViolation("RULE_ID_2", "Error Message 2", "Violåting Content 2", 2),
+        ]
         linter = GitLinter(LintConfig())
 
         # test output with increasing verbosity
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             linter.config.verbosity = 0
             linter.print_violations(violations)
             self.assertEqual("", stderr.getvalue())
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             linter.config.verbosity = 1
             linter.print_violations(violations)
             expected = "-: RULE_ID_1\n2: RULE_ID_2\n"
             self.assertEqual(expected, stderr.getvalue())
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             linter.config.verbosity = 2
             linter.print_violations(violations)
             expected = "-: RULE_ID_1 Error Messåge 1\n2: RULE_ID_2 Error Message 2\n"
             self.assertEqual(expected, stderr.getvalue())
 
-        with patch('gitlint.display.stderr', new=StringIO()) as stderr:
+        with patch("gitlint.display.stderr", new=StringIO()) as stderr:
             linter.config.verbosity = 3
             linter.print_violations(violations)
-            expected = "-: RULE_ID_1 Error Messåge 1: \"Violating Content 1\"\n" + \
-                       "2: RULE_ID_2 Error Message 2: \"Violåting Content 2\"\n"
+            expected = (
+                '-: RULE_ID_1 Error Messåge 1: "Violating Content 1"\n'
+                + '2: RULE_ID_2 Error Message 2: "Violåting Content 2"\n'
+            )
             self.assertEqual(expected, stderr.getvalue())
 
     def test_named_rules(self):
-        """ Test that when named rules are present, both them and the original (non-named) rules executed """
+        """Test that when named rules are present, both them and the original (non-named) rules executed"""
 
         lint_config = LintConfig()
         for rule_name in ["my-ïd", "another-rule-ïd"]:
@@ -240,15 +281,15 @@ class LintTests(BaseTestCase):
             lint_config.set_rule_option(rule_id, "words", ["Föo"])
             linter = GitLinter(lint_config)
 
-        violations = [RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)", "WIP: Föo bar", 1),
-                      RuleViolation("T5:another-rule-ïd", "Title contains the word 'Föo' (case-insensitive)",
-                                    "WIP: Föo bar", 1),
-                      RuleViolation("T5:my-ïd", "Title contains the word 'Föo' (case-insensitive)",
-                                    "WIP: Föo bar", 1)]
+        violations = [
+            RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)", "WIP: Föo bar", 1),
+            RuleViolation("T5:another-rule-ïd", "Title contains the word 'Föo' (case-insensitive)", "WIP: Föo bar", 1),
+            RuleViolation("T5:my-ïd", "Title contains the word 'Föo' (case-insensitive)", "WIP: Föo bar", 1),
+        ]
         self.assertListEqual(violations, linter.lint(self.gitcommit("WIP: Föo bar\n\nFoo bår hur dur bla bla")))
 
     def test_ignore_named_rules(self):
-        """ Test that named rules can be ignored """
+        """Test that named rules can be ignored"""
 
         # Add named rule to lint config
         config_builder = LintConfigBuilder()
@@ -259,9 +300,10 @@ class LintTests(BaseTestCase):
         commit = self.gitcommit("WIP: Föo bar\n\nFoo bår hur dur bla bla")
 
         # By default, we expect both the violations of the regular rule as well as the named rule to show up
-        violations = [RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)", "WIP: Föo bar", 1),
-                      RuleViolation("T5:my-ïd", "Title contains the word 'Föo' (case-insensitive)",
-                                    "WIP: Föo bar", 1)]
+        violations = [
+            RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)", "WIP: Föo bar", 1),
+            RuleViolation("T5:my-ïd", "Title contains the word 'Föo' (case-insensitive)", "WIP: Föo bar", 1),
+        ]
         self.assertListEqual(violations, linter.lint(commit))
 
         # ignore regular rule: only named rule violations show up

--- a/gitlint-core/gitlint/tests/test_lint.py
+++ b/gitlint-core/gitlint/tests/test_lint.py
@@ -15,31 +15,22 @@ class LintTests(BaseTestCase):
         linter = GitLinter(LintConfig())
         gitcontext = self.gitcontext(self.get_sample("commit_message/sample1"))
         violations = linter.lint(gitcontext.commits[-1])
+        # fmt: off
         expected_errors = [
-            RuleViolation(
-                "T3",
-                "Title has trailing punctuation (.)",
-                "Commit title contåining 'WIP', as well as trailing punctuation.",
-                1,
-            ),
-            RuleViolation(
-                "T5",
-                "Title contains the word 'WIP' (case-insensitive)",
-                "Commit title contåining 'WIP', as well as trailing punctuation.",
-                1,
-            ),
+            RuleViolation("T3", "Title has trailing punctuation (.)",
+                                "Commit title contåining 'WIP', as well as trailing punctuation.", 1),
+            RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)",
+                            "Commit title contåining 'WIP', as well as trailing punctuation.", 1),
             RuleViolation("B4", "Second line is not empty", "This line should be empty", 2),
-            RuleViolation(
-                "B1",
-                "Line exceeds max length (135>80)",
-                "This is the first line of the commit message body and it is meant to test "
-                "a line that exceeds the maximum line length of 80 characters.",
-                3,
-            ),
+            RuleViolation("B1", "Line exceeds max length (135>80)",
+                            "This is the first line of the commit message body and it is meant to test " +
+                            "a line that exceeds the maximum line length of 80 characters.", 3),
             RuleViolation("B2", "Line has trailing whitespace", "This line has a tråiling space. ", 4),
             RuleViolation("B2", "Line has trailing whitespace", "This line has a trailing tab.\t", 5),
-            RuleViolation("B3", "Line contains hard tab characters (\\t)", "This line has a trailing tab.\t", 5),
+            RuleViolation("B3", "Line contains hard tab characters (\\t)",
+                            "This line has a trailing tab.\t", 5)
         ]
+        # fmt: on
 
         self.assertListEqual(violations, expected_errors)
 
@@ -59,6 +50,7 @@ class LintTests(BaseTestCase):
         gitcontext = self.gitcontext(self.get_sample("commit_message/sample3"))
         violations = linter.lint(gitcontext.commits[-1])
 
+        # fmt: off
         title = " Commit title containing 'WIP', \tleading and tråiling whitespace and longer than 72 characters."
         expected = [
             RuleViolation("T1", "Title exceeds max length (95>72)", title, 1),
@@ -67,17 +59,15 @@ class LintTests(BaseTestCase):
             RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)", title, 1),
             RuleViolation("T6", "Title has leading whitespace", title, 1),
             RuleViolation("B4", "Second line is not empty", "This line should be empty", 2),
-            RuleViolation(
-                "B1",
-                "Line exceeds max length (101>80)",
-                "This is the first line is meånt to test a line that exceeds the maximum line "
-                "length of 80 characters.",
-                3,
-            ),
+            RuleViolation("B1", "Line exceeds max length (101>80)",
+                            "This is the first line is meånt to test a line that exceeds the maximum line " +
+                            "length of 80 characters.", 3),
             RuleViolation("B2", "Line has trailing whitespace", "This line has a trailing space. ", 4),
             RuleViolation("B2", "Line has trailing whitespace", "This line has a tråiling tab.\t", 5),
-            RuleViolation("B3", "Line contains hard tab characters (\\t)", "This line has a tråiling tab.\t", 5),
+            RuleViolation("B3", "Line contains hard tab characters (\\t)",
+                            "This line has a tråiling tab.\t", 5)
         ]
+        # fmt: on
 
         self.assertListEqual(violations, expected)
 
@@ -167,31 +157,21 @@ class LintTests(BaseTestCase):
         linter = GitLinter(lint_config)
         lint_config.set_rule_option("I3", "regex", "(.*)tråiling(.*)")
         violations = linter.lint(self.gitcommit(self.get_sample("commit_message/sample1")))
+        # fmt: off
         expected_errors = [
-            RuleViolation(
-                "T3",
-                "Title has trailing punctuation (.)",
-                "Commit title contåining 'WIP', as well as trailing punctuation.",
-                1,
-            ),
-            RuleViolation(
-                "T5",
-                "Title contains the word 'WIP' (case-insensitive)",
-                "Commit title contåining 'WIP', as well as trailing punctuation.",
-                1,
-            ),
+            RuleViolation("T3", "Title has trailing punctuation (.)",
+                                "Commit title contåining 'WIP', as well as trailing punctuation.", 1),
+            RuleViolation("T5", "Title contains the word 'WIP' (case-insensitive)",
+                            "Commit title contåining 'WIP', as well as trailing punctuation.", 1),
             RuleViolation("B4", "Second line is not empty", "This line should be empty", 2),
-            RuleViolation(
-                "B1",
-                "Line exceeds max length (135>80)",
-                "This is the first line of the commit message body and it is meant to test "
-                "a line that exceeds the maximum line length of 80 characters.",
-                3,
-            ),
+            RuleViolation("B1", "Line exceeds max length (135>80)",
+                            "This is the first line of the commit message body and it is meant to test " +
+                            "a line that exceeds the maximum line length of 80 characters.", 3),
             RuleViolation("B2", "Line has trailing whitespace", "This line has a trailing tab.\t", 4),
-            RuleViolation("B3", "Line contains hard tab characters (\\t)", "This line has a trailing tab.\t", 4),
+            RuleViolation("B3", "Line contains hard tab characters (\\t)",
+                            "This line has a trailing tab.\t", 4)
         ]
-
+        # fmt: on
         self.assertListEqual(violations, expected_errors)
 
     def test_lint_special_commit(self):

--- a/gitlint-core/gitlint/tests/test_options.py
+++ b/gitlint-core/gitlint/tests/test_options.py
@@ -9,8 +9,14 @@ from gitlint.options import IntOption, BoolOption, StrOption, ListOption, PathOp
 
 class RuleOptionTests(BaseTestCase):
     def test_option_equality(self):
-        options = {IntOption: 123, StrOption: "foöbar", BoolOption: False, ListOption: ["a", "b"],
-                   PathOption: ".", RegexOption: "^foöbar(.*)"}
+        options = {
+            IntOption: 123,
+            StrOption: "foöbar",
+            BoolOption: False,
+            ListOption: ["a", "b"],
+            PathOption: ".",
+            RegexOption: "^foöbar(.*)",
+        }
         for clazz, val in options.items():
             # 2 options are equal if their name, value and description match
             option1 = clazz("test-öption", val, "Test Dëscription")
@@ -97,7 +103,7 @@ class RuleOptionTests(BaseTestCase):
         self.assertEqual(option.value, True)
 
         # error on incorrect value
-        incorrect_values = [1, -1, "foo", "bår", ["foo"], {'foo': "bar"}, None]
+        incorrect_values = [1, -1, "foo", "bår", ["foo"], {"foo": "bar"}, None]
         for value in incorrect_values:
             with self.assertRaisesMessage(RuleOptionError, "Option 'tëst-name' must be either 'true' or 'false'"):
                 option.set(value)
@@ -197,7 +203,7 @@ class RuleOptionTests(BaseTestCase):
         self.assertEqual(option.value, self.get_sample_path())
 
         # Expect exception if path type is invalid
-        option.type = 'föo'
+        option.type = "föo"
         expected = "Option tëst-directory type must be one of: 'file', 'dir', 'both' (current: 'föo')"
         with self.assertRaisesMessage(RuleOptionError, expected):
             option.set("haha")

--- a/gitlint-core/gitlint/tests/test_utils.py
+++ b/gitlint-core/gitlint/tests/test_utils.py
@@ -7,13 +7,12 @@ from gitlint.tests.base import BaseTestCase
 
 
 class UtilsTests(BaseTestCase):
-
     def tearDown(self):
         # Since we're messing around with `utils.PLATFORM_IS_WINDOWS` during these tests, we need to reset
         # its value after we're done this doesn't influence other tests
         utils.PLATFORM_IS_WINDOWS = utils.platform_is_windows()
 
-    @patch('os.environ')
+    @patch("os.environ")
     def test_use_sh_library(self, patched_env):
         patched_env.get.return_value = "1"
         self.assertEqual(utils.use_sh_library(), True)
@@ -33,7 +32,7 @@ class UtilsTests(BaseTestCase):
         utils.PLATFORM_IS_WINDOWS = False
         self.assertEqual(utils.use_sh_library(), True)
 
-    @patch('gitlint.utils.locale')
+    @patch("gitlint.utils.locale")
     def test_default_encoding_non_windows(self, mocked_locale):
         utils.PLATFORM_IS_WINDOWS = False
         mocked_locale.getpreferredencoding.return_value = "foöbar"
@@ -43,7 +42,7 @@ class UtilsTests(BaseTestCase):
         mocked_locale.getpreferredencoding.return_value = False
         self.assertEqual(utils.getpreferredencoding(), "UTF-8")
 
-    @patch('os.environ')
+    @patch("os.environ")
     def test_default_encoding_windows(self, patched_env):
         utils.PLATFORM_IS_WINDOWS = True
         # Mock out os.environ

--- a/gitlint-core/gitlint/utils.py
+++ b/gitlint-core/gitlint/utils.py
@@ -11,7 +11,7 @@ import locale
 # and just executed at import-time.
 
 ########################################################################################################################
-LOG_FORMAT = '%(levelname)s: %(name)s %(message)s'
+LOG_FORMAT = "%(levelname)s: %(name)s %(message)s"
 
 ########################################################################################################################
 # PLATFORM_IS_WINDOWS
@@ -31,7 +31,7 @@ PLATFORM_IS_WINDOWS = platform_is_windows()
 
 
 def use_sh_library():
-    gitlint_use_sh_lib_env = os.environ.get('GITLINT_USE_SH_LIB', None)
+    gitlint_use_sh_lib_env = os.environ.get("GITLINT_USE_SH_LIB", None)
     if gitlint_use_sh_lib_env:
         return gitlint_use_sh_lib_env == "1"
     return not PLATFORM_IS_WINDOWS
@@ -44,8 +44,8 @@ USE_SH_LIB = use_sh_library()
 
 
 def getpreferredencoding():
-    """ Modified version of local.getpreferredencoding() that takes into account LC_ALL, LC_CTYPE, LANG env vars
-        on windows and falls back to UTF-8. """
+    """Modified version of local.getpreferredencoding() that takes into account LC_ALL, LC_CTYPE, LANG env vars
+    on windows and falls back to UTF-8."""
     fallback_encoding = "UTF-8"
     default_encoding = locale.getpreferredencoding() or fallback_encoding
 
@@ -61,7 +61,7 @@ def getpreferredencoding():
                 # If encoding contains a dot: split and use second part, otherwise use everything
                 dot_index = encoding.find(".")
                 if dot_index != -1:
-                    default_encoding = encoding[dot_index + 1:]
+                    default_encoding = encoding[dot_index + 1 :]
                 else:
                     default_encoding = encoding
                 break

--- a/gitlint-core/setup.py
+++ b/gitlint-core/setup.py
@@ -32,7 +32,7 @@ Source code on `github.com/jorisroovers/gitlint`_.
 # shamelessly stolen from mkdocs' setup.py: https://github.com/mkdocs/mkdocs/blob/master/setup.py
 def get_version(package):
     """Return package version as listed in `__version__` in `init.py`."""
-    init_py = io.open(os.path.join(package, '__init__.py'), encoding="UTF-8").read()
+    init_py = io.open(os.path.join(package, "__init__.py"), encoding="UTF-8").read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
 
@@ -56,32 +56,30 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Quality Assurance",
         "Topic :: Software Development :: Testing",
-        "License :: OSI Approved :: MIT License"
+        "License :: OSI Approved :: MIT License",
     ],
     python_requires=">=3.6",
     install_requires=[
-        'Click>=8',
-        'arrow>=1',
+        "Click>=8",
+        "arrow>=1",
         'sh>=1.13.0 ; sys_platform != "win32"',
     ],
     extras_require={
-        'trusted-deps': [
-            'Click==8.0.3',
-            'arrow==1.2.1',
+        "trusted-deps": [
+            "Click==8.0.3",
+            "arrow==1.2.1",
             'sh==1.14.2 ; sys_platform != "win32"',
         ],
     },
-    keywords='gitlint git lint',
-    author='Joris Roovers',
-    url='https://jorisroovers.github.io/gitlint',
+    keywords="gitlint git lint",
+    author="Joris Roovers",
+    url="https://jorisroovers.github.io/gitlint",
     project_urls={
-        'Documentation': 'https://jorisroovers.github.io/gitlint',
-        'Source': 'https://github.com/jorisroovers/gitlint',
+        "Documentation": "https://jorisroovers.github.io/gitlint",
+        "Source": "https://github.com/jorisroovers/gitlint",
     },
-    license='MIT',
-    package_data={
-        'gitlint': ['files/*']
-    },
+    license="MIT",
+    package_data={"gitlint": ["files/*"]},
     packages=find_packages(exclude=["examples"]),
     entry_points={
         "console_scripts": [
@@ -92,16 +90,20 @@ setup(
 
 # Print a red deprecation warning for python < 3.6 users
 if sys.version_info[:2] < (3, 6):
-    msg = "\033[31mDEPRECATION: You're using a python version that has reached end-of-life. " + \
-          "Gitlint does not support Python < 3.6" + \
-          "Please upgrade your Python to 3.6 or above.\033[0m"
+    msg = (
+        "\033[31mDEPRECATION: You're using a python version that has reached end-of-life. "
+        + "Gitlint does not support Python < 3.6"
+        + "Please upgrade your Python to 3.6 or above.\033[0m"
+    )
     print(msg)
 
 # Print a warning message for Windows users
 PLATFORM_IS_WINDOWS = "windows" in platform.system().lower()
 if PLATFORM_IS_WINDOWS:
-    msg = "\n\n\n\n\n****************\n" + \
-          "WARNING: Gitlint support for Windows is still experimental and there are some known issues: " + \
-          "https://github.com/jorisroovers/gitlint/issues?q=is%3Aissue+is%3Aopen+label%3Awindows " + \
-          "\n*******************"
+    msg = (
+        "\n\n\n\n\n****************\n"
+        + "WARNING: Gitlint support for Windows is still experimental and there are some known issues: "
+        + "https://github.com/jorisroovers/gitlint/issues?q=is%3Aissue+is%3Aopen+label%3Awindows "
+        + "\n*******************"
+    )
     print(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 120
+exclude = "gitlint-core/gitlint/tests/samples/user_rules/import_exception/invalid_python.py"
+# include = '\.pyi?$'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.black]
+target_version = ['py36', 'py37', 'py38','py39','py310']
 line-length = 120
 exclude = "gitlint-core/gitlint/tests/samples/user_rules/import_exception/invalid_python.py"
 # include = '\.pyi?$'

--- a/qa/base.py
+++ b/qa/base.py
@@ -20,8 +20,8 @@ from qa.utils import DEFAULT_ENCODING
 
 
 class BaseTestCase(TestCase):
-    """ Base class of which all gitlint integration test classes are derived.
-        Provides a number of convenience methods. """
+    """Base class of which all gitlint integration test classes are derived.
+    Provides a number of convenience methods."""
 
     # In case of assert failures, print the full error message
     maxDiff = None
@@ -32,7 +32,7 @@ class BaseTestCase(TestCase):
     GITLINT_USAGE_ERROR = 253
 
     def setUp(self):
-        """ Sets up the integration tests by creating a new temporary git repository """
+        """Sets up the integration tests by creating a new temporary git repository"""
         self.tmpfiles = []
         self.tmp_git_repos = []
         self.tmp_git_repo = self.create_tmp_git_repo()
@@ -47,7 +47,7 @@ class BaseTestCase(TestCase):
     def assertEqualStdout(self, output, expected):  # pylint: disable=invalid-name
         self.assertIsInstance(output, RunningCommand)
         output = output.stdout.decode(DEFAULT_ENCODING)
-        output = output.replace('\r', '')
+        output = output.replace("\r", "")
         self.assertMultiLineEqual(output, expected)
 
     @staticmethod
@@ -56,7 +56,7 @@ class BaseTestCase(TestCase):
         return os.path.realpath(f"/tmp/gitlint-test-{timestamp}")
 
     def create_tmp_git_repo(self):
-        """ Creates a temporary git repository and returns its directory path """
+        """Creates a temporary git repository and returns its directory path"""
         tmp_git_repo = self.generate_temp_path()
         self.tmp_git_repos.append(tmp_git_repo)
 
@@ -78,28 +78,28 @@ class BaseTestCase(TestCase):
 
     @staticmethod
     def create_file(parent_dir):
-        """ Creates a file inside a passed directory. Returns filename."""
+        """Creates a file inside a passed directory. Returns filename."""
         test_filename = "test-fïle-" + str(uuid4())
         # pylint: disable=consider-using-with
-        io.open(os.path.join(parent_dir, test_filename), 'a', encoding=DEFAULT_ENCODING).close()
+        io.open(os.path.join(parent_dir, test_filename), "a", encoding=DEFAULT_ENCODING).close()
         return test_filename
 
     @staticmethod
     def create_environment(envvars=None):
-        """ Creates a copy of the current os.environ and adds/overwrites a given set of variables to it """
+        """Creates a copy of the current os.environ and adds/overwrites a given set of variables to it"""
         environment = os.environ.copy()
         if envvars:
             environment.update(envvars)
         return environment
 
     def create_tmp_git_config(self, contents):
-        """ Creates an environment with the GIT_CONFIG variable set to a file with the given contents. """
+        """Creates an environment with the GIT_CONFIG variable set to a file with the given contents."""
         tmp_config = self.create_tmpfile(contents)
         return self.create_environment({"GIT_CONFIG": tmp_config})
 
     def create_simple_commit(self, message, out=None, ok_code=None, env=None, git_repo=None, tty_in=False):
-        """ Creates a simple commit with an empty test file.
-            :param message: Commit message for the commit. """
+        """Creates a simple commit with an empty test file.
+        :param message: Commit message for the commit."""
 
         git_repo = self.tmp_git_repo if git_repo is None else git_repo
 
@@ -116,12 +116,21 @@ class BaseTestCase(TestCase):
         if not ok_code:
             ok_code = [0]
 
-        git("commit", "-m", message, _cwd=git_repo, _err_to_out=True, _out=out, _tty_in=tty_in,
-            _ok_code=ok_code, _env=environment)
+        git(
+            "commit",
+            "-m",
+            message,
+            _cwd=git_repo,
+            _err_to_out=True,
+            _out=out,
+            _tty_in=tty_in,
+            _ok_code=ok_code,
+            _env=environment,
+        )
         return test_filename
 
     def create_tmpfile(self, content):
-        """ Utility method to create temp files. These are cleaned at the end of the test """
+        """Utility method to create temp files. These are cleaned at the end of the test"""
         # Not using a context manager to avoid unnecessary indentation in test code
         tmpfile, tmpfilepath = tempfile.mkstemp()
         self.tmpfiles.append(tmpfilepath)
@@ -149,8 +158,8 @@ class BaseTestCase(TestCase):
 
     @staticmethod
     def get_expected(filename="", variable_dict=None):
-        """ Utility method to read an 'expected' file and return it as a string. Optionally replace template variables
-        specified by variable_dict. """
+        """Utility method to read an 'expected' file and return it as a string. Optionally replace template variables
+        specified by variable_dict."""
         expected_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "expected")
         expected_path = os.path.join(expected_dir, filename)
         with io.open(expected_path, encoding=DEFAULT_ENCODING) as file:
@@ -162,20 +171,25 @@ class BaseTestCase(TestCase):
 
     @staticmethod
     def get_system_info_dict():
-        """ Returns a dict with items related to system values logged by `gitlint --debug` """
+        """Returns a dict with items related to system values logged by `gitlint --debug`"""
         expected_gitlint_version = gitlint("--version").replace("gitlint, version ", "").strip()
         expected_git_version = git("--version").strip()
-        return {'platform': platform.platform(), 'python_version': sys.version,
-                'git_version': expected_git_version, 'gitlint_version': expected_gitlint_version,
-                'GITLINT_USE_SH_LIB': BaseTestCase.GITLINT_USE_SH_LIB, 'DEFAULT_ENCODING': DEFAULT_ENCODING}
+        return {
+            "platform": platform.platform(),
+            "python_version": sys.version,
+            "git_version": expected_git_version,
+            "gitlint_version": expected_gitlint_version,
+            "GITLINT_USE_SH_LIB": BaseTestCase.GITLINT_USE_SH_LIB,
+            "DEFAULT_ENCODING": DEFAULT_ENCODING,
+        }
 
     def get_debug_vars_last_commit(self, git_repo=None):
-        """ Returns a dict with items related to `gitlint --debug` output for the last commit. """
+        """Returns a dict with items related to `gitlint --debug` output for the last commit."""
         target_repo = git_repo if git_repo else self.tmp_git_repo
         commit_sha = self.get_last_commit_hash(git_repo=target_repo)
         expected_date = git("log", "-1", "--pretty=%ai", _tty_out=False, _cwd=target_repo)
         expected_date = arrow.get(str(expected_date), "YYYY-MM-DD HH:mm:ss Z").format("YYYY-MM-DD HH:mm:ss Z")
 
         expected_kwargs = self.get_system_info_dict()
-        expected_kwargs.update({'target': target_repo, 'commit_sha': commit_sha, 'commit_date': expected_date})
+        expected_kwargs.update({"target": target_repo, "commit_sha": commit_sha, "commit_date": expected_date})
         return expected_kwargs

--- a/qa/samples/user_rules/extra/extra_rules.py
+++ b/qa/samples/user_rules/extra/extra_rules.py
@@ -5,21 +5,23 @@ from gitlint.options import IntOption, StrOption, ListOption
 
 
 class GitContextRule(CommitRule):
-    """ Rule that tests whether we can correctly access certain gitcontext properties """
+    """Rule that tests whether we can correctly access certain gitcontext properties"""
+
     name = "gïtcontext"
     id = "UC1"
 
     def validate(self, commit):
         violations = [
             RuleViolation(self.id, f"GitContext.current_branch: {commit.context.current_branch}", line_nr=1),
-            RuleViolation(self.id, f"GitContext.commentchar: {commit.context.commentchar}", line_nr=1)
+            RuleViolation(self.id, f"GitContext.commentchar: {commit.context.commentchar}", line_nr=1),
         ]
 
         return violations
 
 
 class GitCommitRule(CommitRule):
-    """ Rule that tests whether we can correctly access certain commit properties """
+    """Rule that tests whether we can correctly access certain commit properties"""
+
     name = "gïtcommit"
     id = "UC2"
 
@@ -33,7 +35,8 @@ class GitCommitRule(CommitRule):
 
 
 class GitlintConfigurationRule(ConfigurationRule):
-    """ Rule that tests whether we can correctly access the config as well as modify the commit message """
+    """Rule that tests whether we can correctly access the config as well as modify the commit message"""
+
     name = "cönfigrule"
     id = "UC3"
 
@@ -50,13 +53,16 @@ class GitlintConfigurationRule(ConfigurationRule):
 
 
 class ConfigurableCommitRule(CommitRule):
-    """ Rule that tests that we can add configuration to user-defined rules """
+    """Rule that tests that we can add configuration to user-defined rules"""
+
     name = "configürable"
     id = "UC4"
 
-    options_spec = [IntOption("int-öption", 2, "int-öption description"),
-                    StrOption("str-öption", "föo", "int-öption description"),
-                    ListOption("list-öption", ["foo", "bar"], "list-öption description")]
+    options_spec = [
+        IntOption("int-öption", 2, "int-öption description"),
+        StrOption("str-öption", "föo", "int-öption description"),
+        ListOption("list-öption", ["foo", "bar"], "list-öption description"),
+    ]
 
     def validate(self, _):
         violations = [

--- a/qa/shell.py
+++ b/qa/shell.py
@@ -1,4 +1,3 @@
-
 # This code is mostly duplicated from the `gitlint.shell` module. We consciously duplicate this code as to not depend
 # on gitlint internals for our integration testing framework.
 
@@ -7,6 +6,7 @@ from qa.utils import USE_SH_LIB, DEFAULT_ENCODING
 
 if USE_SH_LIB:
     from sh import git, echo, gitlint  # pylint: disable=unused-import,no-name-in-module,import-error
+
     gitlint = gitlint.bake(_unify_ttys=True, _tty_in=True)  # pylint: disable=invalid-name
 
     # import exceptions separately, this makes it a little easier to mock them out in the unit tests
@@ -14,17 +14,18 @@ if USE_SH_LIB:
 else:
 
     class CommandNotFound(Exception):
-        """ Exception indicating a command was not found during execution """
+        """Exception indicating a command was not found during execution"""
+
         pass
 
     class RunningCommand:
         pass
 
     class ShResult(RunningCommand):
-        """ Result wrapper class. We use this to more easily migrate from using https://amoffat.github.io/sh/ to using
-        the builtin subprocess module. """
+        """Result wrapper class. We use this to more easily migrate from using https://amoffat.github.io/sh/ to using
+        the builtin subprocess module."""
 
-        def __init__(self, full_cmd, stdout, stderr='', exitcode=0):
+        def __init__(self, full_cmd, stdout, stderr="", exitcode=0):
             self.full_cmd = full_cmd
             # TODO(jorisroovers): The 'sh' library by default will merge stdout and stderr. We mimic this behavior
             # for now until we fully remove the 'sh' library.
@@ -36,7 +37,8 @@ else:
             return self.stdout
 
     class ErrorReturnCode(ShResult, Exception):
-        """ ShResult subclass for unexpected results (acts as an exception). """
+        """ShResult subclass for unexpected results (acts as an exception)."""
+
         pass
 
     def git(*command_parts, **kwargs):
@@ -54,17 +56,17 @@ else:
         # If we reach this point and the result has an exit_code that is larger than 0, this means that we didn't
         # get an exception (which is the default sh behavior for non-zero exit codes) and so the user is expecting
         # a non-zero exit code -> just return the entire result
-        if hasattr(result, 'exit_code') and result.exit_code > 0:
+        if hasattr(result, "exit_code") and result.exit_code > 0:
             return result
         return str(result)
 
     def _exec(*args, **kwargs):
         pipe = subprocess.PIPE
-        popen_kwargs = {'stdout': pipe, 'stderr': pipe, 'shell': kwargs.get('_tty_out', False)}
-        if '_cwd' in kwargs:
-            popen_kwargs['cwd'] = kwargs['_cwd']
-        if '_env' in kwargs:
-            popen_kwargs['env'] = kwargs['_env']
+        popen_kwargs = {"stdout": pipe, "stderr": pipe, "shell": kwargs.get("_tty_out", False)}
+        if "_cwd" in kwargs:
+            popen_kwargs["cwd"] = kwargs["_cwd"]
+        if "_env" in kwargs:
+            popen_kwargs["env"] = kwargs["_env"]
 
         try:
             with subprocess.Popen(args, **popen_kwargs) as p:
@@ -75,10 +77,10 @@ else:
         exit_code = p.returncode
         stdout = result[0].decode(DEFAULT_ENCODING)
         stderr = result[1]  # 'sh' does not decode the stderr bytes to unicode
-        full_cmd = '' if args is None else ' '.join(args)
+        full_cmd = "" if args is None else " ".join(args)
 
         # If not _ok_code is specified, then only a 0 exit code is allowed
-        ok_exit_codes = kwargs.get('_ok_code', [0])
+        ok_exit_codes = kwargs.get("_ok_code", [0])
 
         if exit_code in ok_exit_codes:
             return ShResult(full_cmd, stdout, stderr, exit_code)

--- a/qa/test_commits.py
+++ b/qa/test_commits.py
@@ -9,7 +9,7 @@ from qa.base import BaseTestCase
 
 
 class CommitsTests(BaseTestCase):
-    """Integration tests for the --commits argument, i.e. linting multiple commits at once or linting specific commits"""
+    """Integration tests for the --commits argument, i.e. linting multiple commits or linting specific commits"""
 
     def test_successful(self):
         """Test linting multiple commits without violations"""

--- a/qa/test_commits.py
+++ b/qa/test_commits.py
@@ -9,22 +9,22 @@ from qa.base import BaseTestCase
 
 
 class CommitsTests(BaseTestCase):
-    """ Integration tests for the --commits argument, i.e. linting multiple commits at once or linting specific commits
-    """
+    """Integration tests for the --commits argument, i.e. linting multiple commits at once or linting specific commits"""
 
     def test_successful(self):
-        """ Test linting multiple commits without violations """
+        """Test linting multiple commits without violations"""
         git("checkout", "-b", "test-branch-commits-base", _cwd=self.tmp_git_repo)
         self.create_simple_commit("Sïmple title\n\nSimple bödy describing the commit")
         git("checkout", "-b", "test-branch-commits", _cwd=self.tmp_git_repo)
         self.create_simple_commit("Sïmple title2\n\nSimple bödy describing the commit2")
         self.create_simple_commit("Sïmple title3\n\nSimple bödy describing the commit3")
-        output = gitlint("--commits", "test-branch-commits-base...test-branch-commits",
-                         _cwd=self.tmp_git_repo, _tty_in=True)
+        output = gitlint(
+            "--commits", "test-branch-commits-base...test-branch-commits", _cwd=self.tmp_git_repo, _tty_in=True
+        )
         self.assertEqualStdout(output, "")
 
     def test_violations(self):
-        """ Test linting multiple commits with violations """
+        """Test linting multiple commits with violations"""
         git("checkout", "-b", "test-branch-commits-violations-base", _cwd=self.tmp_git_repo)
         self.create_simple_commit("Sïmple title.\n")
         git("checkout", "-b", "test-branch-commits-violations", _cwd=self.tmp_git_repo)
@@ -33,15 +33,20 @@ class CommitsTests(BaseTestCase):
         commit_sha1 = self.get_last_commit_hash()[:10]
         self.create_simple_commit("Sïmple title3.\n")
         commit_sha2 = self.get_last_commit_hash()[:10]
-        output = gitlint("--commits", "test-branch-commits-violations-base...test-branch-commits-violations",
-                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[4])
+        output = gitlint(
+            "--commits",
+            "test-branch-commits-violations-base...test-branch-commits-violations",
+            _cwd=self.tmp_git_repo,
+            _tty_in=True,
+            _ok_code=[4],
+        )
 
         self.assertEqual(output.exit_code, 4)
-        expected_kwargs = {'commit_sha1': commit_sha1, 'commit_sha2': commit_sha2}
+        expected_kwargs = {"commit_sha1": commit_sha1, "commit_sha2": commit_sha2}
         self.assertEqualStdout(output, self.get_expected("test_commits/test_violations_1", expected_kwargs))
 
     def test_csv_hash_list(self):
-        """ Test linting multiple commits (comma-separated) with violations """
+        """Test linting multiple commits (comma-separated) with violations"""
         git("checkout", "-b", "test-branch-commits-violations-base", _cwd=self.tmp_git_repo)
         self.create_simple_commit("Sïmple title1.\n")
         commit_sha1 = self.get_last_commit_hash()[:10]
@@ -54,15 +59,20 @@ class CommitsTests(BaseTestCase):
         commit_sha4 = self.get_last_commit_hash()[:10]
 
         # Lint subset of the commits in a specific order, passed in via csv list
-        output = gitlint("--commits", f"{commit_sha2},{commit_sha1},{commit_sha4}",
-                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[6])
+        output = gitlint(
+            "--commits",
+            f"{commit_sha2},{commit_sha1},{commit_sha4}",
+            _cwd=self.tmp_git_repo,
+            _tty_in=True,
+            _ok_code=[6],
+        )
 
         self.assertEqual(output.exit_code, 6)
-        expected_kwargs = {'commit_sha1': commit_sha1, 'commit_sha2': commit_sha2, 'commit_sha4': commit_sha4}
+        expected_kwargs = {"commit_sha1": commit_sha1, "commit_sha2": commit_sha2, "commit_sha4": commit_sha4}
         self.assertEqualStdout(output, self.get_expected("test_commits/test_csv_hash_list_1", expected_kwargs))
 
     def test_lint_empty_commit_range(self):
-        """ Tests `gitlint --commits <sha>^...<sha>` --fail-without-commits where the provided range is empty. """
+        """Tests `gitlint --commits <sha>^...<sha>` --fail-without-commits where the provided range is empty."""
         self.create_simple_commit("Sïmple title.\n")
         self.create_simple_commit("Sïmple title2.\n")
         commit_sha = self.get_last_commit_hash()
@@ -75,13 +85,19 @@ class CommitsTests(BaseTestCase):
         self.assertEqualStdout(output, "")
 
         # Gitlint should fail when --fail-without-commits is used
-        output = gitlint("--commits", refspec, "--fail-without-commits", _cwd=self.tmp_git_repo, _tty_in=True,
-                         _ok_code=[self.GITLINT_USAGE_ERROR])
+        output = gitlint(
+            "--commits",
+            refspec,
+            "--fail-without-commits",
+            _cwd=self.tmp_git_repo,
+            _tty_in=True,
+            _ok_code=[self.GITLINT_USAGE_ERROR],
+        )
         self.assertEqual(output.exit_code, self.GITLINT_USAGE_ERROR)
-        self.assertEqualStdout(output, f"Error: No commits in range \"{refspec}\"\n")
+        self.assertEqualStdout(output, f'Error: No commits in range "{refspec}"\n')
 
     def test_lint_single_commit(self):
-        """ Tests `gitlint --commits <sha>^...<same sha>` """
+        """Tests `gitlint --commits <sha>^...<same sha>`"""
         self.create_simple_commit("Sïmple title.\n")
         first_commit_sha = self.get_last_commit_hash()
         self.create_simple_commit("Sïmple title2.\n")
@@ -89,8 +105,7 @@ class CommitsTests(BaseTestCase):
         refspec = f"{commit_sha}^...{commit_sha}"
         self.create_simple_commit("Sïmple title3.\n")
 
-        expected = ("1: T3 Title has trailing punctuation (.): \"Sïmple title2.\"\n" +
-                    "3: B6 Body message is missing\n")
+        expected = '1: T3 Title has trailing punctuation (.): "Sïmple title2."\n' + "3: B6 Body message is missing\n"
 
         # Lint using --commit <commit sha>
         output = gitlint("--commit", commit_sha, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[2])
@@ -104,8 +119,7 @@ class CommitsTests(BaseTestCase):
 
         # Lint the first commit in the repository. This is a use-case that is not supported by --commits
         # As <sha>^...<sha> is not correct refspec in case <sha> points to the initial commit (which has no parents)
-        expected = ("1: T3 Title has trailing punctuation (.): \"Sïmple title.\"\n" +
-                    "3: B6 Body message is missing\n")
+        expected = '1: T3 Title has trailing punctuation (.): "Sïmple title."\n' + "3: B6 Body message is missing\n"
         output = gitlint("--commit", first_commit_sha, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[2])
         self.assertEqual(output.exit_code, 2)
         self.assertEqualStdout(output, expected)
@@ -116,10 +130,10 @@ class CommitsTests(BaseTestCase):
         self.assertEqual(output.exit_code, 254)
 
     def test_lint_staged_stdin(self):
-        """ Tests linting a staged commit. Gitint should lint the passed commit message andfetch additional meta-data
-            from the underlying repository. The easiest way to test this is by inspecting `--debug` output.
-            This is the equivalent of doing:
-            echo "WIP: Pïpe test." | gitlint --staged --debug
+        """Tests linting a staged commit. Gitint should lint the passed commit message andfetch additional meta-data
+        from the underlying repository. The easiest way to test this is by inspecting `--debug` output.
+        This is the equivalent of doing:
+        echo "WIP: Pïpe test." | gitlint --staged --debug
         """
         # Create a commit first, before we stage changes. This ensures the repo is properly initialized.
         self.create_simple_commit("Sïmple title.\n")
@@ -130,30 +144,37 @@ class CommitsTests(BaseTestCase):
         filename2 = self.create_file(self.tmp_git_repo)
         git("add", filename2, _cwd=self.tmp_git_repo)
 
-        output = gitlint(echo("WIP: Pïpe test."), "--staged", "--debug",
-                         _cwd=self.tmp_git_repo, _tty_in=False, _err_to_out=True, _ok_code=[3])
+        output = gitlint(
+            echo("WIP: Pïpe test."),
+            "--staged",
+            "--debug",
+            _cwd=self.tmp_git_repo,
+            _tty_in=False,
+            _err_to_out=True,
+            _ok_code=[3],
+        )
 
         # Determine variable parts of expected output
         expected_kwargs = self.get_debug_vars_last_commit()
-        expected_kwargs.update({'changed_files': sorted([filename1, filename2])})
+        expected_kwargs.update({"changed_files": sorted([filename1, filename2])})
 
         # It's not really possible to determine the "Date: ..." line that is part of the debug output as this date
         # is not taken from git but instead generated by gitlint itself. As a workaround, we extract the date from the
         # gitlint output using a regex, parse the date to ensure the format is correct, and then pass that as an
         # expected variable.
-        matches = re.search(r'^Date:\s+(.*)', str(output), re.MULTILINE)
+        matches = re.search(r"^Date:\s+(.*)", str(output), re.MULTILINE)
         if matches:
             expected_date = arrow.get(str(matches.group(1)), "YYYY-MM-DD HH:mm:ss Z").format("YYYY-MM-DD HH:mm:ss Z")
-            expected_kwargs['staged_date'] = expected_date
+            expected_kwargs["staged_date"] = expected_date
 
         self.assertEqualStdout(output, self.get_expected("test_commits/test_lint_staged_stdin_1", expected_kwargs))
         self.assertEqual(output.exit_code, 3)
 
     def test_lint_staged_msg_filename(self):
-        """ Tests linting a staged commit. Gitint should lint the passed commit message andfetch additional meta-data
-            from the underlying repository. The easiest way to test this is by inspecting `--debug` output.
-            This is the equivalent of doing:
-            gitlint --msg-filename /tmp/my-commit-msg --staged --debug
+        """Tests linting a staged commit. Gitint should lint the passed commit message andfetch additional meta-data
+        from the underlying repository. The easiest way to test this is by inspecting `--debug` output.
+        This is the equivalent of doing:
+        gitlint --msg-filename /tmp/my-commit-msg --staged --debug
         """
         # Create a commit first, before we stage changes. This ensures the repo is properly initialized.
         self.create_simple_commit("Sïmple title.\n")
@@ -166,28 +187,36 @@ class CommitsTests(BaseTestCase):
 
         tmp_commit_msg_file = self.create_tmpfile("WIP: from fïle test.")
 
-        output = gitlint("--msg-filename", tmp_commit_msg_file, "--staged", "--debug",
-                         _cwd=self.tmp_git_repo, _tty_in=False, _err_to_out=True, _ok_code=[3])
+        output = gitlint(
+            "--msg-filename",
+            tmp_commit_msg_file,
+            "--staged",
+            "--debug",
+            _cwd=self.tmp_git_repo,
+            _tty_in=False,
+            _err_to_out=True,
+            _ok_code=[3],
+        )
 
         # Determine variable parts of expected output
         expected_kwargs = self.get_debug_vars_last_commit()
-        expected_kwargs.update({'changed_files': sorted([filename1, filename2])})
+        expected_kwargs.update({"changed_files": sorted([filename1, filename2])})
 
         # It's not really possible to determine the "Date: ..." line that is part of the debug output as this date
         # is not taken from git but instead generated by gitlint itself. As a workaround, we extract the date from the
         # gitlint output using a regex, parse the date to ensure the format is correct, and then pass that as an
         # expected variable.
-        matches = re.search(r'^Date:\s+(.*)', str(output), re.MULTILINE)
+        matches = re.search(r"^Date:\s+(.*)", str(output), re.MULTILINE)
         if matches:
             expected_date = arrow.get(str(matches.group(1)), "YYYY-MM-DD HH:mm:ss Z").format("YYYY-MM-DD HH:mm:ss Z")
-            expected_kwargs['staged_date'] = expected_date
+            expected_kwargs["staged_date"] = expected_date
 
         expected = self.get_expected("test_commits/test_lint_staged_msg_filename_1", expected_kwargs)
         self.assertEqualStdout(output, expected)
         self.assertEqual(output.exit_code, 3)
 
     def test_lint_head(self):
-        """ Testing whether we can also recognize special refs like 'HEAD' """
+        """Testing whether we can also recognize special refs like 'HEAD'"""
         tmp_git_repo = self.create_tmp_git_repo()
         self.create_simple_commit("Sïmple title.\n\nSimple bödy describing the commit", git_repo=tmp_git_repo)
         self.create_simple_commit("Sïmple title", git_repo=tmp_git_repo)
@@ -195,13 +224,16 @@ class CommitsTests(BaseTestCase):
         output = gitlint("--commits", "HEAD", _cwd=tmp_git_repo, _tty_in=True, _ok_code=[3])
         revlist = git("rev-list", "HEAD", _tty_in=True, _cwd=tmp_git_repo).split()
 
-        expected_kwargs = {"commit_sha0": revlist[0][:10], "commit_sha1": revlist[1][:10],
-                           "commit_sha2": revlist[2][:10]}
+        expected_kwargs = {
+            "commit_sha0": revlist[0][:10],
+            "commit_sha1": revlist[1][:10],
+            "commit_sha2": revlist[2][:10],
+        }
 
         self.assertEqualStdout(output, self.get_expected("test_commits/test_lint_head_1", expected_kwargs))
 
     def test_ignore_commits(self):
-        """ Tests multiple commits of which some rules get ignored because of ignore-* rules """
+        """Tests multiple commits of which some rules get ignored because of ignore-* rules"""
         # Create repo and some commits
         tmp_git_repo = self.create_tmp_git_repo()
         self.create_simple_commit("Sïmple title.\n\nSimple bödy describing the commit", git_repo=tmp_git_repo)
@@ -209,14 +241,17 @@ class CommitsTests(BaseTestCase):
         # But in this case only B5 because T3 and T5 are being ignored because of config
         self.create_simple_commit("Release: WIP tïtle.\n\nShort", git_repo=tmp_git_repo)
         # In the following 2 commits, the T3 violations are as normal
-        self.create_simple_commit(
-            "Sïmple WIP title3.\n\nThis is \ta relëase commit\nMore info", git_repo=tmp_git_repo)
+        self.create_simple_commit("Sïmple WIP title3.\n\nThis is \ta relëase commit\nMore info", git_repo=tmp_git_repo)
         self.create_simple_commit("Sïmple title4.\n\nSimple bödy describing the commit4", git_repo=tmp_git_repo)
         revlist = git("rev-list", "HEAD", _tty_in=True, _cwd=tmp_git_repo).split()
 
         config_path = self.get_sample_path("config/ignore-release-commits")
         output = gitlint("--commits", "HEAD", "--config", config_path, _cwd=tmp_git_repo, _tty_in=True, _ok_code=[4])
 
-        expected_kwargs = {"commit_sha0": revlist[0][:10], "commit_sha1": revlist[1][:10],
-                           "commit_sha2": revlist[2][:10], "commit_sha3": revlist[3][:10]}
+        expected_kwargs = {
+            "commit_sha0": revlist[0][:10],
+            "commit_sha1": revlist[1][:10],
+            "commit_sha2": revlist[2][:10],
+            "commit_sha3": revlist[3][:10],
+        }
         self.assertEqualStdout(output, self.get_expected("test_commits/test_ignore_commits_1", expected_kwargs))

--- a/qa/test_config.py
+++ b/qa/test_config.py
@@ -9,19 +9,24 @@ from qa.utils import DEFAULT_ENCODING
 
 
 class ConfigTests(BaseTestCase):
-    """ Integration tests for gitlint configuration and configuration precedence. """
+    """Integration tests for gitlint configuration and configuration precedence."""
 
     def test_ignore_by_id(self):
         self.create_simple_commit("WIP: Thïs is a title.\nContënt on the second line")
         output = gitlint("--ignore", "T5,B4", _tty_in=True, _cwd=self.tmp_git_repo, _ok_code=[1])
-        expected = "1: T3 Title has trailing punctuation (.): \"WIP: Thïs is a title.\"\n"
+        expected = '1: T3 Title has trailing punctuation (.): "WIP: Thïs is a title."\n'
         self.assertEqualStdout(output, expected)
 
     def test_ignore_by_name(self):
         self.create_simple_commit("WIP: Thïs is a title.\nContënt on the second line")
-        output = gitlint("--ignore", "title-must-not-contain-word,body-first-line-empty",
-                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[1])
-        expected = "1: T3 Title has trailing punctuation (.): \"WIP: Thïs is a title.\"\n"
+        output = gitlint(
+            "--ignore",
+            "title-must-not-contain-word,body-first-line-empty",
+            _cwd=self.tmp_git_repo,
+            _tty_in=True,
+            _ok_code=[1],
+        )
+        expected = '1: T3 Title has trailing punctuation (.): "WIP: Thïs is a title."\n'
         self.assertEqualStdout(output, expected)
 
     def test_verbosity(self):
@@ -47,8 +52,10 @@ class ConfigTests(BaseTestCase):
         self.assertEqualStdout(output, self.get_expected("test_config/test_set_rule_option_1"))
 
     def test_config_from_file(self):
-        commit_msg = "WIP: Thïs is a title thåt is a bit longer.\nContent on the second line\n" + \
-                     "This line of the body is here because we need it"
+        commit_msg = (
+            "WIP: Thïs is a title thåt is a bit longer.\nContent on the second line\n"
+            "This line of the body is here because we need it"
+        )
         self.create_simple_commit(commit_msg)
         config_path = self.get_sample_path("config/gitlintconfig")
         output = gitlint("--config", config_path, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[5])
@@ -58,44 +65,58 @@ class ConfigTests(BaseTestCase):
         # Test both on existing and new repo (we've had a bug in the past that was unique to empty repos)
         repos = [self.tmp_git_repo, self.create_tmp_git_repo()]
         for target_repo in repos:
-            commit_msg = "WIP: Thïs is a title thåt is a bit longer.\nContent on the second line\n" + \
-                        "This line of the body is here because we need it"
+            commit_msg = (
+                "WIP: Thïs is a title thåt is a bit longer.\nContent on the second line\n"
+                "This line of the body is here because we need it"
+            )
             filename = self.create_simple_commit(commit_msg, git_repo=target_repo)
             config_path = self.get_sample_path("config/gitlintconfig")
             output = gitlint("--config", config_path, "--debug", _cwd=target_repo, _tty_in=True, _ok_code=[5])
 
             expected_kwargs = self.get_debug_vars_last_commit(git_repo=target_repo)
-            expected_kwargs.update({'config_path': config_path, 'changed_files': [filename]})
-            self.assertEqualStdout(output, self.get_expected("test_config/test_config_from_file_debug_1",
-                                                             expected_kwargs))
+            expected_kwargs.update({"config_path": config_path, "changed_files": [filename]})
+            self.assertEqualStdout(
+                output, self.get_expected("test_config/test_config_from_file_debug_1", expected_kwargs)
+            )
 
     def test_config_from_env(self):
-        """ Test for configuring gitlint from environment variables """
+        """Test for configuring gitlint from environment variables"""
 
         # We invoke gitlint, configuring it via env variables, we can check whether gitlint picks these up correctly
         # by comparing the debug output with what we'd expect
         target_repo = self.create_tmp_git_repo()
-        commit_msg = "WIP: Thïs is a title thåt is a bit longer.\nContent on the second line\n" + \
-                     "This line of the body is here because we need it"
+        commit_msg = (
+            "WIP: Thïs is a title thåt is a bit longer.\nContent on the second line\n"
+            "This line of the body is here because we need it"
+        )
         filename = self.create_simple_commit(commit_msg, git_repo=target_repo)
-        env = self.create_environment({"GITLINT_DEBUG": "1", "GITLINT_VERBOSITY": "2",
-                                       "GITLINT_IGNORE": "T1,T2", "GITLINT_CONTRIB": "CC1,CT1",
-                                       "GITLINT_FAIL_WITHOUT_COMMITS": "1", "GITLINT_IGNORE_STDIN": "1",
-                                       "GITLINT_TARGET": target_repo,
-                                       "GITLINT_COMMITS": self.get_last_commit_hash(git_repo=target_repo)})
+        env = self.create_environment(
+            {
+                "GITLINT_DEBUG": "1",
+                "GITLINT_VERBOSITY": "2",
+                "GITLINT_IGNORE": "T1,T2",
+                "GITLINT_CONTRIB": "CC1,CT1",
+                "GITLINT_FAIL_WITHOUT_COMMITS": "1",
+                "GITLINT_IGNORE_STDIN": "1",
+                "GITLINT_TARGET": target_repo,
+                "GITLINT_COMMITS": self.get_last_commit_hash(git_repo=target_repo),
+            }
+        )
         output = gitlint(_env=env, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[5])
         expected_kwargs = self.get_debug_vars_last_commit(git_repo=target_repo)
-        expected_kwargs.update({'changed_files': [filename]})
+        expected_kwargs.update({"changed_files": [filename]})
 
         self.assertEqualStdout(output, self.get_expected("test_config/test_config_from_env_1", expected_kwargs))
 
         # For some env variables, we need a separate test ast they are mutually exclusive with the ones tested above
         tmp_commit_msg_file = self.create_tmpfile("WIP: msg-fïlename test.")
-        env = self.create_environment({"GITLINT_DEBUG": "1", "GITLINT_TARGET": target_repo,
-                                       "GITLINT_SILENT": "1", "GITLINT_STAGED": "1"})
+        env = self.create_environment(
+            {"GITLINT_DEBUG": "1", "GITLINT_TARGET": target_repo, "GITLINT_SILENT": "1", "GITLINT_STAGED": "1"}
+        )
 
-        output = gitlint("--msg-filename", tmp_commit_msg_file,
-                         _env=env, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3])
+        output = gitlint(
+            "--msg-filename", tmp_commit_msg_file, _env=env, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3]
+        )
 
         # Extract date from actual output to insert it into the expected output
         # We have to do this since there's no way for us to deterministically know that date otherwise

--- a/qa/test_contrib.py
+++ b/qa/test_contrib.py
@@ -5,19 +5,26 @@ from qa.base import BaseTestCase
 
 
 class ContribRuleTests(BaseTestCase):
-    """ Integration tests for contrib rules."""
+    """Integration tests for contrib rules."""
 
     def test_contrib_rules(self):
         self.create_simple_commit("WIP Thi$ is å title\n\nMy bödy that is a bit longer than 20 chars")
-        output = gitlint("--contrib", "contrib-title-conventional-commits,CC1",
-                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3])
+        output = gitlint(
+            "--contrib", "contrib-title-conventional-commits,CC1", _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3]
+        )
         self.assertEqualStdout(output, self.get_expected("test_contrib/test_contrib_rules_1"))
 
     def test_contrib_rules_with_config(self):
         self.create_simple_commit("WIP Thi$ is å title\n\nMy bödy that is a bit longer than 20 chars")
-        output = gitlint("--contrib", "contrib-title-conventional-commits,CC1",
-                         "-c", "contrib-title-conventional-commits.types=föo,bår",
-                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[3])
+        output = gitlint(
+            "--contrib",
+            "contrib-title-conventional-commits,CC1",
+            "-c",
+            "contrib-title-conventional-commits.types=föo,bår",
+            _cwd=self.tmp_git_repo,
+            _tty_in=True,
+            _ok_code=[3],
+        )
         self.assertEqualStdout(output, self.get_expected("test_contrib/test_contrib_rules_with_config_1"))
 
     def test_invalid_contrib_rules(self):

--- a/qa/test_hooks.py
+++ b/qa/test_hooks.py
@@ -6,15 +6,17 @@ from qa.base import BaseTestCase
 
 
 class HookTests(BaseTestCase):
-    """ Integration tests for gitlint commitmsg hooks"""
+    """Integration tests for gitlint commitmsg hooks"""
 
-    VIOLATIONS = ['gitlint: checking commit message...\n',
-                  '1: T3 Title has trailing punctuation (.): "WIP: This ïs a title."\n',
-                  '1: T5 Title contains the word \'WIP\' (case-insensitive): "WIP: This ïs a title."\n',
-                  '2: B4 Second line is not empty: "Contënt on the second line"\n',
-                  '3: B6 Body message is missing\n',
-                  '-----------------------------------------------\n',
-                  'gitlint: \x1b[31mYour commit message contains violations.\x1b[0m\n']
+    VIOLATIONS = [
+        "gitlint: checking commit message...\n",
+        '1: T3 Title has trailing punctuation (.): "WIP: This ïs a title."\n',
+        "1: T5 Title contains the word 'WIP' (case-insensitive): \"WIP: This ïs a title.\"\n",
+        '2: B4 Second line is not empty: "Contënt on the second line"\n',
+        "3: B6 Body message is missing\n",
+        "-----------------------------------------------\n",
+        "gitlint: \x1b[31mYour commit message contains violations.\x1b[0m\n",
+    ]
 
     def setUp(self):
         super().setUp()
@@ -29,16 +31,18 @@ class HookTests(BaseTestCase):
 
         # install git commit-msg hook and assert output
         output_installed = gitlint("install-hook", _cwd=self.tmp_git_repo)
-        expected_installed = ("Successfully installed gitlint commit-msg hook in "
-                              f"{self.tmp_git_repo}/.git/hooks/commit-msg\n")
+        expected_installed = (
+            "Successfully installed gitlint commit-msg hook in " f"{self.tmp_git_repo}/.git/hooks/commit-msg\n"
+        )
 
         self.assertEqualStdout(output_installed, expected_installed)
 
     def tearDown(self):
         # uninstall git commit-msg hook and assert output
         output_uninstalled = gitlint("uninstall-hook", _cwd=self.tmp_git_repo)
-        expected_uninstalled = ("Successfully uninstalled gitlint commit-msg hook from "
-                                f"{self.tmp_git_repo}/.git/hooks/commit-msg\n")
+        expected_uninstalled = (
+            "Successfully uninstalled gitlint commit-msg hook from " f"{self.tmp_git_repo}/.git/hooks/commit-msg\n"
+        )
 
         self.assertEqualStdout(output_uninstalled, expected_uninstalled)
         super().tearDown()
@@ -58,62 +62,72 @@ class HookTests(BaseTestCase):
             self.response_index = (self.response_index + 1) % len(self.responses)
 
     def test_commit_hook_no_violations(self):
-        test_filename = self.create_simple_commit("This ïs a title\n\nBody contënt that should work",
-                                                  out=self._interact, tty_in=True)
+        test_filename = self.create_simple_commit(
+            "This ïs a title\n\nBody contënt that should work", out=self._interact, tty_in=True
+        )
 
         short_hash = self.get_last_commit_short_hash()
-        expected_output = ["gitlint: checking commit message...\n",
-                           "gitlint: \x1b[32mOK\x1b[0m (no violations in commit message)\n",
-                           f"[master {short_hash}] This ïs a title\n",
-                           " 1 file changed, 0 insertions(+), 0 deletions(-)\n",
-                           f" create mode 100644 {test_filename}\n"]
+        expected_output = [
+            "gitlint: checking commit message...\n",
+            "gitlint: \x1b[32mOK\x1b[0m (no violations in commit message)\n",
+            f"[master {short_hash}] This ïs a title\n",
+            " 1 file changed, 0 insertions(+), 0 deletions(-)\n",
+            f" create mode 100644 {test_filename}\n",
+        ]
         for output, expected in zip(self.githook_output, expected_output):
-            self.assertMultiLineEqual(output.replace('\r', ''), expected.replace('\r', ''))
+            self.assertMultiLineEqual(output.replace("\r", ""), expected.replace("\r", ""))
 
     def test_commit_hook_continue(self):
         self.responses = ["y"]
-        test_filename = self.create_simple_commit("WIP: This ïs a title.\nContënt on the second line",
-                                                  out=self._interact, tty_in=True)
+        test_filename = self.create_simple_commit(
+            "WIP: This ïs a title.\nContënt on the second line", out=self._interact, tty_in=True
+        )
 
         # Determine short commit-msg hash, needed to determine expected output
         short_hash = self.get_last_commit_short_hash()
 
         expected_output = self._violations()
-        expected_output += ["Continue with commit anyways (this keeps the current commit message)? " +
-                            "[y(es)/n(no)/e(dit)] " +
-                            f"[master {short_hash}] WIP: This ïs a title. Contënt on the second line\n",
-                            " 1 file changed, 0 insertions(+), 0 deletions(-)\n",
-                            f" create mode 100644 {test_filename}\n"]
+        expected_output += [
+            "Continue with commit anyways (this keeps the current commit message)? "
+            "[y(es)/n(no)/e(dit)] "
+            f"[master {short_hash}] WIP: This ïs a title. Contënt on the second line\n",
+            " 1 file changed, 0 insertions(+), 0 deletions(-)\n",
+            f" create mode 100644 {test_filename}\n",
+        ]
 
         for output, expected in zip(self.githook_output, expected_output):
-            self.assertMultiLineEqual(output.replace('\r', ''), expected.replace('\r', ''))
+            self.assertMultiLineEqual(output.replace("\r", ""), expected.replace("\r", ""))
 
     def test_commit_hook_abort(self):
         self.responses = ["n"]
-        test_filename = self.create_simple_commit("WIP: This ïs a title.\nContënt on the second line",
-                                                  out=self._interact, ok_code=1, tty_in=True)
+        test_filename = self.create_simple_commit(
+            "WIP: This ïs a title.\nContënt on the second line", out=self._interact, ok_code=1, tty_in=True
+        )
         git("rm", "-f", test_filename, _cwd=self.tmp_git_repo)
 
         # Determine short commit-msg hash, needed to determine expected output
 
         expected_output = self._violations()
-        expected_output += ["Continue with commit anyways (this keeps the current commit message)? " +
-                            "[y(es)/n(no)/e(dit)] " +
-                            "Commit aborted.\n",
-                            "Your commit message: \n",
-                            "-----------------------------------------------\n",
-                            "WIP: This ïs a title.\n",
-                            "Contënt on the second line\n",
-                            "-----------------------------------------------\n"]
+        expected_output += [
+            "Continue with commit anyways (this keeps the current commit message)? "
+            "[y(es)/n(no)/e(dit)] "
+            "Commit aborted.\n",
+            "Your commit message: \n",
+            "-----------------------------------------------\n",
+            "WIP: This ïs a title.\n",
+            "Contënt on the second line\n",
+            "-----------------------------------------------\n",
+        ]
 
         for output, expected in zip(self.githook_output, expected_output):
-            self.assertMultiLineEqual(output.replace('\r', ''), expected.replace('\r', ''))
+            self.assertMultiLineEqual(output.replace("\r", ""), expected.replace("\r", ""))
 
     def test_commit_hook_edit(self):
         self.responses = ["e", "y"]
         env = {"EDITOR": ":"}
-        test_filename = self.create_simple_commit("WIP: This ïs a title.\nContënt on the second line",
-                                                  out=self._interact, env=env, tty_in=True)
+        test_filename = self.create_simple_commit(
+            "WIP: This ïs a title.\nContënt on the second line", out=self._interact, env=env, tty_in=True
+        )
         git("rm", "-f", test_filename, _cwd=self.tmp_git_repo)
 
         short_hash = git("rev-parse", "--short", "HEAD", _cwd=self.tmp_git_repo, _tty_in=True).replace("\n", "")
@@ -121,20 +135,23 @@ class HookTests(BaseTestCase):
         # Determine short commit-msg hash, needed to determine expected output
 
         expected_output = self._violations()
-        expected_output += ['Continue with commit anyways (this keeps the current commit message)? ' +
-                            '[y(es)/n(no)/e(dit)] ' + self._violations()[0]]
+        expected_output += [
+            "Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] "
+            + self._violations()[0]
+        ]
         expected_output += self._violations()[1:]
-        expected_output += ['Continue with commit anyways (this keeps the current commit message)? ' +
-                            "[y(es)/n(no)/e(dit)] " +
-                            f"[master {short_hash}] WIP: This ïs a title. Contënt on the second line\n",
-                            " 1 file changed, 0 insertions(+), 0 deletions(-)\n",
-                            f" create mode 100644 {test_filename}\n"]
+        expected_output += [
+            "Continue with commit anyways (this keeps the current commit message)? [y(es)/n(no)/e(dit)] "
+            f"[master {short_hash}] WIP: This ïs a title. Contënt on the second line\n",
+            " 1 file changed, 0 insertions(+), 0 deletions(-)\n",
+            f" create mode 100644 {test_filename}\n",
+        ]
 
         for output, expected in zip(self.githook_output, expected_output):
-            self.assertMultiLineEqual(output.replace('\r', ''), expected.replace('\r', ''))
+            self.assertMultiLineEqual(output.replace("\r", ""), expected.replace("\r", ""))
 
     def test_commit_hook_worktree(self):
-        """ Tests that hook installation and un-installation also work in git worktrees.
+        """Tests that hook installation and un-installation also work in git worktrees.
         Test steps:
             ```sh
             git init <tmpdir>

--- a/qa/test_hooks.py
+++ b/qa/test_hooks.py
@@ -32,7 +32,7 @@ class HookTests(BaseTestCase):
         # install git commit-msg hook and assert output
         output_installed = gitlint("install-hook", _cwd=self.tmp_git_repo)
         expected_installed = (
-            "Successfully installed gitlint commit-msg hook in " f"{self.tmp_git_repo}/.git/hooks/commit-msg\n"
+            f"Successfully installed gitlint commit-msg hook in {self.tmp_git_repo}/.git/hooks/commit-msg\n"
         )
 
         self.assertEqualStdout(output_installed, expected_installed)
@@ -41,7 +41,7 @@ class HookTests(BaseTestCase):
         # uninstall git commit-msg hook and assert output
         output_uninstalled = gitlint("uninstall-hook", _cwd=self.tmp_git_repo)
         expected_uninstalled = (
-            "Successfully uninstalled gitlint commit-msg hook from " f"{self.tmp_git_repo}/.git/hooks/commit-msg\n"
+            f"Successfully uninstalled gitlint commit-msg hook from {self.tmp_git_repo}/.git/hooks/commit-msg\n"
         )
 
         self.assertEqualStdout(output_uninstalled, expected_uninstalled)

--- a/qa/test_named_rules.py
+++ b/qa/test_named_rules.py
@@ -4,7 +4,7 @@ from qa.base import BaseTestCase
 
 
 class NamedRuleTests(BaseTestCase):
-    """ Integration tests for named rules."""
+    """Integration tests for named rules."""
 
     def test_named_rule(self):
         commit_msg = "WIP: thåt dûr bår\n\nSïmple commit body"
@@ -18,6 +18,7 @@ class NamedRuleTests(BaseTestCase):
         self.create_simple_commit(commit_msg)
         config_path = self.get_sample_path("config/named-user-rules")
         extra_path = self.get_sample_path("user_rules/extra")
-        output = gitlint("--extra-path", extra_path, "--config", config_path, _cwd=self.tmp_git_repo, _tty_in=True,
-                         _ok_code=[9])
+        output = gitlint(
+            "--extra-path", extra_path, "--config", config_path, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[9]
+        )
         self.assertEqualStdout(output, self.get_expected("test_named_rules/test_named_user_rule_1"))

--- a/qa/test_stdin.py
+++ b/qa/test_stdin.py
@@ -45,7 +45,6 @@ class StdInTests(BaseTestCase):
         tmp_commit_msg_file = self.create_tmpfile("WIP: STDIN ïs a file test.")
 
         with io.open(tmp_commit_msg_file, encoding=DEFAULT_ENCODING) as file_handle:
-
             # We need to use subprocess.Popen() here instead of sh because when passing a file_handle to sh, it will
             # deal with reading the file itself instead of passing it on to gitlint as a STDIN. Since we're trying to
             # test for the condition where stat.S_ISREG == True that won't work for us here.

--- a/qa/test_stdin.py
+++ b/qa/test_stdin.py
@@ -8,25 +8,24 @@ from qa.utils import DEFAULT_ENCODING
 
 
 class StdInTests(BaseTestCase):
-    """ Integration tests for various STDIN scenarios for gitlint """
+    """Integration tests for various STDIN scenarios for gitlint"""
 
     def test_stdin_pipe(self):
-        """ Test piping input into gitlint.
-            This is the equivalent of doing:
-            $ echo "foo" | gitlint
+        """Test piping input into gitlint.
+        This is the equivalent of doing:
+        $ echo "foo" | gitlint
         """
         # NOTE: There is no use in testing this with _tty_in=True, because if you pipe something into a command
         # there never is a TTY connected to stdin (per definition). We're setting _tty_in=False here to be explicit
         # but note that this is always true when piping something into a command.
-        output = gitlint(echo("WIP: Pïpe test."),
-                         _cwd=self.tmp_git_repo, _tty_in=False, _err_to_out=True, _ok_code=[3])
+        output = gitlint(echo("WIP: Pïpe test."), _cwd=self.tmp_git_repo, _tty_in=False, _err_to_out=True, _ok_code=[3])
         self.assertEqualStdout(output, self.get_expected("test_stdin/test_stdin_pipe_1"))
 
     def test_stdin_pipe_empty(self):
-        """ Test the scenario where no TTY is attached and nothing is piped into gitlint. This occurs in
-            CI runners like Jenkins and Gitlab, see https://github.com/jorisroovers/gitlint/issues/42 for details.
-            This is the equivalent of doing:
-            $ echo -n "" | gitlint
+        """Test the scenario where no TTY is attached and nothing is piped into gitlint. This occurs in
+        CI runners like Jenkins and Gitlab, see https://github.com/jorisroovers/gitlint/issues/42 for details.
+        This is the equivalent of doing:
+        $ echo -n "" | gitlint
         """
         commit_msg = "WIP: This ïs a title.\nContent on the sëcond line"
         self.create_simple_commit(commit_msg)
@@ -39,9 +38,9 @@ class StdInTests(BaseTestCase):
         self.assertEqual(output, self.get_expected("test_stdin/test_stdin_pipe_empty_1"))
 
     def test_stdin_file(self):
-        """ Test the scenario where STDIN is a regular file (stat.S_ISREG = True)
-            This is the equivalent of doing:
-            $ gitlint < myfile
+        """Test the scenario where STDIN is a regular file (stat.S_ISREG = True)
+        This is the equivalent of doing:
+        $ gitlint < myfile
         """
         tmp_commit_msg_file = self.create_tmpfile("WIP: STDIN ïs a file test.")
 
@@ -50,7 +49,8 @@ class StdInTests(BaseTestCase):
             # We need to use subprocess.Popen() here instead of sh because when passing a file_handle to sh, it will
             # deal with reading the file itself instead of passing it on to gitlint as a STDIN. Since we're trying to
             # test for the condition where stat.S_ISREG == True that won't work for us here.
-            with subprocess.Popen("gitlint", stdin=file_handle, cwd=self.tmp_git_repo,
-                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as p:
+            with subprocess.Popen(
+                "gitlint", stdin=file_handle, cwd=self.tmp_git_repo, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            ) as p:
                 output, _ = p.communicate()
                 self.assertEqual(output.decode(DEFAULT_ENCODING), self.get_expected("test_stdin/test_stdin_file_1"))

--- a/qa/test_user_defined.py
+++ b/qa/test_user_defined.py
@@ -5,10 +5,10 @@ from qa.base import BaseTestCase
 
 
 class UserDefinedRuleTests(BaseTestCase):
-    """ Integration tests for user-defined rules."""
+    """Integration tests for user-defined rules."""
 
     def test_user_defined_rules_examples1(self):
-        """ Test the user defined rules in the top-level `examples/` directory """
+        """Test the user defined rules in the top-level `examples/` directory"""
         extra_path = self.get_example_path()
         commit_msg = "WIP: Thi$ is å title\nContent on the second line"
         self.create_simple_commit(commit_msg)
@@ -16,7 +16,7 @@ class UserDefinedRuleTests(BaseTestCase):
         self.assertEqualStdout(output, self.get_expected("test_user_defined/test_user_defined_rules_examples_1"))
 
     def test_user_defined_rules_examples2(self):
-        """ Test the user defined rules in the top-level `examples/` directory """
+        """Test the user defined rules in the top-level `examples/` directory"""
         extra_path = self.get_example_path()
         commit_msg = "Release: Thi$ is å title\nContent on the second line\n$This line is ignored \nThis isn't\t\n"
         self.create_simple_commit(commit_msg)
@@ -24,12 +24,19 @@ class UserDefinedRuleTests(BaseTestCase):
         self.assertEqualStdout(output, self.get_expected("test_user_defined/test_user_defined_rules_examples_2"))
 
     def test_user_defined_rules_examples_with_config(self):
-        """ Test the user defined rules in the top-level `examples/` directory """
+        """Test the user defined rules in the top-level `examples/` directory"""
         extra_path = self.get_example_path()
         commit_msg = "WIP: Thi$ is å title\nContent on the second line"
         self.create_simple_commit(commit_msg)
-        output = gitlint("--extra-path", extra_path, "-c", "body-max-line-count.max-line-count=1",
-                         _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[6])
+        output = gitlint(
+            "--extra-path",
+            extra_path,
+            "-c",
+            "body-max-line-count.max-line-count=1",
+            _cwd=self.tmp_git_repo,
+            _tty_in=True,
+            _ok_code=[6],
+        )
         expected_path = "test_user_defined/test_user_defined_rules_examples_with_config_1"
         self.assertEqualStdout(output, self.get_expected(expected_path))
 
@@ -38,12 +45,15 @@ class UserDefinedRuleTests(BaseTestCase):
         commit_msg = "WIP: Thi$ is å title\nContent on the second line"
         self.create_simple_commit(commit_msg)
         output = gitlint("--extra-path", extra_path, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[9])
-        self.assertEqualStdout(output, self.get_expected("test_user_defined/test_user_defined_rules_extra_1",
-                                                         {'repo-path': self.tmp_git_repo}))
+        self.assertEqualStdout(
+            output,
+            self.get_expected("test_user_defined/test_user_defined_rules_extra_1", {"repo-path": self.tmp_git_repo}),
+        )
 
     def test_invalid_user_defined_rules(self):
         extra_path = self.get_sample_path("user_rules/incorrect_linerule")
         self.create_simple_commit("WIP: test")
         output = gitlint("--extra-path", extra_path, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[255])
-        self.assertEqualStdout(output,
-                               "Config Error: User-defined rule class 'MyUserLineRule' must have a 'validate' method\n")
+        self.assertEqualStdout(
+            output, "Config Error: User-defined rule class 'MyUserLineRule' must have a 'validate' method\n"
+        )

--- a/qa/utils.py
+++ b/qa/utils.py
@@ -22,7 +22,7 @@ PLATFORM_IS_WINDOWS = platform_is_windows()
 
 
 def use_sh_library():
-    gitlint_use_sh_lib_env = os.environ.get('GITLINT_QA_USE_SH_LIB', None)
+    gitlint_use_sh_lib_env = os.environ.get("GITLINT_QA_USE_SH_LIB", None)
     if gitlint_use_sh_lib_env:
         return gitlint_use_sh_lib_env == "1"
     return not PLATFORM_IS_WINDOWS
@@ -35,8 +35,8 @@ USE_SH_LIB = use_sh_library()
 
 
 def getpreferredencoding():
-    """ Modified version of local.getpreferredencoding() that takes into account LC_ALL, LC_CTYPE, LANG env vars
-        on windows and falls back to UTF-8. """
+    """Modified version of local.getpreferredencoding() that takes into account LC_ALL, LC_CTYPE, LANG env vars
+    on windows and falls back to UTF-8."""
     default_encoding = locale.getpreferredencoding() or "UTF-8"
 
     # On Windows, we mimic git/linux by trying to read the LC_ALL, LC_CTYPE, LANG env vars manually
@@ -51,7 +51,7 @@ def getpreferredencoding():
                 # If encoding contains a dot: split and use second part, otherwise use everything
                 dot_index = encoding.find(".")
                 if dot_index != -1:
-                    default_encoding = encoding[dot_index + 1:]
+                    default_encoding = encoding[dot_index + 1 :]
                 else:
                     default_encoding = encoding
                 break

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -75,10 +75,10 @@ handle_test_result(){
 }
 
 run_pep8_check(){
-    # FLAKE 8
-    target=${testargs:-"gitlint-core qa examples"}
-    echo -ne "Running flake8..."
-    RESULT=$(flake8 $target)
+    # BLACK
+    target=${testargs:-"."}
+    echo -ne "Running black --check..."
+    RESULT=$(black --check $target)
     local exit_code=$?
     handle_test_result $exit_code "$RESULT"
     return $exit_code

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,15 +6,15 @@ help(){
     echo "Run gitlint's test suite(s) or some convience commands"
     echo "  -h, --help               Show this help output"
     echo "  -c, --clean              Clean the project of temporary files"
-    echo "  -p, --pep8               Run pep8 checks"
+    echo "  -f, --format             Run format checks"
     echo "  -l, --lint               Run pylint checks"
     echo "  -g, --git                Run gitlint checks"
     echo "  -i, --integration        Run integration tests"
     echo "  -b, --build              Run build tests"
-    echo "  -a, --all                Run all tests and checks (unit, integration, pep8, git)"
+    echo "  -a, --all                Run all tests and checks (unit, integration, formatting, git)"
     echo "  -e, --envs [ENV1],[ENV2] Run tests against specified python environments"
     echo "                           (envs: 36,37,38,39,pypy37)."
-    echo "                           Also works for integration, pep8 and lint tests."
+    echo "                           Also works for integration, formatting and lint tests."
     echo "  -C, --container          Run the specified command in the container for the --envs specified"
     echo "  --all-env                Run all tests against all python environments"
     echo "  --install                Install virtualenvs for the --envs specified"
@@ -74,11 +74,11 @@ handle_test_result(){
     echo -e "${NO_COLOR}"
 }
 
-run_pep8_check(){
+run_formatting_check(){
     # BLACK
     target=${testargs:-"."}
     echo -ne "Running black --check..."
-    RESULT=$(black --check $target)
+    RESULT=$(black --check --diff $target)
     local exit_code=$?
     handle_test_result $exit_code "$RESULT"
     return $exit_code
@@ -230,7 +230,7 @@ run_all(){
     run_build_test
     exit_code=$((exit_code + $?))
     subtitle "# STYLE CHECKS ($(python --version 2>&1), $(which python)) #"
-    run_pep8_check
+    run_formatting_check
     exit_code=$((exit_code + $?))
     run_lint_check
     exit_code=$((exit_code + $?))
@@ -401,7 +401,7 @@ run_in_container(){
 
 
 # default behavior
-just_pep8=0
+just_formatting=0
 just_lint=0
 just_git=0
 just_integration_tests=0
@@ -424,7 +424,7 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         -h|--help) shift; help;;
         -c|--clean) shift; just_clean=1;;
-        -p|--pep8) shift; just_pep8=1;;
+        -f|--format) shift; just_formatting=1;;
         -l|--lint) shift; just_lint=1;;
         -g|--git) shift; just_git=1;;
         -b|--build) shift; just_build_tests=1;;
@@ -465,9 +465,9 @@ for environment in $envs; do
 
     if [ $container_enabled -eq 1 ]; then
         run_in_container "$environment" "$original_envs" "$original_args"
-    elif [ $just_pep8 -eq 1 ]; then
+    elif [ $just_formatting -eq 1 ]; then
         switch_env "$environment"
-        run_pep8_check
+        run_formatting_check
     elif [ $just_stats -eq 1 ]; then
         switch_env "$environment"
         run_stats

--- a/setup.py
+++ b/setup.py
@@ -45,19 +45,19 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Quality Assurance",
         "Topic :: Software Development :: Testing",
-        "License :: OSI Approved :: MIT License"
+        "License :: OSI Approved :: MIT License",
     ],
     python_requires=">=3.6",
     install_requires=[
-        'gitlint-core[trusted-deps]==' + version,
+        "gitlint-core[trusted-deps]==" + version,
     ],
-    keywords='gitlint git lint',
-    author='Joris Roovers',
-    url='https://jorisroovers.github.io/gitlint',
+    keywords="gitlint git lint",
+    author="Joris Roovers",
+    url="https://jorisroovers.github.io/gitlint",
     project_urls={
-        'Documentation': 'https://jorisroovers.github.io/gitlint',
-        'Source': 'https://github.com/jorisroovers/gitlint',
-        'Changelog': 'https://github.com/jorisroovers/gitlint/blob/main/CHANGELOG.md',
+        "Documentation": "https://jorisroovers.github.io/gitlint",
+        "Source": "https://github.com/jorisroovers/gitlint",
+        "Changelog": "https://github.com/jorisroovers/gitlint/blob/main/CHANGELOG.md",
     },
-    license='MIT',
+    license="MIT",
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,7 @@
-flake8==5.0.4
+black==22.6.0
 coverage==6.2
 python-coveralls==2.9.3
 radon==5.1.0
-flake8-polyfill==1.0.2 # Required when installing both flake8 and radon>=4.3.1 
 pytest==7.0.1;
 pylint==2.13.7;
 -r requirements.txt


### PR DESCRIPTION
We're moving to black for formatting. Considered this before but didn't like some of black's aggressive splitting of lines. I've now added `fmt:off`/`fmt:on` to disable black for a few egregious cases.

This should save some time fixing PEP8 errors :-)