### PR TITLE
gitlint: ignore dependabot Co-authored-by lines

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,7 @@
+[general]
+# See https://jorisroovers.com/gitlint/configuration/#regex-style-search
+regex-style-search=True
+
+# Dependabot tends to generate "Co-authored-by" lines that exceed the default 80 char limit. Ignore those.
+[ignore-body-lines]
+regex=^Co-authored-by: dependabot


### PR DESCRIPTION
Dependabot tends to generate "Co-authored-by" lines that exceed the default
80 char limit. Ignore those lines in commit messages.
