### PR TITLE
Add missing metadata hook config in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ source = "vcs"
 [tool.hatch.build]
 exclude = ["*"]
 
+# Use metadata hooks specified in 'hatch_build.py'
+# (this line is critical when building wheels, when building sdist it seems optional)
+[tool.hatch.metadata.hooks.custom]
+
 # Environments #########################################################################################################
 # NOTE: By default all environments inherit from the 'default' environment
 


### PR DESCRIPTION
Without this line, the gitlint wheel is missing it's dependency on
gitlint-core.
