### PR TITLE
Dependabot: also monitor gitlint-core

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: pip
+    directory: /gitlint-core
+    schedule:
+      interval: daily


### PR DESCRIPTION
Previously, dependabot only monitored top-level gitlint dependencies, but
not gitlint-core dependencies.
