### PR TITLE
GHA: Publish release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,46 @@
+name: Publish Release
+run-name: "Publish Release"
+on:
+  workflow_dispatch:
+    inputs:
+      pypi_target:
+        description: "PyPI repository to publish to"
+        required: true
+        type: choice
+        options:
+          - "test.pypi.org"
+        default: "test.pypi.org"
+      repo_release_ref:
+        description: "Gitlint git reference to publish release for"
+        default: "main"
+
+jobs:
+  checks:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Setup python
+        uses: actions/setup-python@v4.5.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Hatch
+        run: python -m pip install hatch==1.6.3
+
+      - uses: actions/checkout@v3.3.0
+        with:
+          ref: ${{ inputs.repo_release_ref }}
+
+      - name: Set SETUPTOOLS_SCM_PRETEND_VERSION
+        run: echo "SETUPTOOLS_SCM_PRETEND_VERSION=$(hatch version | cut -d+ -f1)" >> $GITHUB_ENV
+
+      - name: Test SETUPTOOLS_SCM_PRETEND_VERSION
+        run: echo $SETUPTOOLS_SCM_PRETEND_VERSION
+
+      - name: Build (gitlint-core)
+        run: |
+          hatch build
+        working-directory: ./gitlint-core
+
+      - name: Build (gitlint)
+        run: |
+          hatch build

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,5 +1,5 @@
-name: Release testing
-run-name: "Release testing (${{ inputs.gitlint_version }}, pypi_source=${{ inputs.pypi_source }}, test_repo_ref=${{ inputs.test_repo_ref }})"
+name: Test release
+run-name: "Test release (${{ inputs.gitlint_version }}, pypi_source=${{ inputs.pypi_source }}, repo_test_ref=${{ inputs.repo_test_ref }})"
 on:
   workflow_dispatch:
     inputs:
@@ -15,7 +15,7 @@ on:
           - "pypi.org"
           - "test.pypi.org"
         default: "pypi.org"
-      test_repo_ref:
+      repo_test_ref:
         description: "Git reference to checkout for integration tests"
         default: "main"
 
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/checkout@v3.3.0
         with:
-          ref: ${{ inputs.test_repo_ref }}
+          ref: ${{ inputs.repo_test_ref }}
 
       - name: Install Hatch
         run: python -m pip install hatch==1.6.3


### PR DESCRIPTION
Currently only builds packages, follow-up will also publish to test.pypi.org.

Also renames the Test Release workflow (and some vars in it).

