### PR TITLE
Introduce a gate/check GHA job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -161,3 +161,18 @@ jobs:
       - name: Gitlint check
         run: gitlint --debug
         if: ${{ github.event_name	!= 'pull_request' }}
+
+  check:  # This job does nothing and is only used for the branch protection
+    if: always()  # Ref: https://github.com/marketplace/actions/alls-green#why
+
+    needs:
+      - checks
+      - windows-checks
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This adds a GHA job that reliably determines if all the required dependencies have succeeded or not.

It also allows to reduce the list of required branch protection CI statuses to just one — `check`. This reduces the maintenance burden by a lot and have been battle-tested across a small bunch of projects in its action form and in-house implementations of other people.

It is now in use in aiohttp (and other aio-libs projects), CherryPy, attrs, coveragepy, conda some of the Ansible repositories, pip-tools, pydantic, spaceship-prompt, Towncrier, all of the jaraco's projects (like `setuptools`, `importlib_metadata`), some PyCQA, PyCA, PyPA and pytest projects, a few AWS Labs projects.

The story behind this is explained in more detail at https://github.com/marketplace/actions/alls-green#why.
