### PR TITLE
Ignore dependabot commits entirely

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -2,6 +2,7 @@
 # See https://jorisroovers.com/gitlint/configuration/#regex-style-search
 regex-style-search=True
 
-# Dependabot tends to generate "Co-authored-by" lines that exceed the default 80 char limit. Ignore those.
-[ignore-body-lines]
+# Dependabot tends to generate lines that exceed the default 80 char limit.
+# Ignore those commits.
+[ignore-by-body]
 regex=^Co-authored-by: dependabot

--- a/.gitlint
+++ b/.gitlint
@@ -3,6 +3,7 @@
 regex-style-search=True
 
 # Dependabot tends to generate lines that exceed the default 80 char limit.
-# Ignore those commits.
-[ignore-by-body]
-regex=^Co-authored-by: dependabot
+[ignore-by-author-name]
+regex=dependabot
+ignore=all
+


### PR DESCRIPTION
We were only ignoring Co-authored-by lines for dependabot commits
before, but that sometimes still causes gitlint violations on other lines.

With this changes, we're ignore the entire commit message for commits
generated by dependabot.

