### PR TITLE
Add commit parent hashes in debug output

### DIFF
--- a/gitlint-core/gitlint/git.py
+++ b/gitlint-core/gitlint/git.py
@@ -251,6 +251,7 @@ class GitCommit:
             f"is-fixup-amend-commit: {self.is_fixup_amend_commit}\n"
             f"is-squash-commit: {self.is_squash_commit}\n"
             f"is-revert-commit: {self.is_revert_commit}\n"
+            f"Parents: {self.parents}\n"
             f"Branches: {self.branches}\n"
             f"Changed Files: {self.changed_files}\n"
             f"Changed Files Stats:{changed_files_stats_str}\n"
@@ -300,7 +301,10 @@ class LocalGitCommit(GitCommit, PropertyCache):
 
         (name, email, date, parents), commit_msg = raw_commit[0].split("\x00"), "\n".join(raw_commit[1:])
 
-        commit_parents = parents.split(" ")
+        if parents == "":
+            commit_parents = []
+        else:
+            commit_parents = parents.split(" ")
         commit_is_merge_commit = len(commit_parents) > 1
 
         # "YYYY-MM-DD HH:mm:ss Z" -> ISO 8601-like format

--- a/gitlint-core/gitlint/git.py
+++ b/gitlint-core/gitlint/git.py
@@ -301,10 +301,7 @@ class LocalGitCommit(GitCommit, PropertyCache):
 
         (name, email, date, parents), commit_msg = raw_commit[0].split("\x00"), "\n".join(raw_commit[1:])
 
-        if parents == "":
-            commit_parents = []
-        else:
-            commit_parents = parents.split(" ")
+        commit_parents = [] if parents == "" else parents.split(" ")
         commit_is_merge_commit = len(commit_parents) > 1
 
         # "YYYY-MM-DD HH:mm:ss Z" -> ISO 8601-like format

--- a/gitlint-core/gitlint/tests/cli/test_cli.py
+++ b/gitlint-core/gitlint/tests/cli/test_cli.py
@@ -428,16 +428,16 @@ class CLITests(BaseTestCase):
             "25053ccec5e28e1bb8f7551fdbb5ab213ada2401\n"
             "4da2656b0dadc76c7ee3fd0243a96cb64007f125\n",
             # git log --pretty <FORMAT> <SHA>
-            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00abc\n"
+            "test åuthor1\x00test-email1@föo.com\x002016-12-03 15:28:15 +0100\x00a123\n"
             "commït-title1\n\ncommït-body1",
             "#",                                                     # git config --get core.commentchar
             "5\t8\tcommit-1/file-1\n2\t9\tcommit-1/file-2\n",                    # git diff-tree
             "commit-1-branch-1\ncommit-1-branch-2\n",                # git branch --contains <sha>
-            "test åuthor2\x00test-email2@föo.com\x002016-12-04 15:28:15 +0100\x00abc\n"
+            "test åuthor2\x00test-email2@föo.com\x002016-12-04 15:28:15 +0100\x00b123\n"
             "commït-title2.\n\ncommït-body2",
             "5\t8\tcommit-2/file-1\n7\t9\tcommit-2/file-2\n",        # git diff-tree
             "commit-2-branch-1\ncommit-2-branch-2\n",                # git branch --contains <sha>
-            "test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 +0100\x00abc\n"
+            "test åuthor3\x00test-email3@föo.com\x002016-12-05 15:28:15 +0100\x00c123\n"
             "föobar\nbar",
             "1\t4\tcommit-3/file-1\n3\t4\tcommit-3/file-2\n",        # git diff-tree
             "commit-3-branch-1\ncommit-3-branch-2\n",                # git branch --contains <sha>

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
@@ -83,6 +83,7 @@ is-fixup-commit:  False
 is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
+Parents: ['a123']
 Branches: ['commit-1-branch-1', 'commit-1-branch-2']
 Changed Files: ['commit-1/file-1', 'commit-1/file-2']
 Changed Files Stats:
@@ -106,6 +107,7 @@ is-fixup-commit:  False
 is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
+Parents: ['b123']
 Branches: ['commit-2-branch-1', 'commit-2-branch-2']
 Changed Files: ['commit-2/file-1', 'commit-2/file-2']
 Changed Files Stats:
@@ -128,6 +130,7 @@ is-fixup-commit:  False
 is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
+Parents: ['c123']
 Branches: ['commit-3-branch-1', 'commit-3-branch-2']
 Changed Files: ['commit-3/file-1', 'commit-3/file-2']
 Changed Files Stats:

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
@@ -79,6 +79,7 @@ is-fixup-commit:  False
 is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
+Parents: []
 Branches: []
 Changed Files: []
 Changed Files Stats: {{}}

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
@@ -82,6 +82,7 @@ is-fixup-commit:  False
 is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
+Parents: []
 Branches: ['my-branch']
 Changed Files: ['commit-1/file-1', 'commit-1/file-2']
 Changed Files Stats:

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
@@ -84,6 +84,7 @@ is-fixup-commit:  False
 is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
+Parents: []
 Branches: ['my-branch']
 Changed Files: ['commit-1/file-1', 'commit-1/file-2']
 Changed Files Stats:

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
@@ -82,6 +82,7 @@ is-fixup-commit:  False
 is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
+Parents: []
 Branches: []
 Changed Files: []
 Changed Files Stats: {{}}

--- a/qa/expected/test_commits/test_lint_staged_msg_filename_1
+++ b/qa/expected/test_commits/test_lint_staged_msg_filename_1
@@ -83,6 +83,7 @@ is-fixup-commit:  False
 is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
+Parents: []
 Branches: ['main']
 Changed Files: {changed_files}
 Changed Files Stats:

--- a/qa/expected/test_commits/test_lint_staged_stdin_1
+++ b/qa/expected/test_commits/test_lint_staged_stdin_1
@@ -85,6 +85,7 @@ is-fixup-commit:  False
 is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
+Parents: []
 Branches: ['main']
 Changed Files: {changed_files}
 Changed Files Stats:

--- a/qa/expected/test_config/test_config_from_env_1
+++ b/qa/expected/test_config/test_config_from_env_1
@@ -88,6 +88,7 @@ is-fixup-commit:  False
 is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
+Parents: []
 Branches: ['main']
 Changed Files: {changed_files}
 Changed Files Stats:

--- a/qa/expected/test_config/test_config_from_env_2
+++ b/qa/expected/test_config/test_config_from_env_2
@@ -83,6 +83,7 @@ is-fixup-commit:  False
 is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
+Parents: []
 Branches: ['main']
 Changed Files: []
 Changed Files Stats: {{}}

--- a/qa/expected/test_config/test_config_from_file_debug_1
+++ b/qa/expected/test_config/test_config_from_file_debug_1
@@ -85,6 +85,7 @@ is-fixup-commit:  False
 is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
+Parents: []
 Branches: ['main']
 Changed Files: {changed_files}
 Changed Files Stats:

--- a/qa/expected/test_gitlint/test_commit_binary_file_1
+++ b/qa/expected/test_gitlint/test_commit_binary_file_1
@@ -83,6 +83,7 @@ is-fixup-commit:  False
 is-fixup-amend-commit: False
 is-squash-commit: False
 is-revert-commit: False
+Parents: []
 Branches: ['main']
 Changed Files: {changed_files}
 Changed Files Stats:


### PR DESCRIPTION
Also ensure commit.parents is empty instead [''] (list with empty
string) when the commit has no parents.