### PR TITLE
Docs: Remove experimental wording for Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PyPi Package](https://img.shields.io/pypi/v/gitlint.png)](https://pypi.python.org/pypi/gitlint)
 ![Supported Python Versions](https://img.shields.io/pypi/pyversions/gitlint.svg)
 
-Git commit message linter written in python (for Linux and Mac, experimental on Windows), checks your commit messages for style.
+Git commit message linter written in python, checks your commit messages for style.
 
 **See [jorisroovers.github.io/gitlint](http://jorisroovers.github.io/gitlint/) for full documentation.**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Great for use as a [commit-msg git hook](#using-gitlint-as-a-commit-msg-hook) or
 <script type="text/javascript" src="https://asciinema.org/a/30477.js" id="asciicast-30477" async></script>
 
 !!! note
-    **Gitlint support for Windows is experimental**, and [there are some known issues](https://github.com/jorisroovers/gitlint/issues?q=is%3Aissue+is%3Aopen+label%3Awindows).
+    **Gitlint works on Windows**, but [there are some known issues](https://github.com/jorisroovers/gitlint/issues?q=is%3Aissue+is%3Aopen+label%3Awindows).
 
     Also, gitlint is not the only git commit message linter out there, if you are looking for an alternative written in a different language,
     have a look at [fit-commit](https://github.com/m1foley/fit-commit) (Ruby),


### PR DESCRIPTION
Gitlint has run well on Windows for years now, eventhough we still have
some unicode issues to resolve.
