### PR TITLE
Debug: Rename DEFAULT_ENCODING to TERMINAL_ENCODING, add FILE_ENCODING

### DIFF
--- a/gitlint-core/gitlint/cli.py
+++ b/gitlint-core/gitlint/cli.py
@@ -68,7 +68,8 @@ def log_system_info():
     LOG.debug("Git version: %s", git_version())
     LOG.debug("Gitlint version: %s", gitlint.__version__)
     LOG.debug("GITLINT_USE_SH_LIB: %s", os.environ.get("GITLINT_USE_SH_LIB", "[NOT SET]"))
-    LOG.debug("DEFAULT_ENCODING: %s", gitlint.utils.TERMINAL_ENCODING)
+    LOG.debug("TERMINAL_ENCODING: %s", gitlint.utils.TERMINAL_ENCODING)
+    LOG.debug("FILE_ENCODING: %s", gitlint.utils.FILE_ENCODING)
 
 
 def build_config(

--- a/gitlint-core/gitlint/tests/cli/test_cli.py
+++ b/gitlint-core/gitlint/tests/cli/test_cli.py
@@ -39,7 +39,8 @@ class CLITests(BaseTestCase):
             "gitlint_version": __version__,
             "GITLINT_USE_SH_LIB": BaseTestCase.GITLINT_USE_SH_LIB,
             "target": os.path.realpath(os.getcwd()),
-            "DEFAULT_ENCODING": TERMINAL_ENCODING,
+            "TERMINAL_ENCODING": TERMINAL_ENCODING,
+            "FILE_ENCODING": FILE_ENCODING,
         }
 
     def test_version(self):

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
@@ -4,7 +4,8 @@ DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.cli Git version: git version 1.2.3
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli DEFAULT_ENCODING: {DEFAULT_ENCODING}
+DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
+DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: {config_path}
 [GENERAL]

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
@@ -4,7 +4,8 @@ DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.cli Git version: git version 1.2.3
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli DEFAULT_ENCODING: {DEFAULT_ENCODING}
+DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
+DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: None
 [GENERAL]

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
@@ -4,7 +4,8 @@ DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.cli Git version: git version 1.2.3
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli DEFAULT_ENCODING: {DEFAULT_ENCODING}
+DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
+DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: None
 [GENERAL]

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
@@ -4,7 +4,8 @@ DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.cli Git version: git version 1.2.3
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli DEFAULT_ENCODING: {DEFAULT_ENCODING}
+DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
+DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: None
 [GENERAL]

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
@@ -4,7 +4,8 @@ DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.cli Git version: git version 1.2.3
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli DEFAULT_ENCODING: {DEFAULT_ENCODING}
+DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
+DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: {config_path}
 [GENERAL]

--- a/qa/base.py
+++ b/qa/base.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import arrow
 
 from qa.shell import RunningCommand, git, gitlint
-from qa.utils import DEFAULT_ENCODING, FILE_ENCODING, PLATFORM_IS_WINDOWS
+from qa.utils import FILE_ENCODING, PLATFORM_IS_WINDOWS, TERMINAL_ENCODING
 
 
 class BaseTestCase(TestCase):
@@ -41,7 +41,7 @@ class BaseTestCase(TestCase):
 
     def assertEqualStdout(self, output, expected):
         self.assertIsInstance(output, RunningCommand)
-        output = output.stdout.decode(DEFAULT_ENCODING)
+        output = output.stdout.decode(TERMINAL_ENCODING)
         output = output.replace("\r", "")
         self.assertMultiLineEqual(output, expected)
 
@@ -196,7 +196,8 @@ class BaseTestCase(TestCase):
             "git_version": expected_git_version,
             "gitlint_version": expected_gitlint_version,
             "GITLINT_USE_SH_LIB": BaseTestCase.GITLINT_USE_SH_LIB,
-            "DEFAULT_ENCODING": DEFAULT_ENCODING,
+            "TERMINAL_ENCODING": TERMINAL_ENCODING,
+            "FILE_ENCODING": FILE_ENCODING,
         }
 
     def get_debug_vars_last_commit(self, git_repo=None):

--- a/qa/expected/test_commits/test_lint_staged_msg_filename_1
+++ b/qa/expected/test_commits/test_lint_staged_msg_filename_1
@@ -5,7 +5,8 @@ DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli DEFAULT_ENCODING: UTF-8
+DEBUG: gitlint.cli TERMINAL_ENCODING: UTF-8
+DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: None
 [GENERAL]

--- a/qa/expected/test_commits/test_lint_staged_stdin_1
+++ b/qa/expected/test_commits/test_lint_staged_stdin_1
@@ -5,7 +5,8 @@ DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli DEFAULT_ENCODING: {DEFAULT_ENCODING}
+DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
+DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: None
 [GENERAL]

--- a/qa/expected/test_config/test_config_from_env_1
+++ b/qa/expected/test_config/test_config_from_env_1
@@ -5,7 +5,8 @@ DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli DEFAULT_ENCODING: UTF-8
+DEBUG: gitlint.cli TERMINAL_ENCODING: UTF-8
+DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: None
 [GENERAL]

--- a/qa/expected/test_config/test_config_from_env_2
+++ b/qa/expected/test_config/test_config_from_env_2
@@ -5,7 +5,8 @@ DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli DEFAULT_ENCODING: UTF-8
+DEBUG: gitlint.cli TERMINAL_ENCODING: UTF-8
+DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: None
 [GENERAL]

--- a/qa/expected/test_config/test_config_from_file_debug_1
+++ b/qa/expected/test_config/test_config_from_file_debug_1
@@ -5,7 +5,8 @@ DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli DEFAULT_ENCODING: UTF-8
+DEBUG: gitlint.cli TERMINAL_ENCODING: UTF-8
+DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: {config_path}
 [GENERAL]

--- a/qa/expected/test_gitlint/test_commit_binary_file_1
+++ b/qa/expected/test_gitlint/test_commit_binary_file_1
@@ -5,7 +5,8 @@ DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli DEFAULT_ENCODING: UTF-8
+DEBUG: gitlint.cli TERMINAL_ENCODING: UTF-8
+DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: None
 [GENERAL]

--- a/qa/shell.py
+++ b/qa/shell.py
@@ -3,7 +3,7 @@
 
 import subprocess
 
-from qa.utils import DEFAULT_ENCODING, USE_SH_LIB
+from qa.utils import TERMINAL_ENCODING, USE_SH_LIB
 
 if USE_SH_LIB:
     from sh import (
@@ -41,7 +41,7 @@ else:
             self.exit_code = exitcode
 
         def __str__(self):
-            return self.stdout.decode(DEFAULT_ENCODING)
+            return self.stdout.decode(TERMINAL_ENCODING)
 
         def __unicode__(self):
             return self.stdout

--- a/qa/test_stdin.py
+++ b/qa/test_stdin.py
@@ -2,7 +2,7 @@ import subprocess
 
 from qa.base import BaseTestCase
 from qa.shell import echo, gitlint
-from qa.utils import DEFAULT_ENCODING, FILE_ENCODING
+from qa.utils import FILE_ENCODING, TERMINAL_ENCODING
 
 
 class StdInTests(BaseTestCase):
@@ -50,4 +50,4 @@ class StdInTests(BaseTestCase):
                 "gitlint", stdin=file_handle, cwd=self.tmp_git_repo, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
             ) as p:
                 output, _ = p.communicate()
-                self.assertEqual(output.decode(DEFAULT_ENCODING), self.get_expected("test_stdin/test_stdin_file_1"))
+                self.assertEqual(output.decode(TERMINAL_ENCODING), self.get_expected("test_stdin/test_stdin_file_1"))

--- a/qa/utils.py
+++ b/qa/utils.py
@@ -29,7 +29,8 @@ def use_sh_library():
 USE_SH_LIB = use_sh_library()
 
 ########################################################################################################################
-# DEFAULT_ENCODING
+# TERMINAL_ENCODING
+# Encoding for reading gitlint command output
 
 
 def getpreferredencoding():
@@ -37,7 +38,7 @@ def getpreferredencoding():
     return locale.getpreferredencoding() or "UTF-8"
 
 
-DEFAULT_ENCODING = getpreferredencoding()
+TERMINAL_ENCODING = getpreferredencoding()
 
 
 ########################################################################################################################


### PR DESCRIPTION
Renames DEFAULT_ENCODING to TERMINAL_ENCODING in the debug output.
Adds FILE_ENCODING to the debug output.
