### PR TITLE
Metadata urls to source commit for gitlint-core

### DIFF
--- a/gitlint-core/pyproject.toml
+++ b/gitlint-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gitlint-core"
-dynamic = ["version"]
+dynamic = ["version", "urls"]
 description = "Git commit message linter written in python, checks your commit messages for style."
 readme = "README.md"
 license = "MIT"
@@ -49,11 +49,6 @@ trusted-deps = [
 [project.scripts]
 gitlint = "gitlint.cli:cli"
 
-[project.urls]
-Documentation = "https://jorisroovers.github.io/gitlint"
-Homepage = "https://jorisroovers.github.io/gitlint"
-Source = "https://github.com/jorisroovers/gitlint"
-
 [tool.hatch.version]
 source = "vcs"
 raw-options = { root = ".." }
@@ -66,3 +61,10 @@ include = [
 exclude = [
     "/gitlint/tests", #
 ]
+
+[tool.hatch.metadata.hooks.vcs.urls]
+Homepage = "https://jorisroovers.github.io/gitlint"
+Documentation = "https://jorisroovers.github.io/gitlint"
+Source = "https://github.com/jorisroovers/gitlint/tree/main/gitlint-core"
+Changelog = "https://github.com/jorisroovers/gitlint/blob/main/CHANGELOG.md"
+'Source Commit' = "https://github.com/jorisroovers/gitlint/tree/{commit_hash}/gitlint-core"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ Homepage = "https://jorisroovers.github.io/gitlint"
 Documentation = "https://jorisroovers.github.io/gitlint"
 Source = "https://github.com/jorisroovers/gitlint"
 Changelog = "https://github.com/jorisroovers/gitlint/blob/main/CHANGELOG.md"
-source_archive = "https://github.com/jorisroovers/gitlint/archive/{commit_hash}.zip"
-source_commit = "https://github.com/jorisroovers/gitlint/tree/{commit_hash}"
+'Source Archive' = "https://github.com/jorisroovers/gitlint/archive/{commit_hash}.zip"
+'Source Commit' = "https://github.com/jorisroovers/gitlint/tree/{commit_hash}"
 
 # Use metadata hooks specified in 'hatch_build.py'
 # (this line is critical when building wheels, when building sdist it seems optional)


### PR DESCRIPTION
This enables traceability from the build to the source code for
gitlint-core.
