### PR TITLE
Dockerfile: add /repo as safe git repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ ARG GITLINT_VERSION
 RUN apk add git
 RUN pip install gitlint==$GITLINT_VERSION
 
+RUN git config --global --add safe.directory /repo
 ENTRYPOINT ["gitlint", "--target", "/repo"]


### PR DESCRIPTION
This is required for git=>2.35.2 (Fix for CVE-2022-24765).

This fixes #365