### PR TITLE
GHA: Call test-release after publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -73,13 +73,19 @@ jobs:
       #     HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_PASSWORD }}
       #   if: inputs.pypi_target == 'test.pypi.org' && inputs.repo_release_ref == 'main'
 
-  test_release:
+  check_env:
     needs:
       - publish
     steps:
-      - name: Test release
-        uses: jorisroovers/gitlint/.github/workflows/test-release.yml@main
-        with:
-          gitlint_version: "0.19.0.dev51"
-          pypi_source: ${{ inputs.pypi_target }}
-          repo_test_ref: ${{ inputs.repo_release_ref }}
+      - name: Print SETUPTOOLS_SCM_PRETEND_VERSION
+        run: |
+          echo "$SETUPTOOLS_SCM_PRETEND_VERSION"
+
+  test_release:
+    needs:
+      - publish
+    uses: jorisroovers/gitlint/.github/workflows/test-release.yml@main
+    with:
+      gitlint_version: "0.19.0.dev51"
+      pypi_source: ${{ inputs.pypi_target }}
+      repo_test_ref: ${{ inputs.repo_release_ref }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -58,20 +58,20 @@ jobs:
       - name: Build (gitlint)
         run: hatch build
 
-      # - name: Publish (gitlint-core)
-      #   run: hatch publish -r test
-      #   working-directory: ./gitlint-core
-      #   env:
-      #     HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_GITLINT_CORE_USERNAME }}
-      #     HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_CORE_PASSWORD }}
-      #   if: inputs.pypi_target == 'test.pypi.org' && inputs.repo_release_ref == 'main'
+      - name: Publish (gitlint-core)
+        run: hatch publish -r test
+        working-directory: ./gitlint-core
+        env:
+          HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_GITLINT_CORE_USERNAME }}
+          HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_CORE_PASSWORD }}
+        if: inputs.pypi_target == 'test.pypi.org' && inputs.repo_release_ref == 'main'
 
-      # - name: Publish (gitlint)
-      #   run: hatch publish -r test
-      #   env:
-      #     HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_GITLINT_USERNAME }}
-      #     HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_PASSWORD }}
-      #   if: inputs.pypi_target == 'test.pypi.org' && inputs.repo_release_ref == 'main'
+      - name: Publish (gitlint)
+        run: hatch publish -r test
+        env:
+          HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_GITLINT_USERNAME }}
+          HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_PASSWORD }}
+        if: inputs.pypi_target == 'test.pypi.org' && inputs.repo_release_ref == 'main'
 
   check_env:
     needs:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -58,17 +58,28 @@ jobs:
       - name: Build (gitlint)
         run: hatch build
 
-      - name: Publish (gitlint-core)
-        run: hatch publish -r test
-        working-directory: ./gitlint-core
-        env:
-          HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_GITLINT_CORE_USERNAME }}
-          HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_CORE_PASSWORD }}
-        if: inputs.pypi_target == 'test.pypi.org' && inputs.repo_release_ref == 'main'
+      # - name: Publish (gitlint-core)
+      #   run: hatch publish -r test
+      #   working-directory: ./gitlint-core
+      #   env:
+      #     HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_GITLINT_CORE_USERNAME }}
+      #     HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_CORE_PASSWORD }}
+      #   if: inputs.pypi_target == 'test.pypi.org' && inputs.repo_release_ref == 'main'
 
-      - name: Publish (gitlint)
-        run: hatch publish -r test
-        env:
-          HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_GITLINT_USERNAME }}
-          HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_PASSWORD }}
-        if: inputs.pypi_target == 'test.pypi.org' && inputs.repo_release_ref == 'main'
+      # - name: Publish (gitlint)
+      #   run: hatch publish -r test
+      #   env:
+      #     HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_GITLINT_USERNAME }}
+      #     HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_PASSWORD }}
+      #   if: inputs.pypi_target == 'test.pypi.org' && inputs.repo_release_ref == 'main'
+
+  test_release:
+    needs:
+      - publish
+    steps:
+      - name: Test release
+        uses: jorisroovers/gitlint/.github/workflows/test-release.yml@main
+        with:
+          gitlint_version: "0.19.0.dev51"
+          pypi_source: ${{ inputs.pypi_target }}
+          repo_test_ref: ${{ inputs.repo_release_ref }}

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,6 +1,23 @@
 name: Test Release
 run-name: "Test Release (${{ inputs.gitlint_version }}, pypi_source=${{ inputs.pypi_source }}, repo_test_ref=${{ inputs.repo_test_ref }})"
 on:
+  workflow_call:
+    inputs:
+      gitlint_version:
+        description: "Gitlint version to test"
+        required: true
+        default: "0.18.0"
+      pypi_source:
+        description: "PyPI repository to use"
+        required: true
+        type: choice
+        options:
+          - "pypi.org"
+          - "test.pypi.org"
+        default: "pypi.org"
+      repo_test_ref:
+        description: "Git reference to checkout for integration tests"
+        default: "main"
   workflow_dispatch:
     inputs:
       gitlint_version:


### PR DESCRIPTION
Automatically run integration tests on newly released packages.
