### PR TITLE
cli: Allow for a single commit in the --commits cmd-line param

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -324,6 +324,8 @@ gitlint --commits "origin..HEAD"
 gitlint --commits 019cf40,c50eb150,d6bc75a
 # These can include special references as well
 gitlint --commits HEAD~1,mybranch-name,origin/main,d6bc75a
+# You can also lint a single commit with --commits:
+gitling --commits 019cf40,
 ```
 
 The `--commits` flag takes a **single** refspec argument or commit range. Basically, any range that is understood
@@ -332,6 +334,7 @@ by [git rev-list](https://git-scm.com/docs/git-rev-list) as a single argument wi
 Alternatively, you can pass `--commits` a comma-separated list of commit hashes (both short and full-length SHAs work,
 as well as special references such as `HEAD` and branch names).
 Gitlint will treat these as pointers to **single** commits and lint these in the order you passed.
+`--commits` also accepts a single commit SHA with a trailing comma. 
 
 For cases where the `--commits` option doesn't provide the flexibility you need, you can always use a simple shell
 script to lint an arbitrary set of commits, like shown in the example below.

--- a/gitlint-core/gitlint/cli.py
+++ b/gitlint-core/gitlint/cli.py
@@ -205,7 +205,7 @@ def build_git_context(lint_config, msg_filename, commit_hash, refspec):
     if refspec:
         # 3.1.1 Not real refspec, but comma-separated list of commit hashes
         if "," in refspec:
-            commit_hashes = [hash.strip() for hash in refspec.split(",")]
+            commit_hashes = [hash.strip() for hash in refspec.split(",") if hash]
             return GitContext.from_local_repository(lint_config.target, commit_hashes=commit_hashes)
         # 3.1.2 Real refspec
         return GitContext.from_local_repository(lint_config.target, refspec=refspec)

--- a/qa/test_commits.py
+++ b/qa/test_commits.py
@@ -110,6 +110,11 @@ class CommitsTests(BaseTestCase):
         self.assertEqual(output.exit_code, 2)
         self.assertEqualStdout(output, expected)
 
+        # Lint using --commits <commit sha>,
+        output = gitlint("--commits", f"{commit_sha},", _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[2])
+        self.assertEqual(output.exit_code, 2)
+        self.assertEqualStdout(output, expected)
+
         # Lint a single commit using --commits <refspec> pointing to the single commit
         output = gitlint("--commits", refspec, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[2])
         self.assertEqual(output.exit_code, 2)


### PR DESCRIPTION
In order to avoid applications needing to select between `--commit` and `--commits` based on the number of commits, allow for providing a single commit with `--commits` in the format:

```
$ gitlint --commits <sha>,
```

The trailing comma ensures that gitlint knows this is a commit list and not a refspec.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>