### PR TITLE
GHA: Publish release to test.pypi.org on demand

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -32,7 +32,9 @@ jobs:
           fetch-depth: 0 # checkout all history, needed for hatch versioning
 
       - name: Set SETUPTOOLS_SCM_PRETEND_VERSION
-        run: echo "SETUPTOOLS_SCM_PRETEND_VERSION=$(hatch version | cut -d+ -f1)" >> $GITHUB_ENV
+        run: |
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=$(hatch version | cut -d+ -f1)"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=$(hatch version | cut -d+ -f1)" >> $GITHUB_ENV
 
       - name: Test SETUPTOOLS_SCM_PRETEND_VERSION
         run: echo $SETUPTOOLS_SCM_PRETEND_VERSION

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4.5.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
 
       - name: Install Hatch
         run: python -m pip install hatch==1.6.3
@@ -31,16 +31,25 @@ jobs:
           ref: ${{ inputs.repo_release_ref }}
           fetch-depth: 0 # checkout all history, needed for hatch versioning
 
+      # Create hatch env explicitly to avoid hatch output ("Setting up build environment for missing dependencies")
+      # during the next step (hatch version)
       - name: Hatch env create
         run: hatch env create
 
+      # Hatch versioning is based on git (using hatch-vcs). If there is no explicit tag for the commit we're trying to
+      # publish, hatch versioning strings will have this format: 0.19.0.dev52+g9f7dc7d
+      # With the string after '+' being the 'g<short-sha>' of the commit.
+      #
+      # However, PyPI doesn't allow '+' in version numbers (=no PEP440 local versions allowed on PyPI).
+      # To work around this, we override the version string by setting the SETUPTOOLS_SCM_PRETEND_VERSION env var
+      # to the version string without the '+' and everything after it.
+      # We then only actual publish such releases on the main branch to guarantee the dev numbering scheme remains
+      # unique.
+      # Note that when a tag *is* present (i.e. v0.19.0), hatch versioning will return the tag name (i.e. 0.19.0)
+      # and this step has no effect, ie. SETUPTOOLS_SCM_PRETEND_VERSION will be the same as `hatch version`.
       - name: Set SETUPTOOLS_SCM_PRETEND_VERSION
         run: |
-          echo "SETUPTOOLS_SCM_PRETEND_VERSION=$(hatch version | cut -d+ -f1)"
           echo "SETUPTOOLS_SCM_PRETEND_VERSION=$(hatch version | cut -d+ -f1)" >> $GITHUB_ENV
-
-      - name: Test SETUPTOOLS_SCM_PRETEND_VERSION
-        run: echo $SETUPTOOLS_SCM_PRETEND_VERSION
 
       - name: Build (gitlint-core)
         run: hatch build
@@ -48,3 +57,18 @@ jobs:
 
       - name: Build (gitlint)
         run: hatch build
+
+      - name: Publish (gitlint-core)
+        run: hatch publish -r test
+        working-directory: ./gitlint-core
+        env:
+          HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_GITLINT_CORE_USERNAME }}
+          HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_CORE_PASSWORD }}
+        if: inputs.pypi_target == 'test.pypi.org' && inputs.repo_release_ref == 'main'
+
+      - name: Publish (gitlint)
+        run: hatch publish -r test
+        env:
+          HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_GITLINT_CORE_USERNAME }}
+          HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_CORE_PASSWORD }}
+        if: inputs.pypi_target == 'test.pypi.org' && inputs.repo_release_ref == 'main'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,7 @@ on:
         default: "main"
 
 jobs:
-  checks:
+  publish:
     runs-on: "ubuntu-latest"
     steps:
       - name: Setup python
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v3.3.0
         with:
           ref: ${{ inputs.repo_release_ref }}
+          fetch-depth: 0 # checkout all history, needed for hatch versioning
 
       - name: Set SETUPTOOLS_SCM_PRETEND_VERSION
         run: echo "SETUPTOOLS_SCM_PRETEND_VERSION=$(hatch version | cut -d+ -f1)" >> $GITHUB_ENV

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,6 +31,9 @@ jobs:
           ref: ${{ inputs.repo_release_ref }}
           fetch-depth: 0 # checkout all history, needed for hatch versioning
 
+      - name: Hatch env create
+        run: hatch env create
+
       - name: Set SETUPTOOLS_SCM_PRETEND_VERSION
         run: |
           echo "SETUPTOOLS_SCM_PRETEND_VERSION=$(hatch version | cut -d+ -f1)"
@@ -40,10 +43,8 @@ jobs:
         run: echo $SETUPTOOLS_SCM_PRETEND_VERSION
 
       - name: Build (gitlint-core)
-        run: |
-          hatch build
+        run: hatch build
         working-directory: ./gitlint-core
 
       - name: Build (gitlint)
-        run: |
-          hatch build
+        run: hatch build

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0 # checkout all history, needed for hatch versioning
 
       # Run hatch version once to avoid additional output ("Setting up build environment for missing dependencies")
-      # during the next step (hatch version)
+      # during the next step
       - name: Hatch version
         run: hatch version
 
@@ -40,7 +40,7 @@ jobs:
       # publish, hatch versioning strings will have this format: 0.19.0.dev52+g9f7dc7d
       # With the string after '+' being the 'g<short-sha>' of the commit.
       #
-      # However, PyPI doesn't allow '+' in version numbers (=no PEP440 local versions allowed on PyPI).
+      # However, PyPI doesn't allow '+' in version numbers (no PEP440 local versions allowed on PyPI).
       # To work around this, we override the version string by setting the SETUPTOOLS_SCM_PRETEND_VERSION env var
       # to the version string without the '+' and everything after it.
       # We then only actual publish such releases on the main branch to guarantee the dev numbering scheme remains

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,10 +31,10 @@ jobs:
           ref: ${{ inputs.repo_release_ref }}
           fetch-depth: 0 # checkout all history, needed for hatch versioning
 
-      # Create hatch env explicitly to avoid hatch output ("Setting up build environment for missing dependencies")
+      # Run hatch version once to avoid additional output ("Setting up build environment for missing dependencies")
       # during the next step (hatch version)
-      - name: Hatch env create
-        run: hatch env create
+      - name: Hatch version
+        run: hatch version
 
       # Hatch versioning is based on git (using hatch-vcs). If there is no explicit tag for the commit we're trying to
       # publish, hatch versioning strings will have this format: 0.19.0.dev52+g9f7dc7d
@@ -69,6 +69,6 @@ jobs:
       - name: Publish (gitlint)
         run: hatch publish -r test
         env:
-          HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_GITLINT_CORE_USERNAME }}
-          HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_CORE_PASSWORD }}
+          HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_GITLINT_USERNAME }}
+          HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_PASSWORD }}
         if: inputs.pypi_target == 'test.pypi.org' && inputs.repo_release_ref == 'main'

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,5 +1,5 @@
-name: Test release
-run-name: "Test release (${{ inputs.gitlint_version }}, pypi_source=${{ inputs.pypi_source }}, repo_test_ref=${{ inputs.repo_test_ref }})"
+name: Test Release
+run-name: "Test Release (${{ inputs.gitlint_version }}, pypi_source=${{ inputs.pypi_source }}, repo_test_ref=${{ inputs.repo_test_ref }})"
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Allow for on-demand publishing of the main branch to test.pypi.org.

