### PR TITLE
Add authors-commit contrib rule

### DIFF
--- a/docs/contrib_rules.md
+++ b/docs/contrib_rules.md
@@ -1,4 +1,5 @@
 # Using Contrib Rules
+
 _Introduced in gitlint v0.12.0_
 
 Contrib rules are community-**contrib**uted rules that are disabled by default, but can be enabled through configuration.
@@ -43,6 +44,7 @@ ID    | Name                                | gitlint version   | Description
 CT1   | contrib-title-conventional-commits  | >= 0.12.0         | Enforces [Conventional Commits](https://www.conventionalcommits.org/) commit message style on the title.
 CC1   | contrib-body-requires-signed-off-by | >= 0.12.0         | Commit body must contain a `Signed-off-by` line.
 CC2   | contrib-disallow-cleanup-commits    | >= 0.18.0         | Commit title must not contain `fixup!`, `squash!`, `amend!`.
+CC3   | contrib-authors-commit              | >= 0.18.0         | Enforce that only authors listed in the `AUTHORS` file are allowed to commit.
 
 ## CT1: contrib-title-conventional-commits ##
 
@@ -70,5 +72,12 @@ ID    | Name                             | gitlint version    | Description
 ------|----------------------------------|--------------------|-------------------------------------------
 CC2   | contrib-disallow-cleanup-commits | >= 0.18.0          | Commit title must not contain `fixup!`, `squash!` or `amend!`. This means `git commit --fixup` and `git commit --squash` commits are not allowed.
 
+## CC3: contrib-authors-commit ##
+
+ID    | Name                             | gitlint version    | Description
+------|----------------------------------|--------------------|-------------------------------------------
+CC3   | contrib-authors-commit           | >= 0.18.0          | The commit author must be listed in an `AUTHORS` file to be allowed to commit. Possible file names are also `AUTHORS.txt` and `AUTHORS.md`.
+
 ## Contributing Contrib rules
+
 We'd love for you to contribute new Contrib rules to gitlint or improve existing ones! Please visit the [Contributing](contributing.md) page on how to get started.

--- a/docs/contrib_rules.md
+++ b/docs/contrib_rules.md
@@ -44,7 +44,7 @@ ID    | Name                                | gitlint version   | Description
 CT1   | contrib-title-conventional-commits  | >= 0.12.0         | Enforces [Conventional Commits](https://www.conventionalcommits.org/) commit message style on the title.
 CC1   | contrib-body-requires-signed-off-by | >= 0.12.0         | Commit body must contain a `Signed-off-by` line.
 CC2   | contrib-disallow-cleanup-commits    | >= 0.18.0         | Commit title must not contain `fixup!`, `squash!`, `amend!`.
-CC3   | contrib-authors-commit              | >= 0.18.0         | Enforce that only authors listed in the `AUTHORS` file are allowed to commit.
+CC3   | contrib-allowed-authors              | >= 0.18.0         | Enforce that only authors listed in the `AUTHORS` file are allowed to commit.
 
 ## CT1: contrib-title-conventional-commits ##
 
@@ -72,11 +72,11 @@ ID    | Name                             | gitlint version    | Description
 ------|----------------------------------|--------------------|-------------------------------------------
 CC2   | contrib-disallow-cleanup-commits | >= 0.18.0          | Commit title must not contain `fixup!`, `squash!` or `amend!`. This means `git commit --fixup` and `git commit --squash` commits are not allowed.
 
-## CC3: contrib-authors-commit ##
+## CC3: contrib-allowed-authors ##
 
 ID    | Name                             | gitlint version    | Description
 ------|----------------------------------|--------------------|-------------------------------------------
-CC3   | contrib-authors-commit           | >= 0.18.0          | The commit author must be listed in an `AUTHORS` file to be allowed to commit. Possible file names are also `AUTHORS.txt` and `AUTHORS.md`.
+CC3   | contrib-allowed-authors           | >= 0.18.0          | The commit author must be listed in an `AUTHORS` file to be allowed to commit. Possible file names are also `AUTHORS.txt` and `AUTHORS.md`.
 
 ## Contributing Contrib rules
 

--- a/gitlint-core/gitlint/contrib/rules/authors_commit.py
+++ b/gitlint-core/gitlint/contrib/rules/authors_commit.py
@@ -1,0 +1,48 @@
+import re
+from pathlib import Path
+from typing import Tuple
+
+
+from gitlint.rules import CommitRule, RuleViolation
+
+
+class Authors(CommitRule):
+    """Enforce that only authors listed in the AUTHORS file are allowed to commit."""
+
+    authors_file_names = ("AUTHORS", "AUTHORS.txt", "AUTHORS.md")
+    parse_authors = re.compile(r"^(?P<name>.*) <(?P<email>.*)>$", re.MULTILINE)
+
+    # A rule MUST have a human friendly name
+    name = "contrib-authors-commit"
+
+    # A rule MUST have a *unique* id, we recommend starting with UC (for User-defined Commit-rule).
+    id = "CC3"
+
+    @classmethod
+    def _read_authors_from_file(cls, git_ctx) -> Tuple[str, str]:
+        for file_name in cls.authors_file_names:
+            path = Path(git_ctx.repository_path / file_name)
+            if path.exists():
+                authors_file = path
+                break
+        else:
+            raise FileNotFoundError("No AUTHORS file found!")
+
+        authors_file_content = authors_file.read_text("utf-8")
+        authors = re.findall(cls.parse_authors, authors_file_content)
+
+        return set(authors), authors_file.name
+
+    def validate(self, commit):
+        registered_authors, authors_file_name = Authors._read_authors_from_file(commit.message.context)
+
+        author = (commit.author_name, commit.author_email.lower())
+
+        if author not in registered_authors:
+            return [
+                RuleViolation(
+                    self.id,
+                    f"Author not in '{authors_file_name}' file: " f'"{commit.author_name} <{commit.author_email}>"',
+                )
+            ]
+        return []

--- a/gitlint-core/gitlint/contrib/rules/authors_commit.py
+++ b/gitlint-core/gitlint/contrib/rules/authors_commit.py
@@ -21,7 +21,7 @@ class Authors(CommitRule):
     @classmethod
     def _read_authors_from_file(cls, git_ctx) -> Tuple[str, str]:
         for file_name in cls.authors_file_names:
-            path = Path(git_ctx.repository_path / file_name)
+            path = Path(git_ctx.repository_path) / file_name
             if path.exists():
                 authors_file = path
                 break

--- a/gitlint-core/gitlint/contrib/rules/authors_commit.py
+++ b/gitlint-core/gitlint/contrib/rules/authors_commit.py
@@ -6,16 +6,14 @@ from typing import Tuple
 from gitlint.rules import CommitRule, RuleViolation
 
 
-class Authors(CommitRule):
+class AllowedAuthors(CommitRule):
     """Enforce that only authors listed in the AUTHORS file are allowed to commit."""
 
     authors_file_names = ("AUTHORS", "AUTHORS.txt", "AUTHORS.md")
     parse_authors = re.compile(r"^(?P<name>.*) <(?P<email>.*)>$", re.MULTILINE)
 
-    # A rule MUST have a human friendly name
-    name = "contrib-authors-commit"
+    name = "contrib-allowed-authors"
 
-    # A rule MUST have a *unique* id, we recommend starting with UC (for User-defined Commit-rule).
     id = "CC3"
 
     @classmethod
@@ -34,7 +32,7 @@ class Authors(CommitRule):
         return set(authors), authors_file.name
 
     def validate(self, commit):
-        registered_authors, authors_file_name = Authors._read_authors_from_file(commit.message.context)
+        registered_authors, authors_file_name = AllowedAuthors._read_authors_from_file(commit.message.context)
 
         author = (commit.author_name, commit.author_email.lower())
 

--- a/gitlint-core/gitlint/tests/contrib/rules/test_authors_commit.py
+++ b/gitlint-core/gitlint/tests/contrib/rules/test_authors_commit.py
@@ -1,88 +1,106 @@
 from collections import namedtuple
-from unittest.mock import Mock, patch
-
-import pytest
+from unittest.mock import patch
+from gitlint.tests.base import BaseTestCase
+from gitlint.rules import RuleViolation
+from gitlint.config import LintConfig
 
 from gitlint.contrib.rules.authors_commit import Authors
 
 
-Author = namedtuple("Author", "name, email")
-GitCtx = namedtuple("GitCtx", "repository_path")
-MockFile = namedtuple("MockFile", "name")
+class ContribAuthorsCommitTests(BaseTestCase):
+    def setUp(self):
+        author = namedtuple("Author", "name, email")
+        self.author_1 = author("John Doe", "john.doe@mail.com")
+        self.author_2 = author("Bob Smith", "bob.smith@mail.com")
+        self.rule = Authors()
+        self.gitcontext = self.get_gitcontext()
 
+    def get_gitcontext(self):
+        gitcontext = self.gitcontext(self.get_sample("commit_message/sample1"))
+        gitcontext.repository_path = self.get_sample_path("config")
+        return gitcontext
 
-@pytest.fixture(name="git_ctx")
-def gen_git_ctx(tmpdir):
-    authors_file = tmpdir / "AUTHORS"
-    authors_file.write_text("John Doe <john.doe@mail.com>\nBob Smith <bob.smith@mail.com>", "utf-8")
-    return GitCtx(tmpdir)
+    def get_commit(self, name, email):
+        commit = self.gitcommit("commit_message/sample1", author_name=name, author_email=email)
+        commit.message.context = self.gitcontext
+        return commit
 
+    def test_enable(self):
+        for rule_ref in ["CC3", "contrib-authors-commit"]:
+            config = LintConfig()
+            config.contrib = [rule_ref]
+            self.assertIn(Authors(), config.rules)
 
-AUTHOR_1 = Author("John Doe", "john.doe@mail.com")
-AUTHOR_2 = Author("Bob Smith", "bob.smith@mail.com")
+    def test_authors_succeeds(self):
+        for author in [self.author_1, self.author_2]:
+            commit = self.get_commit(author.name, author.email)
+            violations = self.rule.validate(commit)
+            self.assertListEqual([], violations)
 
+    def test_authors_email_is_case_insensitive(self):
+        for email in [
+            self.author_2.email.capitalize(),
+            self.author_2.email.lower(),
+            self.author_2.email.upper(),
+        ]:
+            commit = self.get_commit(self.author_2.name, email)
+            violations = self.rule.validate(commit)
+            self.assertListEqual([], violations)
 
-@pytest.mark.parametrize("author", [AUTHOR_1, AUTHOR_2])
-def test_authors_succeeds(author, git_ctx):
-    assert not validate_authors_rule(author.name, author.email, git_ctx)
+    def test_authors_name_is_case_sensitive(self):
+        for name in [self.author_2.name.lower(), self.author_2.name.upper()]:
+            commit = self.get_commit(name, self.author_2.email)
+            violations = self.rule.validate(commit)
+            expected_violation = RuleViolation(
+                "CC3",
+                f"Author not in 'AUTHORS' file: " f'"{name} <{self.author_2.email}>"',
+            )
+            self.assertListEqual([expected_violation], violations)
 
+    def test_authors_bad_name_fails(self):
+        for name in ["", "root"]:
+            commit = self.get_commit(name, self.author_2.email)
+            violations = self.rule.validate(commit)
+            expected_violation = RuleViolation(
+                "CC3",
+                f"Author not in 'AUTHORS' file: " f'"{name} <{self.author_2.email}>"',
+            )
+            self.assertListEqual([expected_violation], violations)
 
-@pytest.mark.parametrize(
-    "email",
-    [
-        AUTHOR_2.email.capitalize(),
-        AUTHOR_2.email.lower(),
-        AUTHOR_2.email.upper(),
-    ],
-)
-def test_authors_email_is_case_insensitive(email, git_ctx):
-    assert not validate_authors_rule(AUTHOR_2.name, email, git_ctx)
+    def test_authors_bad_email_fails(self):
+        for email in ["", "root@example.com"]:
+            commit = self.get_commit(self.author_2.name, email)
+            violations = self.rule.validate(commit)
+            expected_violation = RuleViolation(
+                "CC3",
+                f"Author not in 'AUTHORS' file: " f'"{self.author_2.name} <{email}>"',
+            )
+            self.assertListEqual([expected_violation], violations)
 
+    def test_authors_invalid_combination_fails(self):
+        commit = self.get_commit(self.author_1.name, self.author_2.email)
+        violations = self.rule.validate(commit)
+        expected_violation = RuleViolation(
+            "CC3",
+            f"Author not in 'AUTHORS' file: " f'"{self.author_1.name} <{self.author_2.email}>"',
+        )
+        self.assertListEqual([expected_violation], violations)
 
-@pytest.mark.parametrize("name", [AUTHOR_2.name.lower(), AUTHOR_2.name.upper()])
-def test_authors_name_is_case_sensitive(name, git_ctx):
-    assert validate_authors_rule(name, AUTHOR_2.email, git_ctx)
+    @patch(
+        "gitlint.contrib.rules.authors_commit.Path.read_text",
+        return_value="John Doe <john.doe@mail.com>",
+    )
+    def test_read_authors_file(self, _mock_read_text):
+        authors, authors_file_name = Authors._read_authors_from_file(self.gitcontext)
+        assert authors_file_name == "AUTHORS"
+        assert len(authors) == 1
+        assert authors == {self.author_1}
 
-
-@pytest.mark.parametrize("name", ["", "root"])
-def test_authors_bad_name_fails(name, git_ctx):
-    assert validate_authors_rule(name, AUTHOR_2.email, git_ctx)
-
-
-@pytest.mark.parametrize("email", ["", "root@example.com"])
-def test_authors_bad_email_fails(email, git_ctx):
-    assert validate_authors_rule(AUTHOR_2.name, email, git_ctx)
-
-
-def test_authors_invalid_combination_fails(git_ctx):
-    assert validate_authors_rule(AUTHOR_1.name, AUTHOR_2.email, git_ctx)
-
-
-def validate_authors_rule(name, email, git_ctx):
-    commit = Mock()
-    commit.author_name = name
-    commit.author_email = email
-    commit.message.context = git_ctx
-
-    rule = Authors()
-    return rule.validate(commit)
-
-
-@patch(
-    "gitlint.contrib.rules.authors_commit.Path.read_text",
-    return_value="John Doe <john.doe@mail.com>",
-)
-def test_read_authors_file(_mock_read_text, git_ctx):
-    authors, authors_file_name = Authors._read_authors_from_file(git_ctx)
-    assert authors_file_name == "AUTHORS"
-    assert len(authors) == 1
-    assert authors == {AUTHOR_1}
-
-
-@patch(
-    "gitlint.contrib.rules.authors_commit.Path.exists",
-    return_value=False,
-)
-def test_read_authors_file_missing_file(_mock_iterdir, git_ctx):
-    with pytest.raises(FileNotFoundError):
-        Authors._read_authors_from_file(git_ctx)
+    @patch(
+        "gitlint.contrib.rules.authors_commit.Path.exists",
+        return_value=False,
+    )
+    def test_read_authors_file_missing_file(self, _mock_iterdir):
+        with self.assertRaises(FileNotFoundError) as err:
+            Authors._read_authors_from_file(self.gitcontext)
+            self.assertEqual(err.exception.args[0], "AUTHORS file not found")

--- a/gitlint-core/gitlint/tests/contrib/rules/test_authors_commit.py
+++ b/gitlint-core/gitlint/tests/contrib/rules/test_authors_commit.py
@@ -4,7 +4,7 @@ from gitlint.tests.base import BaseTestCase
 from gitlint.rules import RuleViolation
 from gitlint.config import LintConfig
 
-from gitlint.contrib.rules.authors_commit import Authors
+from gitlint.contrib.rules.authors_commit import AllowedAuthors
 
 
 class ContribAuthorsCommitTests(BaseTestCase):
@@ -12,7 +12,7 @@ class ContribAuthorsCommitTests(BaseTestCase):
         author = namedtuple("Author", "name, email")
         self.author_1 = author("John Doe", "john.doe@mail.com")
         self.author_2 = author("Bob Smith", "bob.smith@mail.com")
-        self.rule = Authors()
+        self.rule = AllowedAuthors()
         self.gitcontext = self.get_gitcontext()
 
     def get_gitcontext(self):
@@ -26,10 +26,10 @@ class ContribAuthorsCommitTests(BaseTestCase):
         return commit
 
     def test_enable(self):
-        for rule_ref in ["CC3", "contrib-authors-commit"]:
+        for rule_ref in ["CC3", "contrib-allowed-authors"]:
             config = LintConfig()
             config.contrib = [rule_ref]
-            self.assertIn(Authors(), config.rules)
+            self.assertIn(AllowedAuthors(), config.rules)
 
     def test_authors_succeeds(self):
         for author in [self.author_1, self.author_2]:
@@ -91,10 +91,10 @@ class ContribAuthorsCommitTests(BaseTestCase):
         return_value="John Doe <john.doe@mail.com>",
     )
     def test_read_authors_file(self, _mock_read_text):
-        authors, authors_file_name = Authors._read_authors_from_file(self.gitcontext)
-        assert authors_file_name == "AUTHORS"
-        assert len(authors) == 1
-        assert authors == {self.author_1}
+        authors, authors_file_name = AllowedAuthors._read_authors_from_file(self.gitcontext)
+        self.assertEqual(authors_file_name, "AUTHORS")
+        self.assertEqual(len(authors), 1)
+        self.assertEqual(authors, {self.author_1})
 
     @patch(
         "gitlint.contrib.rules.authors_commit.Path.exists",
@@ -102,5 +102,5 @@ class ContribAuthorsCommitTests(BaseTestCase):
     )
     def test_read_authors_file_missing_file(self, _mock_iterdir):
         with self.assertRaises(FileNotFoundError) as err:
-            Authors._read_authors_from_file(self.gitcontext)
+            AllowedAuthors._read_authors_from_file(self.gitcontext)
             self.assertEqual(err.exception.args[0], "AUTHORS file not found")

--- a/gitlint-core/gitlint/tests/contrib/rules/test_authors_commit.py
+++ b/gitlint-core/gitlint/tests/contrib/rules/test_authors_commit.py
@@ -1,0 +1,88 @@
+from collections import namedtuple
+from unittest.mock import Mock, patch
+
+import pytest
+
+from gitlint.contrib.rules.authors_commit import Authors
+
+
+Author = namedtuple("Author", "name, email")
+GitCtx = namedtuple("GitCtx", "repository_path")
+MockFile = namedtuple("MockFile", "name")
+
+
+@pytest.fixture(name="git_ctx")
+def gen_git_ctx(tmpdir):
+    authors_file = tmpdir / "AUTHORS"
+    authors_file.write_text("John Doe <john.doe@mail.com>\nBob Smith <bob.smith@mail.com>", "utf-8")
+    return GitCtx(tmpdir)
+
+
+AUTHOR_1 = Author("John Doe", "john.doe@mail.com")
+AUTHOR_2 = Author("Bob Smith", "bob.smith@mail.com")
+
+
+@pytest.mark.parametrize("author", [AUTHOR_1, AUTHOR_2])
+def test_authors_succeeds(author, git_ctx):
+    assert not validate_authors_rule(author.name, author.email, git_ctx)
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        AUTHOR_2.email.capitalize(),
+        AUTHOR_2.email.lower(),
+        AUTHOR_2.email.upper(),
+    ],
+)
+def test_authors_email_is_case_insensitive(email, git_ctx):
+    assert not validate_authors_rule(AUTHOR_2.name, email, git_ctx)
+
+
+@pytest.mark.parametrize("name", [AUTHOR_2.name.lower(), AUTHOR_2.name.upper()])
+def test_authors_name_is_case_sensitive(name, git_ctx):
+    assert validate_authors_rule(name, AUTHOR_2.email, git_ctx)
+
+
+@pytest.mark.parametrize("name", ["", "root"])
+def test_authors_bad_name_fails(name, git_ctx):
+    assert validate_authors_rule(name, AUTHOR_2.email, git_ctx)
+
+
+@pytest.mark.parametrize("email", ["", "root@example.com"])
+def test_authors_bad_email_fails(email, git_ctx):
+    assert validate_authors_rule(AUTHOR_2.name, email, git_ctx)
+
+
+def test_authors_invalid_combination_fails(git_ctx):
+    assert validate_authors_rule(AUTHOR_1.name, AUTHOR_2.email, git_ctx)
+
+
+def validate_authors_rule(name, email, git_ctx):
+    commit = Mock()
+    commit.author_name = name
+    commit.author_email = email
+    commit.message.context = git_ctx
+
+    rule = Authors()
+    return rule.validate(commit)
+
+
+@patch(
+    "gitlint.contrib.rules.authors_commit.Path.read_text",
+    return_value="John Doe <john.doe@mail.com>",
+)
+def test_read_authors_file(_mock_read_text, git_ctx):
+    authors, authors_file_name = Authors._read_authors_from_file(git_ctx)
+    assert authors_file_name == "AUTHORS"
+    assert len(authors) == 1
+    assert authors == {AUTHOR_1}
+
+
+@patch(
+    "gitlint.contrib.rules.authors_commit.Path.exists",
+    return_value=False,
+)
+def test_read_authors_file_missing_file(_mock_iterdir, git_ctx):
+    with pytest.raises(FileNotFoundError):
+        Authors._read_authors_from_file(git_ctx)

--- a/gitlint-core/gitlint/tests/samples/config/AUTHORS
+++ b/gitlint-core/gitlint/tests/samples/config/AUTHORS
@@ -1,0 +1,2 @@
+John Doe <john.doe@mail.com>
+Bob Smith <bob.smith@mail.com>


### PR DESCRIPTION
It is possible to manage a so-called [AUTHORS](https://opensource.google/documentation/reference/releasing/authors) file in the repository. In this file, all committers for the respective project are listed.
With this `gitlint` rule, it can be ensured that only people who are listed in the AUTHORS file can commit.