### PR TITLE
Disable gitlint to gitlint-core versioning matching in dev env

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,4 +1,5 @@
 # hatch_build.py is executed by hatch at build-time and can contain custom build logic hooks
+import os
 from hatchling.metadata.plugin.interface import MetadataHookInterface
 
 
@@ -6,4 +7,7 @@ class CustomMetadataHook(MetadataHookInterface):
     """Custom metadata hook for hatch that ensures that gitlint and gitlint-core[trusted-deps] versions always match"""
 
     def update(self, metadata: dict) -> None:
-        metadata["dependencies"] = [f"gitlint-core[trusted-deps]=={metadata['version']}"]
+        # Only enforce versioning matching outside of the 'dev' environment, this allows for re-use of the 'dev'
+        # environment between different git branches.
+        if os.environ.get("HATCH_ENV_ACTIVE", "not-dev") != "dev":
+            metadata["dependencies"] = [f"gitlint-core[trusted-deps]=={metadata['version']}"]


### PR DESCRIPTION
This allows for re-use of the 'dev' environment between different git branches.
