### PR TITLE
Cleanup docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ gitlint generate-config
 You can also use a different config file like so:
 
 ```sh
-gitlint --config myconfigfile.ini 
+gitlint --config myconfigfile.ini
 ```
 
 The block below shows a sample `.gitlint` file. Details about rule config options can be found on the
@@ -49,7 +49,7 @@ ignore-squash-commits=true
 # Ignore any data sent to gitlint via stdin
 ignore-stdin=true
 
-# Fetch additional meta-data from the local repository when manually passing a 
+# Fetch additional meta-data from the local repository when manually passing a
 # commit message to gitlint via stdin or --commit-msg. Disabled by default.
 staged=true
 
@@ -193,7 +193,7 @@ gitlint-ignore: all
 
 `gitlint-ignore: all` can occur on any line, as long as it is at the start of the line.
 
-You can also specify specific rules to be ignored as follows: 
+You can also specify specific rules to be ignored as follows:
 ```
 WIP: This is my commit message
 
@@ -369,7 +369,7 @@ gitlint --contrib=contrib-title-conventional-commits,CC1
 # different way of doing the same
 gitlint -c general.contrib=contrib-title-conventional-commits,CC1
 # using env variable
-GITLINT_CONTRIB=contrib-title-conventional-commits,CC1 gitlint   
+GITLINT_CONTRIB=contrib-title-conventional-commits,CC1 gitlint
 ```
 ```ini
 #.gitlint
@@ -412,7 +412,7 @@ to tell gitlint to fail on **valid but empty** commit ranges.
 ```sh
 # CLI
 # The following will cause gitlint to hard fail (i.e. exit code > 0)
-# since HEAD..HEAD is a valid but empty commit range. 
+# since HEAD..HEAD is a valid but empty commit range.
 gitlint --fail-without-commits --commits HEAD..HEAD
 GITLINT_FAIL_WITHOUT_COMMITS=1 gitlint       # using env variable
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,7 +207,7 @@ gitlint-ignore: T1, body-hard-tab
 gitlint configuration is applied in the following order of precedence:
 
 1. Commit specific config (e.g.: `gitlint-ignore: all` in the commit message)
-2. Configuration Rules (e.g.: [ignore-by-title](/rules/#i1-ignore-by-title))
+2. Configuration Rules (e.g.: [ignore-by-title](rules.md#i1-ignore-by-title))
 3. Commandline convenience flags (e.g.:  `-vv`, `--silent`, `--ignore`)
 4. Environment variables (e.g.: `GITLINT_VERBOSITY=3`)
 5. Commandline configuration flags (e.g.: `-c title-max-length=123`)
@@ -356,7 +356,7 @@ extra-path=/home/joe/rules/
 
 ### contrib
 
-Comma-separated list of [Contrib rules](contrib_rules) to enable (by name or id).
+Comma-separated list of [Contrib rules](contrib_rules.md) to enable (by name or id).
 
 | Default value | gitlint version | commandline flag | environment variable |
 | ------------- | --------------- | ---------------- | -------------------- |

--- a/docs/contrib_rules.md
+++ b/docs/contrib_rules.md
@@ -5,7 +5,7 @@ Contrib rules are community-**contrib**uted rules that are disabled by default, 
 
 Contrib rules are meant to augment default gitlint behavior by providing users with rules for common use-cases without
 forcing these rules on all gitlint users. This also means that users don't have to
-re-implement these commonly used rules themselves as [user-defined](user_defined_rules) rules.
+re-implement these commonly used rules themselves as [user-defined](user_defined_rules.md) rules.
 
 To enable certain contrib rules, you can use the `--contrib` flag.
 ```sh
@@ -71,4 +71,4 @@ ID    | Name                             | gitlint version    | Description
 CC2   | contrib-disallow-cleanup-commits | >= 0.18.0          | Commit title must not contain `fixup!`, `squash!` or `amend!`. This means `git commit --fixup` and `git commit --squash` commits are not allowed.
 
 ## Contributing Contrib rules
-We'd love for you to contribute new Contrib rules to gitlint or improve existing ones! Please visit the [Contributing](contributing) page on how to get started.
+We'd love for you to contribute new Contrib rules to gitlint or improve existing ones! Please visit the [Contributing](contributing.md) page on how to get started.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -110,13 +110,13 @@ tools/windows/run_tests.bat          # Windows run unit tests
 ```
 
 ## Contrib rules
-Since gitlint 0.12.0, we support [Contrib rules](../contrib_rules): community contributed rules that are part of gitlint
+Since gitlint 0.12.0, we support [Contrib rules](contrib_rules.md): community contributed rules that are part of gitlint
 itself. Thanks for considering to add a new one to gitlint!
 
 Before starting, please read all the other documentation on this page about contributing first.
 Then, we suggest taking the following approach to add a Contrib rule:
 
-1. **Write your rule as a [user-defined rule](../user_defined_rules)**. In terms of code, Contrib rules are identical to
+1. **Write your rule as a [user-defined rule](user_defined_rules.md)**. In terms of code, Contrib rules are identical to
    user-defined rules, they just happen to have their code sit within the gitlint codebase itself.
 2. **Add your user-defined rule to gitlint**. You should put your file(s) in the [gitlint/contrib/rules](https://github.com/jorisroovers/gitlint/tree/main/gitlint-core/gitlint/contrib/rules) directory.
 3. **Write unit tests**. The gitlint codebase contains [Contrib rule test files you can copy and modify](https://github.com/jorisroovers/gitlint/tree/main/gitlint-core/gitlint/tests/contrib/rules).
@@ -129,7 +129,7 @@ If you follow the steps above and follow the existing gitlint conventions wrt na
 
 In case you're looking for a slightly more formal spec, here's what gitlint requires of Contrib rules.
 
-- Since Contrib rules are really just user-defined rules that live within the gitlint code-base, all the [user-rule requirements](../user_defined_rules/#rule-requirements) also apply to Contrib rules.
+- Since Contrib rules are really just user-defined rules that live within the gitlint code-base, all the [user-rule requirements](user_defined_rules.md#rule-requirements) also apply to Contrib rules.
 - All contrib rules **must** have associated unit tests. We *sort of* enforce this by a unit test that verifies that there's a
   test file for each contrib file.
 - All contrib rules **must** have names that start with `contrib-`. This is to easily distinguish them from default gitlint rules.
@@ -137,4 +137,4 @@ In case you're looking for a slightly more formal spec, here's what gitlint requ
 - All contrib rules **must** have unique names and ids.
 - You **can** add multiple rule classes to the same file, but classes **should** be logically grouped together in a single file that implements related rules.
 - Contrib rules **should** be meaningfully different from one another. If a behavior change or tweak can be added to an existing rule by adding options, that should be considered first. However, large [god classes](https://en.wikipedia.org/wiki/God_object) that implement multiple rules in a single class should obviously also be avoided.
-- Contrib rules **should** use [options](../user_defined_rules/#options) to make rules configurable.
+- Contrib rules **should** use [options](user_defined_rules.md#options) to make rules configurable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Great for use as a [commit-msg git hook](#using-gitlint-as-a-commit-msg-hook) or
 [standards](http://chris.beams.io/posts/git-commit/), others are based on checks that we've found
 useful throughout the years.
  - **Easily configurable:** Gitlint has sane defaults, but [you can also easily customize it to your own liking](configuration.md).
- - **Community contributed rules**: Conventions that are common but not universal [can be selectively enabled](contrib_rules).
+ - **Community contributed rules**: Conventions that are common but not universal [can be selectively enabled](contrib_rules.md).
  - **User-defined rules:** Want to do more then what gitlint offers out of the box? Write your own [user defined rules](user_defined_rules.md).
  - **Full unicode support:** Lint your Russian, Chinese or Emoji commit messages with ease!
  - **Production-ready:** Gitlint checks a lot of the boxes you're looking for: actively maintained, high unit test coverage, integration tests,

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ useful throughout the years.
 # Pip is recommended to install the latest version
 pip install gitlint
 
-# Alternative: by default, gitlint is installed with pinned dependencies. 
+# Alternative: by default, gitlint is installed with pinned dependencies.
 # To install gitlint with looser dependency requirements, only install gitlint-core.
 pip install gitlint-core
 
@@ -280,7 +280,7 @@ The `--commits` flag takes a **single** refspec argument or commit range. Basica
 by [git rev-list](https://git-scm.com/docs/git-rev-list) as a single argument will work.
 
 Alternatively, you can pass `--commits` a comma-separated list of commit hashes (both short and full-length SHAs work,
-as well as special references such as `HEAD` and branch names). 
+as well as special references such as `HEAD` and branch names).
 Gitlint will treat these as pointers to single commits and lint these in the order you passed.
 
 For cases where the `--commits` option doesn't provide the flexibility you need, you can always use a simple shell
@@ -389,7 +389,7 @@ additional unique identifier (i.e. the rule *name*) during configuration.
     For example, by defining 2 `body-max-line-length` rules with different `line-length` options, you obviously create
     a conflicting situation. Gitlint does not do any resolution of such conflicts, it's up to you to make sure
     any configuration is non-conflicting. So caution advised!
-    
+
 Defining a named rule is easy, for example using your `.gitlint` file:
 
 ```ini
@@ -415,7 +415,7 @@ When executing gitlint, you will see the violations from the default `title-must
 the violations caused by the additional Named Rules.
 
 ```sh
-$ gitlint 
+$ gitlint
 1: T5 Title contains the word 'WIP' (case-insensitive): "WIP: foo wonderwoman hur bar"
 1: T5:This-Can_Be*Whatever$YouWant Title contains the word 'wonderwoman' (case-insensitive): "WIP: foo wonderwoman hur bar"
 1: T5:extra-words Title contains the word 'foo' (case-insensitive): "WIP: foo wonderwoman hur bar"


### PR DESCRIPTION
I noticed that some links in the docs were broken, so I fixed them in this PR.
To verify the links, I used [markdown-link-check](https://github.com/tcort/markdown-link-check).
I also removed some trailing whitespace in the docs.