### PR TITLE
GHA: Auto publish dev build on main

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -118,3 +118,13 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+
+    # When on main, auto publish dev build
+    auto_publish_dev:
+      needs:
+        - checks
+      if: github.ref == 'refs/heads/main'
+      uses: ./.github/workflows/publish-release.yml
+      with:
+        pypi_target: "test.pypi.org"
+        repo_release_ref: "main"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -119,12 +119,12 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
 
-    # When on main, auto publish dev build
-    auto_publish_dev:
-      needs:
-        - checks
-      if: github.ref == 'refs/heads/main'
-      uses: ./.github/workflows/publish-release.yml
-      with:
-        pypi_target: "test.pypi.org"
-        repo_release_ref: "main"
+  # When on main, auto publish dev build
+  auto_publish_dev:
+    needs:
+      - checks
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/publish-release.yml
+    with:
+      pypi_target: "test.pypi.org"
+      repo_release_ref: "main"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -122,7 +122,7 @@ jobs:
   # When on main, auto publish dev build
   auto_publish_dev:
     needs:
-      - checks
+      - check
     if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/publish-release.yml
     with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,6 +1,17 @@
 name: Publish Release
 run-name: "Publish Release"
 on:
+  workflow_call:
+    inputs:
+      pypi_target:
+        description: "PyPI repository to publish to"
+        required: true
+        type: string
+        default: "test.pypi.org"
+      repo_release_ref:
+        description: "Gitlint git reference to publish release for"
+        type: string
+        default: "main"
   workflow_dispatch:
     inputs:
       pypi_target:
@@ -12,6 +23,7 @@ on:
         default: "test.pypi.org"
       repo_release_ref:
         description: "Gitlint git reference to publish release for"
+        type: string
         default: "main"
 
 jobs:

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -48,6 +48,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # Intentionally install hatch before gitlint, to buy us a few extra seconds in case the gitlint package was just
+      # published and hasn't appeared on PyPI yet.
+      - name: Install Hatch
+        run: python -m pip install hatch==1.6.3
+
       - name: Install gitlint
         run: |
           python -m pip install gitlint==${{ inputs.gitlint_version }}
@@ -66,9 +71,6 @@ jobs:
       - uses: actions/checkout@v3.3.0
         with:
           ref: ${{ inputs.repo_test_ref }}
-
-      - name: Install Hatch
-        run: python -m pip install hatch==1.6.3
 
       - name: Integration tests (default -> GITLINT_USE_SH_LIB=1)
         run: |


### PR DESCRIPTION
Also perform hatch download before gitlint install in test-release
workflow. This buys us a little more time for the package to show up on
PyPI before trying to install and test it.
