### PR TITLE
Config: read from `setup.cfg` too, with `tool:gitlint:` section prefix

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,6 +168,17 @@ ignore=T1,body-min-length
 types = bugfix,user-story,epic
 ```
 
+## The setup.cfg file
+
+The syntax and contents of configuration via `setup.cfg` is the same as via `.gitlint`,
+except that gitlint related sections in it are prefixed with `tool:gitlint:`.
+For example:
+
+```ini
+[tool:gitlint:general]
+# ...
+```
+
 ## Commandline config
 
 You can also use one or more `-c` flags like so:
@@ -211,7 +222,7 @@ gitlint configuration is applied in the following order of precedence:
 3. Commandline convenience flags (e.g.:  `-vv`, `--silent`, `--ignore`)
 4. Environment variables (e.g.: `GITLINT_VERBOSITY=3`)
 5. Commandline configuration flags (e.g.: `-c title-max-length=123`)
-6. Configuration file (local `.gitlint` file, or file specified using `-C`/`--config`)
+6. Configuration file (first of: file specified using `-C`/`--config`, local `.gitlint` file, local `setup.cfg` file)
 7. Default gitlint config
 
 ## General Options

--- a/gitlint-core/gitlint/cli.py
+++ b/gitlint-core/gitlint/cli.py
@@ -30,6 +30,9 @@ DEFAULT_CONFIG_FILE = ".gitlint"
 # -n: disable swap files. This fixes a vim error on windows (E303: Unable to open swap file for <path>)
 DEFAULT_COMMIT_MSG_EDITOR = "vim -n"
 
+SETUP_CFG_FILE = "setup.cfg"
+SETUP_CFG_SECTION_PREFIX = "tool:gitlint:"
+
 # Since we use the return code to denote the amount of errors, we need to change the default click usage error code
 click.UsageError.exit_code = USAGE_ERROR_CODE
 
@@ -94,6 +97,8 @@ def build_config(
         config_builder.set_from_config_file(config_path)
     elif os.path.exists(DEFAULT_CONFIG_FILE):
         config_builder.set_from_config_file(DEFAULT_CONFIG_FILE)
+    elif os.path.exists(SETUP_CFG_FILE):
+        config_builder.set_from_config_file(SETUP_CFG_FILE, SETUP_CFG_SECTION_PREFIX)
 
     # Then process any commandline configuration flags
     config_builder.set_config_from_string_list(c)

--- a/gitlint-core/gitlint/config.py
+++ b/gitlint-core/gitlint/config.py
@@ -460,7 +460,7 @@ class LintConfigBuilder:
                     f"'{config_option}' is an invalid configuration option. Use '<rule>.<option>=<value>'"
                 ) from e
 
-    def set_from_config_file(self, filename):
+    def set_from_config_file(self, filename, section_prefix=None):
         """Loads lint config from an ini-style config file"""
         if not os.path.exists(filename):
             raise LintConfigError(f"Invalid file path: {filename}")
@@ -472,8 +472,14 @@ class LintConfigBuilder:
                 parser.read_file(config_file, filename)
 
             for section_name in parser.sections():
+                if section_prefix:
+                    if not section_name.startswith(section_prefix):
+                        continue
+                    target_section = section_name[len(section_prefix) :]
+                else:
+                    target_section = section_name
                 for option_name, option_value in parser.items(section_name):
-                    self.set_option(section_name, option_name, str(option_value))
+                    self.set_option(target_section, option_name, str(option_value))
 
         except ConfigParserError as e:
             raise LintConfigError(str(e)) from e


### PR DESCRIPTION
Allows consolidating config in Python projects making use of that file.

`pyproject.toml` would be kind of nicer these days, but there's no TOML parser dependency in gitlint at the moment, and adding one in order to support it would sound a bit much. It can always be added in addition to this later if desired.