### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", pypy-3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", pypy-3.9]
         os: ["macos-latest", "ubuntu-latest"]
     steps:
       - uses: actions/checkout@v3.0.2

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Great for use as a [commit-msg git hook](#using-gitlint-as-a-commit-msg-hook) or
 
 
 !!! important
-    **Gitlint no longer supports Python 2.7 and Python 3.5 as they [have reached End-Of-Life](https://endoflife.date/python). The last gitlint version to support Python 2.7 and Python 3.5 is `0.14.0` (released on October 24th, 2020).**
+    **Gitlint requires Python 3.7 (or above). For Python 2.7 and Python 3.5 use `gitlint==0.14.0` (released 2020-10-24), for Python 3.6 `gitlint==0.18.0` (released 2022-11-16).**
 
 ## Features
  - **Commit message hook**: [Auto-trigger validations against new commit message right when you're committing](#using-gitlint-as-a-commit-msg-hook). Also [works with pre-commit](#using-gitlint-through-pre-commit).

--- a/gitlint-core/setup.py
+++ b/gitlint-core/setup.py
@@ -44,7 +44,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -58,7 +57,7 @@ setup(
         "Topic :: Software Development :: Testing",
         "License :: OSI Approved :: MIT License",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "Click>=8",
         "arrow>=1",
@@ -87,15 +86,6 @@ setup(
         ],
     },
 )
-
-# Print a red deprecation warning for python < 3.6 users
-if sys.version_info[:2] < (3, 6):
-    msg = (
-        "\033[31mDEPRECATION: You're using a python version that has reached end-of-life. "
-        + "Gitlint does not support Python < 3.6"
-        + "Please upgrade your Python to 3.6 or above.\033[0m"
-    )
-    print(msg)
 
 # Print a warning message for Windows users
 PLATFORM_IS_WINDOWS = "windows" in platform.system().lower()

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -48,7 +47,7 @@ setup(
         "Topic :: Software Development :: Testing",
         "License :: OSI Approved :: MIT License",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "gitlint-core[trusted-deps]==" + version,
     ],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,10 +1,8 @@
 black==22.8.0
-coverage==6.2; python_version == '3.6'
-coverage==6.4.4; python_version != '3.6'
+coverage==6.4.4
 python-coveralls==2.9.3
 radon==5.1.0
 pytest==7.0.1
-pylint==2.13.7; python_version == '3.6'
-pylint==2.15.3; python_version != '3.6'
+pylint==2.15.3;
 pdbr==0.6.6; sys_platform != "win32"
 -r requirements.txt


### PR DESCRIPTION
Bumped minimal python version in setup.py to 3.7.

Updated docs and test-requirements.txt accordingly.

