### PR TITLE
CI: only run on PR and push to main

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,14 @@
 name: Tests and Checks
 
-on: [push, pull_request]
+# Only run CI on pushes to main and pull requests
+# We don't run CI on other branches, but those should be merged into main via a PR anyways which will trigger CI before the merge.
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
   checks:


### PR DESCRIPTION
This avoids running jobs twice and unneccessarily running gitlint
against in-progress work.
