### PR TITLE
GHA: Pass secrets to publish-release workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -125,6 +125,7 @@ jobs:
       - check
     if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/publish-release.yml
+    secrets: inherit # pass all secrets (required to access secrets in a called workflow)
     with:
       pypi_target: "test.pypi.org"
       repo_release_ref: "main"


### PR DESCRIPTION
When invoking the publish-release from the checks workflows on main,
pass all secrets. This is required for PYPI secrets to be available.
