### PR TITLE
Disable use of sh library by default

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -54,9 +54,11 @@ jobs:
       - name: Integration Tests
         run: ./run_tests.sh -i
 
-      - name: Integration Tests (GITLINT_USE_SH_LIB=0)
+      # Gitlint no longer uses `sh` by default, but for now we're still supporting the manual enablement of it.
+      # By setting GITLINT_USE_SH_LIB=1, we test whether this still works.
+      - name: Integration Tests (GITLINT_USE_SH_LIB=1)
         env:
-          GITLINT_USE_SH_LIB: 0
+          GITLINT_USE_SH_LIB: 1
         run: ./run_tests.sh -i
 
       - name: Code formatting (black)

--- a/gitlint-core/gitlint/tests/test_utils.py
+++ b/gitlint-core/gitlint/tests/test_utils.py
@@ -22,13 +22,9 @@ class UtilsTests(BaseTestCase):
             self.assertEqual(utils.use_sh_library(), False, invalid_val)
             patched_env.get.assert_called_once_with("GITLINT_USE_SH_LIB", None)
 
-        # Assert that when GITLINT_USE_SH_LIB is not set, we fallback to checking whether we're on Windows
-        utils.PLATFORM_IS_WINDOWS = True
+        # Assert that when GITLINT_USE_SH_LIB is not set, we fallback to False (not using)
         patched_env.get.return_value = None
         self.assertEqual(utils.use_sh_library(), False)
-
-        utils.PLATFORM_IS_WINDOWS = False
-        self.assertEqual(utils.use_sh_library(), True)
 
     @patch("gitlint.utils.locale")
     def test_default_encoding_non_windows(self, mocked_locale):

--- a/gitlint-core/gitlint/utils.py
+++ b/gitlint-core/gitlint/utils.py
@@ -34,7 +34,7 @@ def use_sh_library():
     gitlint_use_sh_lib_env = os.environ.get("GITLINT_USE_SH_LIB", None)
     if gitlint_use_sh_lib_env:
         return gitlint_use_sh_lib_env == "1"
-    return not PLATFORM_IS_WINDOWS
+    return False
 
 
 USE_SH_LIB = use_sh_library()


### PR DESCRIPTION
Future goal is to remove the sh dependency entirely from gitlint-core.
For now, the use of sh can be re-enabled using GITLINT_USE_SH_LIB=1.
