### PR TITLE
Python 3.11 release support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,8 +7,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version:
-          ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-rc.2", pypy-3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", pypy-3.9]
         os: ["macos-latest", "ubuntu-latest"]
     steps:
       - uses: actions/checkout@v3.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog #
 
+## v0.18.0 (2021-11-?)  - Unreleased ##
+- Python 3.11 support
+- Last release to support Python 3.6 (EOL since 2021-12-23)
+
 ## v0.17.0 (2021-11-28) ##
 Contributors:
 Special thanks to all contributors for this release, in particular [andersk](https://github.com/andersk) and [sigmavirus24](https://github.com/sigmavirus24).


### PR DESCRIPTION
Python 3.11 was released on 2022-10-24, enable support in CI for
the final 3.11 release (was RC2 before).
