### PR TITLE
Pyupgrade: upgrade code to python3.6+

### DIFF
--- a/examples/my_commit_rules.py
+++ b/examples/my_commit_rules.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from gitlint.rules import CommitRule, RuleViolation
 from gitlint.options import IntOption, ListOption
 

--- a/examples/my_configuration_rules.py
+++ b/examples/my_configuration_rules.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from gitlint.rules import ConfigurationRule
 from gitlint.options import IntOption
 

--- a/examples/my_line_rules.py
+++ b/examples/my_line_rules.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from gitlint.rules import LineRule, RuleViolation, CommitMessageTitle
 from gitlint.options import ListOption
 

--- a/gitlint-core/gitlint/config.py
+++ b/gitlint-core/gitlint/config.py
@@ -1,7 +1,6 @@
 from configparser import ConfigParser, Error as ConfigParserError
 
 import copy
-import io
 import re
 import os
 import shutil
@@ -376,8 +375,7 @@ class RuleCollection:
                 del self._rules[rule.id]
 
     def __iter__(self):
-        for rule in self._rules.values():
-            yield rule
+        yield from self._rules.values()
 
     def __eq__(self, other):
         return isinstance(other, RuleCollection) and self._rules == other._rules
@@ -454,7 +452,7 @@ class LintConfigBuilder:
         try:
             parser = ConfigParser()
 
-            with io.open(filename, encoding=DEFAULT_ENCODING) as config_file:
+            with open(filename, encoding=DEFAULT_ENCODING) as config_file:
                 parser.read_file(config_file, filename)
 
             for section_name in parser.sections():

--- a/gitlint-core/gitlint/hooks.py
+++ b/gitlint-core/gitlint/hooks.py
@@ -1,4 +1,3 @@
-import io
 import shutil
 import os
 import stat
@@ -53,7 +52,7 @@ class GitHookInstaller:
         if not os.path.exists(dest_path):
             raise GitHookInstallerError(f"There is no commit-msg hook present in {dest_path}.")
 
-        with io.open(dest_path, encoding=DEFAULT_ENCODING) as fp:
+        with open(dest_path, encoding=DEFAULT_ENCODING) as fp:
             lines = fp.readlines()
             if len(lines) < 2 or lines[1] != GITLINT_HOOK_IDENTIFIER:
                 msg = (

--- a/gitlint-core/gitlint/tests/base.py
+++ b/gitlint-core/gitlint/tests/base.py
@@ -1,8 +1,5 @@
-# -*- coding: utf-8 -*-
-
 import contextlib
 import copy
-import io
 import logging
 import os
 import re
@@ -59,7 +56,7 @@ class BaseTestCase(unittest.TestCase):
     def get_sample(filename=""):
         """Read and return the contents of a file in gitlint/tests/samples"""
         sample_path = BaseTestCase.get_sample_path(filename)
-        with io.open(sample_path, encoding=DEFAULT_ENCODING) as content:
+        with open(sample_path, encoding=DEFAULT_ENCODING) as content:
             sample = content.read()
         return sample
 
@@ -75,7 +72,7 @@ class BaseTestCase(unittest.TestCase):
         """Utility method to read an expected file from gitlint/tests/expected and return it as a string.
         Optionally replace template variables specified by variable_dict."""
         expected_path = os.path.join(BaseTestCase.EXPECTED_DIR, filename)
-        with io.open(expected_path, encoding=DEFAULT_ENCODING) as content:
+        with open(expected_path, encoding=DEFAULT_ENCODING) as content:
             expected = content.read()
 
         if variable_dict:

--- a/gitlint-core/gitlint/tests/cli/test_cli.py
+++ b/gitlint-core/gitlint/tests/cli/test_cli.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import io
 import os
 import sys
@@ -29,7 +26,7 @@ class CLITests(BaseTestCase):
     GITLINT_SUCCESS_CODE = 0
 
     def setUp(self):
-        super(CLITests, self).setUp()
+        super().setUp()
         self.cli = CliRunner()
 
         # Patch gitlint.cli.git_version() so that we don't have to patch it separately in every test
@@ -321,7 +318,7 @@ class CLITests(BaseTestCase):
 
         with self.tempdir() as tmpdir:
             msg_filename = os.path.join(tmpdir, "msg")
-            with io.open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
+            with open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
                 f.write("WIP: msg-filename tïtle\n")
 
             with patch("gitlint.display.stderr", new=StringIO()) as stderr:
@@ -371,7 +368,7 @@ class CLITests(BaseTestCase):
 
         with self.tempdir() as tmpdir:
             msg_filename = os.path.join(tmpdir, "msg")
-            with io.open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
+            with open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
                 f.write("Commït title\n")
 
             with patch("gitlint.display.stderr", new=StringIO()) as stderr:

--- a/gitlint-core/gitlint/tests/cli/test_cli_hooks.py
+++ b/gitlint-core/gitlint/tests/cli/test_cli_hooks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import io
 from io import StringIO
 import os
@@ -23,7 +21,7 @@ class CLIHookTests(BaseTestCase):
     CONFIG_ERROR_CODE = 255
 
     def setUp(self):
-        super(CLIHookTests, self).setUp()
+        super().setUp()
         self.cli = CliRunner()
 
         # Patch gitlint.cli.git_version() so that we don't have to patch it separately in every test
@@ -110,7 +108,7 @@ class CLIHookTests(BaseTestCase):
 
         with self.tempdir() as tmpdir:
             msg_filename = os.path.join(tmpdir, "hür")
-            with io.open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
+            with open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
                 f.write("WIP: tïtle\n")
 
             with patch("gitlint.display.stderr", new=StringIO()) as stderr:
@@ -139,7 +137,7 @@ class CLIHookTests(BaseTestCase):
             with self.patch_input(["e", "e", "n"]):
                 with self.tempdir() as tmpdir:
                     msg_filename = os.path.realpath(os.path.join(tmpdir, "hür"))
-                    with io.open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
+                    with open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
                         f.write(commit_messages[i] + "\n")
 
                     with patch("gitlint.display.stderr", new=StringIO()) as stderr:
@@ -168,7 +166,7 @@ class CLIHookTests(BaseTestCase):
         with self.patch_input(["n"]):
             with self.tempdir() as tmpdir:
                 msg_filename = os.path.join(tmpdir, "hür")
-                with io.open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
+                with open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
                     f.write("WIP: höok no\n")
 
                 with patch("gitlint.display.stderr", new=StringIO()) as stderr:
@@ -186,7 +184,7 @@ class CLIHookTests(BaseTestCase):
         with self.patch_input(["y"]):
             with self.tempdir() as tmpdir:
                 msg_filename = os.path.join(tmpdir, "hür")
-                with io.open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
+                with open(msg_filename, "w", encoding=DEFAULT_ENCODING) as f:
                     f.write("WIP: höok yes\n")
 
                 with patch("gitlint.display.stderr", new=StringIO()) as stderr:

--- a/gitlint-core/gitlint/tests/config/test_config.py
+++ b/gitlint-core/gitlint/tests/config/test_config.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from unittest.mock import patch
 
 from gitlint import rules

--- a/gitlint-core/gitlint/tests/config/test_config_builder.py
+++ b/gitlint-core/gitlint/tests/config/test_config_builder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import copy
 
 from gitlint.tests.base import BaseTestCase

--- a/gitlint-core/gitlint/tests/config/test_config_precedence.py
+++ b/gitlint-core/gitlint/tests/config/test_config_precedence.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from io import StringIO
 
 from click.testing import CliRunner

--- a/gitlint-core/gitlint/tests/config/test_rule_collection.py
+++ b/gitlint-core/gitlint/tests/config/test_rule_collection.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from collections import OrderedDict
 from gitlint import rules
 from gitlint.config import RuleCollection

--- a/gitlint-core/gitlint/tests/contrib/rules/test_conventional_commit.py
+++ b/gitlint-core/gitlint/tests/contrib/rules/test_conventional_commit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from gitlint.tests.base import BaseTestCase
 from gitlint.rules import RuleViolation
 from gitlint.contrib.rules.conventional_commit import ConventionalCommit

--- a/gitlint-core/gitlint/tests/contrib/rules/test_disallow_cleanup_commits.py
+++ b/gitlint-core/gitlint/tests/contrib/rules/test_disallow_cleanup_commits.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from gitlint.tests.base import BaseTestCase
 from gitlint.rules import RuleViolation
 from gitlint.contrib.rules.disallow_cleanup_commits import DisallowCleanupCommits

--- a/gitlint-core/gitlint/tests/contrib/rules/test_signedoff_by.py
+++ b/gitlint-core/gitlint/tests/contrib/rules/test_signedoff_by.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from gitlint.tests.base import BaseTestCase
 from gitlint.rules import RuleViolation
 from gitlint.contrib.rules.signedoff_by import SignedOffBy

--- a/gitlint-core/gitlint/tests/contrib/test_contrib_rules.py
+++ b/gitlint-core/gitlint/tests/contrib/test_contrib_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from gitlint.tests.base import BaseTestCase

--- a/gitlint-core/gitlint/tests/git/test_git.py
+++ b/gitlint-core/gitlint/tests/git/test_git.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from unittest.mock import patch, call

--- a/gitlint-core/gitlint/tests/git/test_git_commit.py
+++ b/gitlint-core/gitlint/tests/git/test_git_commit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import copy
 import datetime
 

--- a/gitlint-core/gitlint/tests/git/test_git_context.py
+++ b/gitlint-core/gitlint/tests/git/test_git_context.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from unittest.mock import patch, call
 
 from gitlint.tests.base import BaseTestCase

--- a/gitlint-core/gitlint/tests/rules/test_body_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_body_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from gitlint.tests.base import BaseTestCase
 from gitlint import rules
 
@@ -101,13 +100,13 @@ class BodyRuleTests(BaseTestCase):
         expected_violation = rules.RuleViolation("B5", "Body message is too short (21<120)", "å" * 21, 3)
 
         rule = rules.BodyMinLength({"min-length": 120})
-        commit = self.gitcommit("Title\n\n{0}\n".format("å" * 21))  # pylint: disable=consider-using-f-string
+        commit = self.gitcommit("Title\n\n{}\n".format("å" * 21))  # pylint: disable=consider-using-f-string
         violations = rule.validate(commit)
         self.assertListEqual(violations, [expected_violation])
 
         # Make sure we don't get the error if the body-length is exactly the min-length
         rule = rules.BodyMinLength({"min-length": 8})
-        commit = self.gitcommit("Tïtle\n\n{0}\n".format("å" * 8))  # pylint: disable=consider-using-f-string
+        commit = self.gitcommit("Tïtle\n\n{}\n".format("å" * 8))  # pylint: disable=consider-using-f-string
         violations = rule.validate(commit)
         self.assertIsNone(violations)
 

--- a/gitlint-core/gitlint/tests/rules/test_configuration_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_configuration_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from gitlint.tests.base import BaseTestCase
 from gitlint import rules
 from gitlint.config import LintConfig

--- a/gitlint-core/gitlint/tests/rules/test_meta_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_meta_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from gitlint.tests.base import BaseTestCase
 from gitlint.rules import AuthorValidEmail, RuleViolation
 

--- a/gitlint-core/gitlint/tests/rules/test_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from gitlint.tests.base import BaseTestCase
 from gitlint.rules import Rule, RuleViolation
 

--- a/gitlint-core/gitlint/tests/rules/test_title_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_title_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from gitlint.tests.base import BaseTestCase
 from gitlint.rules import (
     TitleMaxLength,

--- a/gitlint-core/gitlint/tests/rules/test_user_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_user_rules.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 
@@ -72,7 +70,7 @@ class UserRuleTests(BaseTestCase):
         classes = find_rule_classes(user_rule_path)
 
         # convert classes to strings and sort them so we can compare them
-        class_strings = sorted([str(clazz) for clazz in classes])
+        class_strings = sorted(str(clazz) for clazz in classes)
         expected = ["<class 'my_commit_rules.MyUserCommitRule'>", "<class 'parent_package.InitFileRule'>"]
         self.assertListEqual(class_strings, expected)
 

--- a/gitlint-core/gitlint/tests/samples/user_rules/incorrect_linerule/my_line_rule.py
+++ b/gitlint-core/gitlint/tests/samples/user_rules/incorrect_linerule/my_line_rule.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from gitlint.rules import LineRule
 
 

--- a/gitlint-core/gitlint/tests/samples/user_rules/my_commit_rules.py
+++ b/gitlint-core/gitlint/tests/samples/user_rules/my_commit_rules.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from gitlint.rules import CommitRule, RuleViolation
 from gitlint.options import IntOption
 

--- a/gitlint-core/gitlint/tests/samples/user_rules/parent_package/__init__.py
+++ b/gitlint-core/gitlint/tests/samples/user_rules/parent_package/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This file is meant to test that we can also load rules from __init__.py files, this was an issue with pypy before.
 
 from gitlint.rules import CommitRule

--- a/gitlint-core/gitlint/tests/samples/user_rules/parent_package/my_commit_rules.py
+++ b/gitlint-core/gitlint/tests/samples/user_rules/parent_package/my_commit_rules.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from gitlint.rules import CommitRule
 
 

--- a/gitlint-core/gitlint/tests/test_cache.py
+++ b/gitlint-core/gitlint/tests/test_cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from gitlint.tests.base import BaseTestCase
 from gitlint.cache import PropertyCache, cache
 

--- a/gitlint-core/gitlint/tests/test_display.py
+++ b/gitlint-core/gitlint/tests/test_display.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from io import StringIO
 
 from unittest.mock import patch  # pylint: disable=no-name-in-module, import-error

--- a/gitlint-core/gitlint/tests/test_hooks.py
+++ b/gitlint-core/gitlint/tests/test_hooks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 
 from unittest.mock import patch, ANY, mock_open
@@ -85,7 +83,7 @@ class HookTests(BaseTestCase):
         git_hooks_dir.return_value = os.path.join("/föo", "bar", ".git", "hooks")
         lint_config.target = os.path.join("/hür", "dur")
         read_data = "#!/bin/sh\n" + GITLINT_HOOK_IDENTIFIER
-        with patch("gitlint.hooks.io.open", mock_open(read_data=read_data), create=True):
+        with patch("builtins.open", mock_open(read_data=read_data), create=True):
             GitHookInstaller.uninstall_commit_msg_hook(lint_config)
 
         expected_dst = os.path.join(git_hooks_dir.return_value, COMMIT_MSG_HOOK_DST_PATH)
@@ -133,7 +131,7 @@ class HookTests(BaseTestCase):
             "(or it was modified).\nUninstallation of 3th party or modified gitlint hooks "
             "is not supported."
         )
-        with patch("gitlint.hooks.io.open", mock_open(read_data=read_data), create=True):
+        with patch("builtins.open", mock_open(read_data=read_data), create=True):
             with self.assertRaisesMessage(GitHookInstallerError, expected_msg):
                 GitHookInstaller.uninstall_commit_msg_hook(lint_config)
             remove.assert_not_called()

--- a/gitlint-core/gitlint/tests/test_lint.py
+++ b/gitlint-core/gitlint/tests/test_lint.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from io import StringIO
 
 from unittest.mock import patch  # pylint: disable=no-name-in-module, import-error

--- a/gitlint-core/gitlint/tests/test_options.py
+++ b/gitlint-core/gitlint/tests/test_options.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import re
 

--- a/gitlint-core/gitlint/tests/test_utils.py
+++ b/gitlint-core/gitlint/tests/test_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from unittest.mock import patch
 
 from gitlint import utils

--- a/gitlint-core/setup.py
+++ b/gitlint-core/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 from setuptools import setup, find_packages
 import io
 import re
@@ -32,7 +31,7 @@ Source code on `github.com/jorisroovers/gitlint`_.
 # shamelessly stolen from mkdocs' setup.py: https://github.com/mkdocs/mkdocs/blob/master/setup.py
 def get_version(package):
     """Return package version as listed in `__version__` in `init.py`."""
-    init_py = io.open(os.path.join(package, "__init__.py"), encoding="UTF-8").read()
+    init_py = open(os.path.join(package, "__init__.py"), encoding="UTF-8").read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
 

--- a/qa/base.py
+++ b/qa/base.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=bad-option-value,unidiomatic-typecheck,undefined-variable,no-else-return,
 # pylint: disable=too-many-function-args,unexpected-keyword-arg
 
-import io
 import os
 import platform
 import shutil
@@ -81,7 +79,7 @@ class BaseTestCase(TestCase):
         """Creates a file inside a passed directory. Returns filename."""
         test_filename = "test-fïle-" + str(uuid4())
         # pylint: disable=consider-using-with
-        io.open(os.path.join(parent_dir, test_filename), "a", encoding=DEFAULT_ENCODING).close()
+        open(os.path.join(parent_dir, test_filename), "a", encoding=DEFAULT_ENCODING).close()
         return test_filename
 
     @staticmethod
@@ -134,7 +132,7 @@ class BaseTestCase(TestCase):
         # Not using a context manager to avoid unnecessary indentation in test code
         tmpfile, tmpfilepath = tempfile.mkstemp()
         self.tmpfiles.append(tmpfilepath)
-        with io.open(tmpfile, "w", encoding=DEFAULT_ENCODING) as f:
+        with open(tmpfile, "w", encoding=DEFAULT_ENCODING) as f:
             f.write(content)
         return tmpfilepath
 
@@ -162,7 +160,7 @@ class BaseTestCase(TestCase):
         specified by variable_dict."""
         expected_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "expected")
         expected_path = os.path.join(expected_dir, filename)
-        with io.open(expected_path, encoding=DEFAULT_ENCODING) as file:
+        with open(expected_path, encoding=DEFAULT_ENCODING) as file:
             expected = file.read()
 
             if variable_dict:

--- a/qa/samples/user_rules/extra/extra_rules.py
+++ b/qa/samples/user_rules/extra/extra_rules.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from gitlint.rules import CommitRule, RuleViolation, ConfigurationRule
 from gitlint.options import IntOption, StrOption, ListOption
 

--- a/qa/test_commits.py
+++ b/qa/test_commits.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=too-many-function-args,unexpected-keyword-arg
 import re
 

--- a/qa/test_config.py
+++ b/qa/test_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=too-many-function-args,unexpected-keyword-arg
 
 import re

--- a/qa/test_contrib.py
+++ b/qa/test_contrib.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=
 from qa.shell import gitlint
 from qa.base import BaseTestCase

--- a/qa/test_gitlint.py
+++ b/qa/test_gitlint.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=too-many-function-args,unexpected-keyword-arg
-import io
 import os
 from qa.shell import echo, git, gitlint
 from qa.base import BaseTestCase
@@ -60,7 +58,7 @@ class IntegrationTests(BaseTestCase):
         self.assertEqualStdout(output, expected)
 
         # Make a small modification to the commit and commit it using fixup commit
-        with io.open(os.path.join(self.tmp_git_repo, test_filename), "a", encoding=DEFAULT_ENCODING) as fh:
+        with open(os.path.join(self.tmp_git_repo, test_filename), "a", encoding=DEFAULT_ENCODING) as fh:
             fh.write("Appending söme stuff\n")
 
         git("add", test_filename, _cwd=self.tmp_git_repo)
@@ -89,7 +87,7 @@ class IntegrationTests(BaseTestCase):
         self.assertEqualStdout(output, expected)
 
         # Make a small modification to the commit and commit it using fixup=amend commit
-        with io.open(os.path.join(self.tmp_git_repo, test_filename), "a", encoding=DEFAULT_ENCODING) as fh:
+        with open(os.path.join(self.tmp_git_repo, test_filename), "a", encoding=DEFAULT_ENCODING) as fh:
             fh.write("Appending söme stuff\n")
 
         git("add", test_filename, _cwd=self.tmp_git_repo)
@@ -135,7 +133,7 @@ class IntegrationTests(BaseTestCase):
         self.assertEqualStdout(output, expected)
 
         # Make a small modification to the commit and commit it using squash commit
-        with io.open(os.path.join(self.tmp_git_repo, test_filename), "a", encoding=DEFAULT_ENCODING) as fh:
+        with open(os.path.join(self.tmp_git_repo, test_filename), "a", encoding=DEFAULT_ENCODING) as fh:
             # Wanted to write a unicode string, but that's obnoxious if you want to do it across Python 2 and 3.
             # https://stackoverflow.com/questions/22392377/
             # error-writing-a-file-with-file-write-in-python-unicodeencodeerror

--- a/qa/test_hooks.py
+++ b/qa/test_hooks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=too-many-function-args,unexpected-keyword-arg
 import os
 from qa.shell import git, gitlint

--- a/qa/test_named_rules.py
+++ b/qa/test_named_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from qa.shell import gitlint
 from qa.base import BaseTestCase
 

--- a/qa/test_stdin.py
+++ b/qa/test_stdin.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=too-many-function-args,unexpected-keyword-arg
-import io
 import subprocess
 from qa.shell import echo, gitlint
 from qa.base import BaseTestCase
@@ -44,7 +42,7 @@ class StdInTests(BaseTestCase):
         """
         tmp_commit_msg_file = self.create_tmpfile("WIP: STDIN ïs a file test.")
 
-        with io.open(tmp_commit_msg_file, encoding=DEFAULT_ENCODING) as file_handle:
+        with open(tmp_commit_msg_file, encoding=DEFAULT_ENCODING) as file_handle:
             # We need to use subprocess.Popen() here instead of sh because when passing a file_handle to sh, it will
             # deal with reading the file itself instead of passing it on to gitlint as a STDIN. Since we're trying to
             # test for the condition where stat.S_ISREG == True that won't work for us here.

--- a/qa/test_user_defined.py
+++ b/qa/test_user_defined.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=too-many-function-args,unexpected-keyword-arg
 from qa.shell import gitlint
 from qa.base import BaseTestCase


### PR DESCRIPTION
Result of running pyupgrade against gitlint, targetting Python 3.6+.
This mostly cleans up some unneccesary python 2 compatibility code.