### PR TITLE
Support for general.regex-style-search

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -425,20 +425,57 @@ fail-without-commits=true
 ---
 ### regex-style-search
 
-Whether to use Python `search` instead of `match` semantics in rules that use
-regexes. 
-
-
-!!! important
-    **This is disabled by default, but will be enabled by default in the future.**
-    Gitlint will print a warning when you're using a rule that uses a regex and this
-    option is not enabled.
-    For more context, see [issue #254](https://github.com/jorisroovers/gitlint/issues/254).
-
+Whether to use Python `re.search()` instead of `re.match()` semantics in all built-in rules that use regular expressions. 
 
 | Default value | gitlint version | commandline flag | environment variable |
 | ------------- | --------------- | ---------------- | -------------------- |
 | false         | >= 0.18.0       | Not Available    | Not Available        |
+
+!!! important
+    At this time, `regex-style-search` is **disabled** by default, but it will be **enabled** by default in the future.
+    
+
+
+Gitlint will log a warning when you're using a rule that uses a custom regex and this option is not enabled:
+
+```plain
+WARNING: I1 - ignore-by-title: gitlint will be switching from using Python regex 'match' (match beginning) to
+'search' (match anywhere) semantics. Please review your ignore-by-title.regex option accordingly.
+To remove this warning, set general.regex-style-search=True. 
+More details: https://jorisroovers.github.io/gitlint/configuration/#regex-style-search
+```
+
+*If you don't have any custom regex specified, gitlint will not log a warning and no action is needed.*
+
+**To remove the warning:** 
+
+1. Review your regex in the rules gitlint warned for and ensure it's still accurate when using [`re.search()` semantics](https://docs.python.org/3/library/re.html#search-vs-match).
+2. Enable `regex-style-search` in your `.gitlint` file (or using [any other way to configure gitlint](http://127.0.0.1:8000/gitlint/configuration/)):
+
+```ini
+[general]
+regex-style-search=true
+```
+
+#### More context
+Python offers [two different primitive operations based on regular expressions](https://docs.python.org/3/library/re.html#search-vs-match): 
+`re.match()` checks for a match only at the beginning of the string, while `re.search()` checks for a match anywhere
+in the string.
+
+
+
+Most rules in gitlint already use `re.search()` instead of `re.match()`, but there's a few notable exceptions that
+use `re.match()`, which can lead to unexpected matching behavior.
+
+- M1 - author-valid-email
+- I1 - ignore-by-title
+- I2 - ignore-by-body
+- I3 - ignore-body-lines
+- I4 - ignore-by-author-name
+
+The `regex-style-search` option is meant to fix this inconsistency. Setting it to `true` will force the above rules to
+use `re.search()` instead of `re.match()`. For detailed context, see [issue #254](https://github.com/jorisroovers/gitlint/issues/254).
+
 
 #### Examples
 ```sh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,11 @@ staged=true
 # Disabled by default.
 fail-without-commits=true
 
+# Whether to use Python `search` instead of `match` semantics in rules that use
+# regexes. Context: https://github.com/jorisroovers/gitlint/issues/254
+# Disabled by default, but will be enabled by default in the future.
+regex-style-search=true
+
 # Enable debug mode (prints more output). Disabled by default.
 debug=true
 
@@ -217,9 +222,9 @@ using commandline flags or in `[general]` section in a `.gitlint` configuration 
 
 Enable silent mode (no output). Use [exit](index.md#exit-codes) code to determine result.
 
-Default value  |  gitlint version | commandline flag  | environment variable
----------------|------------------|-------------------|-----------------------
-`False`        | >= 0.1.0         | `--silent`        | `GITLINT_SILENT`
+| Default value | gitlint version | commandline flag | environment variable |
+| ------------- | --------------- | ---------------- | -------------------- |
+| `False`       | >= 0.1.0        | `--silent`       | `GITLINT_SILENT`     |
 
 #### Examples
 ```sh
@@ -232,9 +237,9 @@ GITLINT_SILENT=1 gitlint  # using env variable
 
 Amount of output gitlint will show when printing errors.
 
-Default value  |  gitlint version | commandline flag  | environment variable 
----------------|------------------|-------------------|-----------------------
-3              | >= 0.1.0         | `-v`              | `GITLINT_VERBOSITY`
+| Default value | gitlint version | commandline flag | environment variable |
+| ------------- | --------------- | ---------------- | -------------------- |
+| 3             | >= 0.1.0        | `-v`             | `GITLINT_VERBOSITY`  |
 
 
 #### Examples
@@ -258,9 +263,9 @@ verbosity=2
 
 Comma separated list of rules to ignore (by name or id).
 
-Default value              |  gitlint version | commandline flag  | environment variable   
----------------------------|------------------|-------------------|-----------------------
- [] (=empty list)          | >= 0.1.0         | `--ignore`        | `GITLINT_IGNORE`
+| Default value    | gitlint version | commandline flag | environment variable |
+| ---------------- | --------------- | ---------------- | -------------------- |
+| [] (=empty list) | >= 0.1.0        | `--ignore`       | `GITLINT_IGNORE`     |
 
 #### Examples
 ```sh
@@ -280,9 +285,9 @@ ignore=T1,body-min-length
 
 Enable debugging output.
 
-Default value  |  gitlint version | commandline flag  | environment variable   
----------------|------------------|-------------------|-----------------------
- false         | >= 0.7.1         | `--debug`         | `GITLINT_DEBUG`
+| Default value | gitlint version | commandline flag | environment variable |
+| ------------- | --------------- | ---------------- | -------------------- |
+| false         | >= 0.7.1        | `--debug`        | `GITLINT_DEBUG`      |
 
 #### Examples
 ```sh
@@ -297,9 +302,9 @@ GITLINT_DEBUG=1 gitlint # using env variable
 
 Target git repository gitlint should be linting against.
 
-Default value              |  gitlint version | commandline flag  | environment variable   
----------------------------|------------------|-------------------|-----------------------
-(empty)                    | >= 0.8.0         | `--target`        | `GITLINT_TARGET`
+| Default value | gitlint version | commandline flag | environment variable |
+| ------------- | --------------- | ---------------- | -------------------- |
+| (empty)       | >= 0.8.0        | `--target`       | `GITLINT_TARGET`     |
 
 #### Examples
 ```sh
@@ -317,9 +322,9 @@ target=/home/joe/myrepo/
 
 Path where gitlint looks for a config file.
 
-Default value              |  gitlint version | commandline flag  | environment variable   
----------------------------|------------------|-------------------|-----------------------
-`.gitlint`                 | >= 0.1.0         | `--config`        | `GITLINT_CONFIG`
+| Default value | gitlint version | commandline flag | environment variable |
+| ------------- | --------------- | ---------------- | -------------------- |
+| `.gitlint`    | >= 0.1.0        | `--config`       | `GITLINT_CONFIG`     |
 
 #### Examples
 ```sh
@@ -332,9 +337,9 @@ GITLINT_CONFIG=/home/joe/gitlint.ini  # using env variable
 
 Path where gitlint looks for [user-defined rules](user_defined_rules.md).
 
-Default value              |  gitlint version | commandline flag  | environment variable   
----------------------------|------------------|-------------------|-----------------------
- (empty)                   | >= 0.8.0         | `--extra-path`    | `GITLINT_EXTRA_PATH`
+| Default value | gitlint version | commandline flag | environment variable |
+| ------------- | --------------- | ---------------- | -------------------- |
+| (empty)       | >= 0.8.0        | `--extra-path`   | `GITLINT_EXTRA_PATH` |
 
 #### Examples
 ```sh
@@ -353,9 +358,9 @@ extra-path=/home/joe/rules/
 
 Comma-separated list of [Contrib rules](contrib_rules) to enable (by name or id).
 
-Default value              |  gitlint version | commandline flag  | environment variable   
----------------------------|------------------|-------------------|-----------------------
- (empty)                   | >= 0.12.0        | `--contrib`       | `GITLINT_CONTRIB`
+| Default value | gitlint version | commandline flag | environment variable |
+| ------------- | --------------- | ---------------- | -------------------- |
+| (empty)       | >= 0.12.0       | `--contrib`      | `GITLINT_CONTRIB`    |
 
 #### Examples
 ```sh
@@ -376,9 +381,9 @@ contrib=contrib-title-conventional-commits,CC1
 
 Fetch additional meta-data from the local repository when manually passing a commit message to gitlint via stdin or `--commit-msg`.
 
-Default value  |  gitlint version | commandline flag  | environment variable   
----------------|------------------|-------------------|-----------------------
- false         | >= 0.13.0        | `--staged`        | `GITLINT_STAGED`
+| Default value | gitlint version | commandline flag | environment variable |
+| ------------- | --------------- | ---------------- | -------------------- |
+| false         | >= 0.13.0       | `--staged`       | `GITLINT_STAGED`     |
 
 #### Examples
 ```sh
@@ -399,9 +404,9 @@ Hard fail when the target commit range is empty. Note that gitlint will
 already fail by default on invalid commit ranges. This option is specifically
 to tell gitlint to fail on **valid but empty** commit ranges.
 
-Default value  |  gitlint version | commandline flag  | environment variable   
----------------|------------------|---------------------------|-----------------------
- false         | >= 0.15.2        | `--fail-without-commits`  | `GITLINT_FAIL_WITHOUT_COMMITS`
+| Default value | gitlint version | commandline flag         | environment variable           |
+| ------------- | --------------- | ------------------------ | ------------------------------ |
+| false         | >= 0.15.2       | `--fail-without-commits` | `GITLINT_FAIL_WITHOUT_COMMITS` |
 
 #### Examples
 ```sh
@@ -417,13 +422,42 @@ GITLINT_FAIL_WITHOUT_COMMITS=1 gitlint       # using env variable
 fail-without-commits=true
 ```
 
+---
+### regex-style-search
+
+Whether to use Python `search` instead of `match` semantics in rules that use
+regexes. 
+
+
+!!! important
+    **This is disabled by default, but will be enabled by default in the future.**
+    Gitlint will print a warning when you're using a rule that uses a regex and this
+    option is not enabled.
+    For more context, see [issue #254](https://github.com/jorisroovers/gitlint/issues/254).
+
+
+| Default value | gitlint version | commandline flag | environment variable |
+| ------------- | --------------- | ---------------- | -------------------- |
+| false         | >= 0.18.0       | Not Available    | Not Available        |
+
+#### Examples
+```sh
+# CLI
+gitlint -c general.regex-style-search=true
+```
+```ini
+#.gitlint
+[general]
+regex-style-search=true
+```
+---
 ### ignore-stdin
 
 Ignore any stdin data. Sometimes useful when running gitlint in a CI server.
 
-Default value  |  gitlint version | commandline flag  | environment variable   
----------------|------------------|-------------------|-----------------------
- false         | >= 0.12.0        | `--ignore-stdin`  | `GITLINT_IGNORE_STDIN`
+| Default value | gitlint version | commandline flag | environment variable   |
+| ------------- | --------------- | ---------------- | ---------------------- |
+| false         | >= 0.12.0       | `--ignore-stdin` | `GITLINT_IGNORE_STDIN` |
 
 #### Examples
 ```sh
@@ -442,9 +476,9 @@ ignore-stdin=true
 
 Whether or not to ignore merge commits.
 
-Default value  |  gitlint version | commandline flag  | environment variable  
----------------|------------------|-------------------|-----------------------
- true          | >= 0.7.0         | Not Available     | Not Available  
+| Default value | gitlint version | commandline flag | environment variable |
+| ------------- | --------------- | ---------------- | -------------------- |
+| true          | >= 0.7.0        | Not Available    | Not Available        |
 
 #### Examples
 ```sh
@@ -461,9 +495,9 @@ ignore-merge-commits=false
 
 Whether or not to ignore revert commits.
 
-Default value  |  gitlint version | commandline flag  | environment variable   
----------------|------------------|-------------------|-----------------------
- true          | >= 0.13.0        | Not Available     | Not Available  
+| Default value | gitlint version | commandline flag | environment variable |
+| ------------- | --------------- | ---------------- | -------------------- |
+| true          | >= 0.13.0       | Not Available    | Not Available        |
 
 #### Examples
 ```sh
@@ -480,9 +514,9 @@ ignore-revert-commits=false
 
 Whether or not to ignore [fixup](https://git-scm.com/docs/git-commit#git-commit---fixupltcommitgt) commits.
 
-Default value  |  gitlint version | commandline flag  | environment variable  
----------------|------------------|-------------------|-----------------------
- true          | >= 0.9.0         | Not Available     | Not Available  
+| Default value | gitlint version | commandline flag | environment variable |
+| ------------- | --------------- | ---------------- | -------------------- |
+| true          | >= 0.9.0        | Not Available    | Not Available        |
 
 #### Examples
 ```sh
@@ -499,9 +533,9 @@ ignore-fixup-commits=false
 
 Whether or not to ignore [fixup=amend](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupamendrewordltcommitgt) commits.
 
-Default value  |  gitlint version | commandline flag  | environment variable  
----------------|------------------|-------------------|-----------------------
- true          | >= 0.18.0        | Not Available     | Not Available  
+| Default value | gitlint version | commandline flag | environment variable |
+| ------------- | --------------- | ---------------- | -------------------- |
+| true          | >= 0.18.0       | Not Available    | Not Available        |
 
 #### Examples
 ```sh
@@ -518,9 +552,9 @@ ignore-fixup-amend-commits=false
 
 Whether or not to ignore [squash](https://git-scm.com/docs/git-commit#git-commit---squashltcommitgt) commits.
 
-Default value  |  gitlint version | commandline flag  | environment variable 
----------------|------------------|-------------------|-----------------------
- true          | >= 0.9.0         | Not Available     | Not Available  
+| Default value | gitlint version | commandline flag | environment variable |
+| ------------- | --------------- | ---------------- | -------------------- |
+| true          | >= 0.9.0        | Not Available    | Not Available        |
 
 #### Examples
 ```sh

--- a/gitlint-core/gitlint/cli.py
+++ b/gitlint-core/gitlint/cli.py
@@ -11,6 +11,7 @@ import click
 import gitlint
 from gitlint.lint import GitLinter
 from gitlint.config import LintConfigBuilder, LintConfigError, LintConfigGenerator
+from gitlint.deprecation import LOG as DEPRECATED_LOG, DEPRECATED_LOG_FORMAT
 from gitlint.git import GitContext, GitContextError, git_version
 from gitlint import hooks
 from gitlint.shell import shell
@@ -44,13 +45,22 @@ class GitLintUsageError(GitlintError):
 
 def setup_logging():
     """Setup gitlint logging"""
+
+    # Root log, mostly used for debug
     root_log = logging.getLogger("gitlint")
     root_log.propagate = False  # Don't propagate to child loggers, the gitlint root logger handles everything
+    root_log.setLevel(logging.ERROR)
     handler = logging.StreamHandler()
     formatter = logging.Formatter(LOG_FORMAT)
     handler.setFormatter(formatter)
     root_log.addHandler(handler)
-    root_log.setLevel(logging.ERROR)
+
+    # Deprecated log, to log deprecation warnings
+    DEPRECATED_LOG.propagate = False  # Don't propagate to child logger
+    DEPRECATED_LOG.setLevel(logging.WARNING)
+    deprecated_log_handler = logging.StreamHandler()
+    deprecated_log_handler.setFormatter(logging.Formatter(DEPRECATED_LOG_FORMAT))
+    DEPRECATED_LOG.addHandler(deprecated_log_handler)
 
 
 def log_system_info():
@@ -284,6 +294,7 @@ def cli(  # pylint: disable=too-many-arguments
     try:
         if debug:
             logging.getLogger("gitlint").setLevel(logging.DEBUG)
+            DEPRECATED_LOG.setLevel(logging.DEBUG)
         LOG.debug("To report issues, please visit https://github.com/jorisroovers/gitlint/issues")
 
         log_system_info()

--- a/gitlint-core/gitlint/config.py
+++ b/gitlint-core/gitlint/config.py
@@ -84,6 +84,9 @@ class LintConfig:  # pylint: disable=too-many-instance-attributes
         self._fail_without_commits = options.BoolOption(
             "fail-without-commits", False, "Hard fail when the target commit range is empty"
         )
+        self._regex_style_search = options.BoolOption(
+            "regex-style-search", False, "Use `search` instead of `match` semantics for regex rules"
+        )
 
     @property
     def target(self):
@@ -197,6 +200,15 @@ class LintConfig:  # pylint: disable=too-many-instance-attributes
         return self._fail_without_commits.set(value)
 
     @property
+    def regex_style_search(self):
+        return self._regex_style_search.value
+
+    @regex_style_search.setter
+    @handle_option_error
+    def regex_style_search(self, value):
+        return self._regex_style_search.set(value)
+
+    @property
     def extra_path(self):
         return self._extra_path.value if self._extra_path else None
 
@@ -301,6 +313,7 @@ class LintConfig:  # pylint: disable=too-many-instance-attributes
             and self.ignore_stdin == other.ignore_stdin
             and self.staged == other.staged
             and self.fail_without_commits == other.fail_without_commits
+            and self.regex_style_search == other.regex_style_search
             and self.debug == other.debug
             and self.ignore == other.ignore
             and self._config_path == other._config_path
@@ -322,6 +335,7 @@ class LintConfig:  # pylint: disable=too-many-instance-attributes
             f"ignore-stdin: {self.ignore_stdin}\n"
             f"staged: {self.staged}\n"
             f"fail-without-commits: {self.fail_without_commits}\n"
+            f"regex-style-search: {self.regex_style_search}\n"
             f"verbosity: {self.verbosity}\n"
             f"debug: {self.debug}\n"
             f"target: {self.target}\n"

--- a/gitlint-core/gitlint/deprecation.py
+++ b/gitlint-core/gitlint/deprecation.py
@@ -8,12 +8,18 @@ DEPRECATED_LOG_FORMAT = "%(levelname)s: %(message)s"
 class Deprecation:
     """Singleton class that handles deprecation warnings and behavior."""
 
+    # LintConfig class that is used to determine deprecation behavior
     config = None
 
+    # Set of warning messages that have already been logged, to prevent duplicate warnings
     warning_msgs = set()
 
     @classmethod
     def get_regex_method(cls, rule, regex_option):
+        """Returns the regex method to be used for a given rule based on general.regex-style-search option.
+        Logs a warning if the deprecated re.match method is returned."""
+
+        # if general.regex-style-search is set, just return re.search
         if cls.config.regex_style_search:
             return regex_option.value.search
 

--- a/gitlint-core/gitlint/deprecation.py
+++ b/gitlint-core/gitlint/deprecation.py
@@ -1,0 +1,34 @@
+import logging
+
+
+LOG = logging.getLogger("gitlint.deprecated")
+DEPRECATED_LOG_FORMAT = "%(levelname)s: %(message)s"
+
+
+class Deprecation:
+    """Singleton class that handles deprecation warnings and behavior."""
+
+    config = None
+
+    warning_msgs = set()
+
+    @classmethod
+    def get_regex_method(cls, rule, regex_option):
+        if cls.config.regex_style_search:
+            return regex_option.value.search
+
+        warning_msg = (
+            f"{rule.id} - {rule.name}: gitlint will be switching from using Python regex 'match' (match beginning) to "
+            "'search' (match anywhere) semantics. "
+            f"Please review your {rule.name}.regex option accordingly. "
+            "To remove this warning, set general.regex-style-search=True. "
+            "More details: TODO"
+        )
+
+        # Only log warnings once
+        if warning_msg not in cls.warning_msgs:
+            log = logging.getLogger("gitlint.deprecated.regex_style_search")
+            log.warning(warning_msg)
+        cls.warning_msgs.add(warning_msg)
+
+        return regex_option.value.match

--- a/gitlint-core/gitlint/deprecation.py
+++ b/gitlint-core/gitlint/deprecation.py
@@ -28,7 +28,7 @@ class Deprecation:
             "'search' (match anywhere) semantics. "
             f"Please review your {rule.name}.regex option accordingly. "
             "To remove this warning, set general.regex-style-search=True. "
-            "More details: TODO"
+            "More details: https://jorisroovers.github.io/gitlint/configuration/#regex-style-search"
         )
 
         # Only log warnings once

--- a/gitlint-core/gitlint/files/gitlint
+++ b/gitlint-core/gitlint/files/gitlint
@@ -34,6 +34,11 @@
 # Disabled by default.
 # fail-without-commits=true
 
+# Whether to use Python `search` instead of `match` semantics in rules that use
+# regexes. Context: https://github.com/jorisroovers/gitlint/issues/254
+# Disabled by default, but will be enabled by default in the future.
+# regex-style-search=true
+
 # Enable debug mode (prints more output). Disabled by default.
 # debug=true
 

--- a/gitlint-core/gitlint/lint.py
+++ b/gitlint-core/gitlint/lint.py
@@ -2,6 +2,7 @@
 import logging
 from gitlint import rules as gitlint_rules
 from gitlint import display
+from gitlint.deprecation import Deprecation
 
 LOG = logging.getLogger(__name__)
 logging.basicConfig()
@@ -84,6 +85,9 @@ class GitLinter:
         """Lint the last commit in a given git context by applying all ignore, title, body and commit rules."""
         LOG.debug("Linting commit %s", commit.sha or "[SHA UNKNOWN]")
         LOG.debug("Commit Object\n" + str(commit))
+
+        # Ensure the Deprecation class has a reference to the config currently being used
+        Deprecation.config = self.config
 
         # Apply config rules
         for rule in self.configuration_rules:

--- a/gitlint-core/gitlint/tests/base.py
+++ b/gitlint-core/gitlint/tests/base.py
@@ -19,7 +19,8 @@ EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING = (
     "WARNING: gitlint.deprecated.regex_style_search {0} - {1}: gitlint will be switching from using "
     "Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. "
     "Please review your {1}.regex option accordingly. "
-    "To remove this warning, set general.regex-style-search=True. More details: TODO"
+    "To remove this warning, set general.regex-style-search=True. More details: "
+    "https://jorisroovers.github.io/gitlint/configuration/#regex-style-search"
 )
 
 

--- a/gitlint-core/gitlint/tests/base.py
+++ b/gitlint-core/gitlint/tests/base.py
@@ -15,6 +15,13 @@ from gitlint.deprecation import Deprecation, LOG as DEPRECATION_LOG
 from gitlint.git import GitContext, GitChangedFileStats
 from gitlint.utils import LOG_FORMAT, DEFAULT_ENCODING
 
+EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING = (
+    "WARNING: gitlint.deprecated.regex_style_search {0} - {1}: gitlint will be switching from using "
+    "Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. "
+    "Please review your {1}.regex option accordingly. "
+    "To remove this warning, set general.regex-style-search=True. More details: TODO"
+)
+
 
 class BaseTestCase(unittest.TestCase):
     """Base class of which all gitlint unit test classes are derived. Provides a number of convenience methods."""

--- a/gitlint-core/gitlint/tests/config/test_config.py
+++ b/gitlint-core/gitlint/tests/config/test_config.py
@@ -51,6 +51,7 @@ class LintConfigTests(BaseTestCase):
         self.assertFalse(config.ignore_stdin)
         self.assertFalse(config.staged)
         self.assertFalse(config.fail_without_commits)
+        self.assertFalse(config.regex_style_search)
         self.assertFalse(config.debug)
         self.assertEqual(config.verbosity, 3)
         active_rule_classes = tuple(type(rule) for rule in config.rules)
@@ -103,6 +104,10 @@ class LintConfigTests(BaseTestCase):
         # fail-without-commits
         config.set_general_option("fail-without-commits", "true")
         self.assertTrue(config.fail_without_commits)
+
+        # regex-style-search
+        config.set_general_option("regex-style-search", "true")
+        self.assertTrue(config.regex_style_search)
 
         # target
         config.set_general_option("target", self.SAMPLES_DIR)
@@ -243,7 +248,7 @@ class LintConfigTests(BaseTestCase):
         # splitting which means it it will accept just about everything
 
         # invalid boolean options
-        for attribute in ["debug", "staged", "ignore_stdin", "fail_without_commits"]:
+        for attribute in ["debug", "staged", "ignore_stdin", "fail_without_commits", "regex_style_search"]:
             option_name = attribute.replace("_", "-")
             with self.assertRaisesMessage(LintConfigError, f"Option '{option_name}' must be either 'true' or 'false'"):
                 setattr(config, attribute, "föobar")
@@ -274,6 +279,8 @@ class LintConfigTests(BaseTestCase):
             ("verbosity", 1),
             ("rules", []),
             ("ignore_stdin", True),
+            ("fail_without_commits", True),
+            ("regex_style_search", True),
             ("debug", True),
             ("ignore", ["T1"]),
             ("staged", True),

--- a/gitlint-core/gitlint/tests/config/test_config_precedence.py
+++ b/gitlint-core/gitlint/tests/config/test_config_precedence.py
@@ -11,6 +11,7 @@ from gitlint.config import LintConfigBuilder
 
 class LintConfigPrecedenceTests(BaseTestCase):
     def setUp(self):
+        super().setUp()
         self.cli = CliRunner()
 
     @patch("gitlint.cli.get_stdin_data", return_value="WIP:fö\n\nThis is å test message\n")

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
@@ -61,7 +61,7 @@ target: {target}
   B8: body-match-regex
      regex=None
   M1: author-valid-email
-     regex=[^@ ]+@[^@ ]+\.[^@ ]+
+     regex=^[^@ ]+@[^@ ]+\.[^@ ]+
 
 DEBUG: gitlint.cli No --msg-filename flag, no or empty data passed to stdin. Using the local repo.
 DEBUG: gitlint.git ('rev-list', 'foo...bar')

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
@@ -19,6 +19,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: False
 fail-without-commits: False
+regex-style-search: False
 verbosity: 1
 debug: True
 target: {target}

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
@@ -61,7 +61,7 @@ target: {target}
   B8: body-match-regex
      regex=None
   M1: author-valid-email
-     regex=[^@ ]+@[^@ ]+\.[^@ ]+
+     regex=^[^@ ]+@[^@ ]+\.[^@ ]+
 
 DEBUG: gitlint.cli Stdin data: 'WIP: tïtle 
 '

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
@@ -19,6 +19,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: False
 fail-without-commits: False
+regex-style-search: False
 verbosity: 3
 debug: True
 target: {target}

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
@@ -19,6 +19,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: True
 fail-without-commits: False
+regex-style-search: False
 verbosity: 3
 debug: True
 target: {target}

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
@@ -61,7 +61,7 @@ target: {target}
   B8: body-match-regex
      regex=None
   M1: author-valid-email
-     regex=[^@ ]+@[^@ ]+\.[^@ ]+
+     regex=^[^@ ]+@[^@ ]+\.[^@ ]+
 
 DEBUG: gitlint.cli Fetching additional meta-data from staged commit
 DEBUG: gitlint.cli Using --msg-filename.

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
@@ -19,6 +19,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: True
 fail-without-commits: False
+regex-style-search: False
 verbosity: 3
 debug: True
 target: {target}

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
@@ -61,7 +61,7 @@ target: {target}
   B8: body-match-regex
      regex=None
   M1: author-valid-email
-     regex=[^@ ]+@[^@ ]+\.[^@ ]+
+     regex=^[^@ ]+@[^@ ]+\.[^@ ]+
 
 DEBUG: gitlint.cli Fetching additional meta-data from staged commit
 DEBUG: gitlint.cli Stdin data: 'WIP: tïtle 

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
@@ -19,6 +19,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: False
 fail-without-commits: False
+regex-style-search: False
 verbosity: 3
 debug: True
 target: {target}

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
@@ -61,7 +61,7 @@ target: {target}
   B8: body-match-regex
      regex=None
   M1: author-valid-email
-     regex=[^@ ]+@[^@ ]+\.[^@ ]+
+     regex=^[^@ ]+@[^@ ]+\.[^@ ]+
   T5:extra-wörds: title-must-not-contain-word:extra-wörds
      words=hür,tëst
   T5:even-more-wörds: title-must-not-contain-word:even-more-wörds

--- a/gitlint-core/gitlint/tests/rules/test_configuration_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_configuration_rules.py
@@ -21,11 +21,15 @@ class ConfigurationRuleTests(BaseTestCase):
         rule.apply(config, commit)
         self.assertEqual(config, expected_config)
 
-        expected_log_message = (
+        expected_log_messages = [
+            "WARNING: gitlint.deprecated.regex_style_search I1 - ignore-by-title: gitlint will be switching from using "
+            "Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. "
+            "Please review your ignore-by-title.regex option accordingly. "
+            "To remove this warning, set general.regex-style-search=True. More details: TODO",
             "DEBUG: gitlint.rules Ignoring commit because of rule 'I1': "
-            "Commit title 'Releäse' matches the regex '^Releäse(.*)', ignoring rules: all"
-        )
-        self.assert_log_contains(expected_log_message)
+            "Commit title 'Releäse' matches the regex '^Releäse(.*)', ignoring rules: all",
+        ]
+        self.assert_logged(expected_log_messages)
 
         # Matching regex with specific ignore
         rule = rules.IgnoreByTitle({"regex": "^Releäse(.*)", "ignore": "T1,B2"})
@@ -34,10 +38,11 @@ class ConfigurationRuleTests(BaseTestCase):
         rule.apply(config, commit)
         self.assertEqual(config, expected_config)
 
-        expected_log_message = (
+        expected_log_messages += [
             "DEBUG: gitlint.rules Ignoring commit because of rule 'I1': "
             "Commit title 'Releäse' matches the regex '^Releäse(.*)', ignoring rules: T1,B2"
-        )
+        ]
+        self.assert_logged(expected_log_messages)
 
     def test_ignore_by_body(self):
         commit = self.gitcommit("Tïtle\n\nThis is\n a relëase body\n line")

--- a/gitlint-core/gitlint/tests/rules/test_configuration_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_configuration_rules.py
@@ -1,4 +1,4 @@
-from gitlint.tests.base import BaseTestCase
+from gitlint.tests.base import BaseTestCase, EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING
 from gitlint import rules
 from gitlint.config import LintConfig
 
@@ -22,10 +22,7 @@ class ConfigurationRuleTests(BaseTestCase):
         self.assertEqual(config, expected_config)
 
         expected_log_messages = [
-            "WARNING: gitlint.deprecated.regex_style_search I1 - ignore-by-title: gitlint will be switching from using "
-            "Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. "
-            "Please review your ignore-by-title.regex option accordingly. "
-            "To remove this warning, set general.regex-style-search=True. More details: TODO",
+            EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING.format("I1", "ignore-by-title"),
             "DEBUG: gitlint.rules Ignoring commit because of rule 'I1': "
             "Commit title 'Releäse' matches the regex '^Releäse(.*)', ignoring rules: all",
         ]
@@ -61,12 +58,13 @@ class ConfigurationRuleTests(BaseTestCase):
         rule.apply(config, commit)
         self.assertEqual(config, expected_config)
 
-        expected_log_message = (
+        expected_log_messages = [
+            EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING.format("I2", "ignore-by-body"),
             "DEBUG: gitlint.rules Ignoring commit because of rule 'I2': "
             "Commit message line ' a relëase body' matches the regex '(.*)relëase(.*)',"
-            " ignoring rules: all"
-        )
-        self.assert_log_contains(expected_log_message)
+            " ignoring rules: all",
+        ]
+        self.assert_logged(expected_log_messages)
 
         # Matching regex with specific ignore
         rule = rules.IgnoreByBody({"regex": "(.*)relëase(.*)", "ignore": "T1,B2"})
@@ -75,11 +73,11 @@ class ConfigurationRuleTests(BaseTestCase):
         rule.apply(config, commit)
         self.assertEqual(config, expected_config)
 
-        expected_log_message = (
+        expected_log_messages += [
             "DEBUG: gitlint.rules Ignoring commit because of rule 'I2': "
             "Commit message line ' a relëase body' matches the regex '(.*)relëase(.*)', ignoring rules: T1,B2"
-        )
-        self.assert_log_contains(expected_log_message)
+        ]
+        self.assert_logged(expected_log_messages)
 
     def test_ignore_by_author_name(self):
         commit = self.gitcommit("Tïtle\n\nThis is\n a relëase body\n line", author_name="Tëst nåme")
@@ -98,12 +96,13 @@ class ConfigurationRuleTests(BaseTestCase):
         rule.apply(config, commit)
         self.assertEqual(config, expected_config)
 
-        expected_log_message = (
+        expected_log_messages = [
+            EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING.format("I4", "ignore-by-author-name"),
             "DEBUG: gitlint.rules Ignoring commit because of rule 'I4': "
             "Commit Author Name 'Tëst nåme' matches the regex '(.*)ëst(.*)',"
-            " ignoring rules: all"
-        )
-        self.assert_log_contains(expected_log_message)
+            " ignoring rules: all",
+        ]
+        self.assert_logged(expected_log_messages)
 
         # Matching regex with specific ignore
         rule = rules.IgnoreByAuthorName({"regex": "(.*)nåme", "ignore": "T1,B2"})
@@ -112,11 +111,11 @@ class ConfigurationRuleTests(BaseTestCase):
         rule.apply(config, commit)
         self.assertEqual(config, expected_config)
 
-        expected_log_message = (
+        expected_log_messages += [
             "DEBUG: gitlint.rules Ignoring commit because of rule 'I4': "
             "Commit Author Name 'Tëst nåme' matches the regex '(.*)nåme', ignoring rules: T1,B2"
-        )
-        self.assert_log_contains(expected_log_message)
+        ]
+        self.assert_logged(expected_log_messages)
 
     def test_ignore_body_lines(self):
         commit1 = self.gitcommit("Tïtle\n\nThis is\n a relëase body\n line")
@@ -142,9 +141,11 @@ class ConfigurationRuleTests(BaseTestCase):
         expected_commit.message.original = commit1.message.original
         self.assertEqual(commit1, expected_commit)
         self.assertEqual(config, LintConfig())  # config shouldn't have been modified
-        self.assert_log_contains(
-            "DEBUG: gitlint.rules Ignoring line ' a relëase body' because it " + "matches '(.*)relëase(.*)'"
-        )
+        expected_log_messages = [
+            EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING.format("I3", "ignore-body-lines"),
+            "DEBUG: gitlint.rules Ignoring line ' a relëase body' because it " + "matches '(.*)relëase(.*)'",
+        ]
+        self.assert_logged(expected_log_messages)
 
         # Non-Matching regex: no changes expected
         commit1 = self.gitcommit("Tïtle\n\nThis is\n a relëase body\n line")

--- a/gitlint-core/gitlint/tests/rules/test_meta_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_meta_rules.py
@@ -1,4 +1,4 @@
-from gitlint.tests.base import BaseTestCase
+from gitlint.tests.base import BaseTestCase, EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING
 from gitlint.rules import AuthorValidEmail, RuleViolation
 
 
@@ -43,6 +43,11 @@ class MetaRuleTests(BaseTestCase):
             violations = rule.validate(commit)
             self.assertListEqual(violations, [RuleViolation("M1", "Author email for commit is invalid", email)])
 
+        # Ensure nothing is logged, this relates specifically to a deprecation warning on the use of
+        # re.match vs re.search in the rules (see issue #254)
+        # If no custom regex is used, the rule uses the default regex in combination with re.search
+        self.assert_logged([])
+
     def test_author_valid_email_rule_custom_regex(self):
         # regex=None -> the rule isn't applied
         rule = AuthorValidEmail()
@@ -67,3 +72,6 @@ class MetaRuleTests(BaseTestCase):
             commit = self.gitcommit("", author_email=email)
             violations = rule.validate(commit)
             self.assertListEqual(violations, [RuleViolation("M1", "Author email for commit is invalid", email)])
+
+        # When a custom regex is used, a warning should be logged by default
+        self.assert_logged([EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING.format("M1", "author-valid-email")])

--- a/gitlint-core/gitlint/tests/test_deprecation.py
+++ b/gitlint-core/gitlint/tests/test_deprecation.py
@@ -1,0 +1,23 @@
+from gitlint.config import LintConfig
+from gitlint.deprecation import Deprecation
+from gitlint.rules import IgnoreByTitle
+from gitlint.tests.base import EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING, BaseTestCase
+
+
+class DeprecationTests(BaseTestCase):
+    def test_get_regex_method(self):
+        config = LintConfig()
+        Deprecation.config = config
+        rule = IgnoreByTitle({"regex": "^Releäse(.*)"})
+
+        # When general.regex-style-search=True, we expect regex.search to be returned and no warning to be logged
+        config.regex_style_search = True
+        regex_method = Deprecation.get_regex_method(rule, rule.options["regex"])
+        self.assertEqual(regex_method, rule.options["regex"].value.search)
+        self.assert_logged([])
+
+        # When general.regex-style-search=False, we expect regex.match to be returned and a warning to be logged
+        config.regex_style_search = False
+        regex_method = Deprecation.get_regex_method(rule, rule.options["regex"])
+        self.assertEqual(regex_method, rule.options["regex"].value.match)
+        self.assert_logged([EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING.format("I1", "ignore-by-title")])

--- a/qa/expected/test_commits/test_ignore_commits_1
+++ b/qa/expected/test_commits/test_ignore_commits_1
@@ -1,5 +1,5 @@
-WARNING: I1 - ignore-by-title: gitlint will be switching from using Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. Please review your ignore-by-title.regex option accordingly. To remove this warning, set general.regex-style-search=True. More details: TODO
-WARNING: I2 - ignore-by-body: gitlint will be switching from using Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. Please review your ignore-by-body.regex option accordingly. To remove this warning, set general.regex-style-search=True. More details: TODO
+WARNING: I1 - ignore-by-title: gitlint will be switching from using Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. Please review your ignore-by-title.regex option accordingly. To remove this warning, set general.regex-style-search=True. More details: https://jorisroovers.github.io/gitlint/configuration/#regex-style-search
+WARNING: I2 - ignore-by-body: gitlint will be switching from using Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. Please review your ignore-by-body.regex option accordingly. To remove this warning, set general.regex-style-search=True. More details: https://jorisroovers.github.io/gitlint/configuration/#regex-style-search
 Commit {commit_sha0}:
 1: T3 Title has trailing punctuation (.): "Sïmple title4."
 

--- a/qa/expected/test_commits/test_ignore_commits_1
+++ b/qa/expected/test_commits/test_ignore_commits_1
@@ -1,3 +1,5 @@
+WARNING: I1 - ignore-by-title: gitlint will be switching from using Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. Please review your ignore-by-title.regex option accordingly. To remove this warning, set general.regex-style-search=True. More details: TODO
+WARNING: I2 - ignore-by-body: gitlint will be switching from using Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. Please review your ignore-by-body.regex option accordingly. To remove this warning, set general.regex-style-search=True. More details: TODO
 Commit {commit_sha0}:
 1: T3 Title has trailing punctuation (.): "Sïmple title4."
 

--- a/qa/expected/test_commits/test_lint_staged_msg_filename_1
+++ b/qa/expected/test_commits/test_lint_staged_msg_filename_1
@@ -62,7 +62,7 @@ target: {target}
   B8: body-match-regex
      regex=None
   M1: author-valid-email
-     regex=[^@ ]+@[^@ ]+\.[^@ ]+
+     regex=^[^@ ]+@[^@ ]+\.[^@ ]+
 
 DEBUG: gitlint.cli Fetching additional meta-data from staged commit
 DEBUG: gitlint.cli Using --msg-filename.

--- a/qa/expected/test_commits/test_lint_staged_msg_filename_1
+++ b/qa/expected/test_commits/test_lint_staged_msg_filename_1
@@ -20,6 +20,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: True
 fail-without-commits: False
+regex-style-search: False
 verbosity: 3
 debug: True
 target: {target}

--- a/qa/expected/test_commits/test_lint_staged_stdin_1
+++ b/qa/expected/test_commits/test_lint_staged_stdin_1
@@ -62,7 +62,7 @@ target: {target}
   B8: body-match-regex
      regex=None
   M1: author-valid-email
-     regex=[^@ ]+@[^@ ]+\.[^@ ]+
+     regex=^[^@ ]+@[^@ ]+\.[^@ ]+
 
 DEBUG: gitlint.cli Fetching additional meta-data from staged commit
 DEBUG: gitlint.cli Stdin data: 'WIP: Pïpe test.

--- a/qa/expected/test_commits/test_lint_staged_stdin_1
+++ b/qa/expected/test_commits/test_lint_staged_stdin_1
@@ -20,6 +20,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: True
 fail-without-commits: False
+regex-style-search: False
 verbosity: 3
 debug: True
 target: {target}

--- a/qa/expected/test_config/test_config_from_env_1
+++ b/qa/expected/test_config/test_config_from_env_1
@@ -20,6 +20,7 @@ ignore-revert-commits: True
 ignore-stdin: True
 staged: False
 fail-without-commits: True
+regex-style-search: False
 verbosity: 2
 debug: True
 target: {target}

--- a/qa/expected/test_config/test_config_from_env_1
+++ b/qa/expected/test_config/test_config_from_env_1
@@ -62,7 +62,7 @@ target: {target}
   B8: body-match-regex
      regex=None
   M1: author-valid-email
-     regex=[^@ ]+@[^@ ]+\.[^@ ]+
+     regex=^[^@ ]+@[^@ ]+\.[^@ ]+
   CC1: contrib-body-requires-signed-off-by
   CT1: contrib-title-conventional-commits
      types=fix,feat,chore,docs,style,refactor,perf,test,revert,ci,build

--- a/qa/expected/test_config/test_config_from_env_2
+++ b/qa/expected/test_config/test_config_from_env_2
@@ -62,7 +62,7 @@ target: {target}
   B8: body-match-regex
      regex=None
   M1: author-valid-email
-     regex=[^@ ]+@[^@ ]+\.[^@ ]+
+     regex=^[^@ ]+@[^@ ]+\.[^@ ]+
 
 DEBUG: gitlint.cli Fetching additional meta-data from staged commit
 DEBUG: gitlint.cli Using --msg-filename.

--- a/qa/expected/test_config/test_config_from_env_2
+++ b/qa/expected/test_config/test_config_from_env_2
@@ -20,6 +20,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: True
 fail-without-commits: False
+regex-style-search: False
 verbosity: 0
 debug: True
 target: {target}

--- a/qa/expected/test_config/test_config_from_file_debug_1
+++ b/qa/expected/test_config/test_config_from_file_debug_1
@@ -62,7 +62,7 @@ target: {target}
   B8: body-match-regex
      regex=None
   M1: author-valid-email
-     regex=[^@ ]+@[^@ ]+\.[^@ ]+
+     regex=^[^@ ]+@[^@ ]+\.[^@ ]+
 
 DEBUG: gitlint.cli No --msg-filename flag, no or empty data passed to stdin. Using the local repo.
 DEBUG: gitlint.git ('log', '-1', '--pretty=%H')

--- a/qa/expected/test_config/test_config_from_file_debug_1
+++ b/qa/expected/test_config/test_config_from_file_debug_1
@@ -20,6 +20,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: False
 fail-without-commits: False
+regex-style-search: False
 verbosity: 2
 debug: True
 target: {target}

--- a/qa/expected/test_gitlint/test_commit_binary_file_1
+++ b/qa/expected/test_gitlint/test_commit_binary_file_1
@@ -62,7 +62,7 @@ target: {target}
   B8: body-match-regex
      regex=None
   M1: author-valid-email
-     regex=[^@ ]+@[^@ ]+\.[^@ ]+
+     regex=^[^@ ]+@[^@ ]+\.[^@ ]+
 
 DEBUG: gitlint.cli No --msg-filename flag, no or empty data passed to stdin. Using the local repo.
 DEBUG: gitlint.git ('log', '-1', '--pretty=%H')

--- a/qa/expected/test_gitlint/test_commit_binary_file_1
+++ b/qa/expected/test_gitlint/test_commit_binary_file_1
@@ -20,6 +20,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: False
 fail-without-commits: False
+regex-style-search: False
 verbosity: 3
 debug: True
 target: {target}


### PR DESCRIPTION
Support for `general.regex-style-search` option which determines regex semantics for 
- author-valid-email
- ignore-by-title
- ignore-by-body
- ignore-body-lines
- ignore-by-author-name

Also includes a new `Deprecation` class to globally implement deprecation behavior and warnings.