### PR TITLE
Integration tests: set git config commit.cleanup=verbatim

### DIFF
--- a/qa/base.py
+++ b/qa/base.py
@@ -69,6 +69,9 @@ class BaseTestCase(TestCase):
         # http://stackoverflow.com/questions/5581857/git-and-the-umlaut-problem-on-mac-os-x
         git("config", "core.precomposeunicode", "true", _cwd=tmp_git_repo)
 
+        # Git now does commit message cleanup by default (e.g. removing trailing whitespace), disable that for testing
+        git("config", "commit.cleanup", "verbatim", _cwd=tmp_git_repo)
+
         return tmp_git_repo
 
     @staticmethod

--- a/qa/expected/test_user_defined/test_user_defined_rules_examples_2
+++ b/qa/expected/test_user_defined/test_user_defined_rules_examples_2
@@ -2,3 +2,4 @@
 1: UC3 Branch name 'main' does not start with one of ['feature/', 'hotfix/', 'release/']
 1: UL1 Title contains the special character '$'
 2: B4 Second line is not empty
+3: B3 Line contains hard tab characters (\t)

--- a/qa/test_user_defined.py
+++ b/qa/test_user_defined.py
@@ -18,7 +18,7 @@ class UserDefinedRuleTests(BaseTestCase):
         extra_path = self.get_example_path()
         commit_msg = "Release: Thi$ is å title\nContent on the second line\n$This line is ignored \nThis isn't\t\n"
         self.create_simple_commit(commit_msg)
-        output = gitlint("--extra-path", extra_path, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[4])
+        output = gitlint("--extra-path", extra_path, _cwd=self.tmp_git_repo, _tty_in=True, _ok_code=[5])
         self.assertEqualStdout(output, self.get_expected("test_user_defined/test_user_defined_rules_examples_2"))
 
     def test_user_defined_rules_examples_with_config(self):


### PR DESCRIPTION
Modern git does commit message cleanup by default (e.g. removing trailing
whitespace). We disable this during integration testing by setting:

git config commit.cleanup=verbatim
