### PR TITLE
fix: Use specific checkout action version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", pypy-3.9]
         os: ["macos-latest", "ubuntu-latest"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }} # Checkout pull request HEAD commit instead of merge commit
 
@@ -91,7 +91,7 @@ jobs:
       matrix:
         python-version: [3.6]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }} # Checkout pull request HEAD commit instead of merge commit
 


### PR DESCRIPTION
GitHub Actions unfortunately runs the *latest* version of the actions which fits the `uses` directive version. So right now `actions/checkout@v3` is equivalent to `actions/checkout@v3.0.2`, but this can change at any time. To avoid workflows suddenly failing in case a new minor/patch version of an action, this PR uses the most specific version number available for the checkout action.