### PR TITLE
Bugfix: ignore-by-author-name crashes without --staged

### DIFF
--- a/gitlint-core/gitlint/cli.py
+++ b/gitlint-core/gitlint/cli.py
@@ -48,7 +48,7 @@ def setup_logging():
     # Root log, mostly used for debug
     root_log = logging.getLogger("gitlint")
     root_log.propagate = False  # Don't propagate to child loggers, the gitlint root logger handles everything
-    root_log.setLevel(logging.ERROR)
+    root_log.setLevel(logging.WARN)
     handler = logging.StreamHandler()
     formatter = logging.Formatter(LOG_FORMAT)
     handler.setFormatter(formatter)

--- a/gitlint-core/gitlint/rules.py
+++ b/gitlint-core/gitlint/rules.py
@@ -459,6 +459,17 @@ class IgnoreByAuthorName(ConfigurationRule):
         if not self.options["regex"].value:
             return
 
+        # If commit.author_name is not available, log warning and return
+        if commit.author_name is None:
+            warning_msg = (
+                "%s - %s: skipping - commit.author_name unknown. "
+                "Suggested fix: Using the --staged flag (or set general.staged=True in .gitlint). "
+                "More details: https://jorisroovers.com/gitlint/configuration/#staged"
+            )
+
+            self.log.warning(warning_msg, self.name, self.id)
+            return
+
         regex_method = Deprecation.get_regex_method(self, self.options["regex"])
 
         if regex_method(commit.author_name):

--- a/gitlint-core/gitlint/rules.py
+++ b/gitlint-core/gitlint/rules.py
@@ -463,7 +463,7 @@ class IgnoreByAuthorName(ConfigurationRule):
         if commit.author_name is None:
             warning_msg = (
                 "%s - %s: skipping - commit.author_name unknown. "
-                "Suggested fix: Using the --staged flag (or set general.staged=True in .gitlint). "
+                "Suggested fix: Use the --staged flag (or set general.staged=True in .gitlint). "
                 "More details: https://jorisroovers.com/gitlint/configuration/#staged"
             )
 

--- a/gitlint-core/gitlint/tests/rules/test_configuration_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_configuration_rules.py
@@ -92,7 +92,7 @@ class ConfigurationRuleTests(BaseTestCase):
         self.assertEqual(config, LintConfig())
         self.assert_logged([])  # nothing logged -> nothing ignored
 
-        # No regex specified -> Config shouldn't be changed
+        # No author available -> rule is skipped and warning logged
         staged_commit = self.gitcommit("Tïtle\n\nThis is\n a relëase body\n line")
         rule = rules.IgnoreByAuthorName({"regex": "foo"})
         config = LintConfig()

--- a/gitlint-core/gitlint/tests/rules/test_configuration_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_configuration_rules.py
@@ -100,7 +100,7 @@ class ConfigurationRuleTests(BaseTestCase):
         self.assertEqual(config, LintConfig())
         expected_log_messages = [
             "WARNING: gitlint.rules ignore-by-author-name - I4: skipping - commit.author_name unknown. "
-            "Suggested fix: Using the --staged flag (or set general.staged=True in .gitlint). "
+            "Suggested fix: Use the --staged flag (or set general.staged=True in .gitlint). "
             "More details: https://jorisroovers.com/gitlint/configuration/#staged"
         ]
         self.assert_logged(expected_log_messages)


### PR DESCRIPTION
If the user has an ignore-by-author-name rule configured, and when manually
passing a git commit message to gitlint using --msg-filename or via STDIN
without also using the --staged flag, gitlint crashes because
commit.author_name is unknown.

This fix will print a warning instead and skip the rule.

Fixes #403.

