### PR TITLE
GHA: Increase post publish PYPI wait timeout to 10min

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -126,10 +126,10 @@ jobs:
           [ "$(gitlint --version)" == "gitlint, version ${{ needs.publish.outputs.gitlint_version }}" ]
 
       # Unfortunately, it's not because the newly published package installation worked once that replication
-      # has finished amongst all PyPI servers (subsequent installations might still fail). We sleep for 3 min here
+      # has finished amongst all PyPI servers (subsequent installations might still fail). We sleep for 10 min here
       # to increase the odds that replication has finished.
       - name: Sleep
-        run: sleep 180
+        run: sleep 600
 
   test-release:
     needs:


### PR DESCRIPTION
By increasing the timeout to 10min, we further increase the odds that PYPI
package replication to all servers has finished before triggering the
test-release workflow.
