### PR TITLE
CI: Python version bump for windows tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -90,7 +90,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: "Upgrade pip on Python 3"
-        if: matrix.python-version == '3.6'
+        if: matrix.python-version == '3.10'
         run: python -m pip install --upgrade pip
 
       - name: Install requirements


### PR DESCRIPTION
Previously was still running on python 3.6, bumped to 3.10