### PR TITLE
GHA: Enable publishing packages to pypi.org

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -120,12 +120,12 @@ jobs:
           jobs: ${{ toJSON(needs) }}
 
   # When on main, auto publish dev build
-  auto_publish_dev:
+  auto-publish-dev:
     needs:
       - check
     if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/publish-release.yml
     secrets: inherit # pass all secrets (required to access secrets in a called workflow)
     with:
-      pypi_target: "test.pypi.org"
+      pypi_target: "pypi.org"
       repo_release_ref: "main"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,5 +1,5 @@
 name: Publish Release
-run-name: "Publish Release (pypi_target=${{ inputs.pypi_source }}, repo_release_ref=${{ inputs.repo_release_ref }})"
+run-name: "Publish Release (pypi_target=${{ inputs.pypi_target }}, repo_release_ref=${{ inputs.repo_release_ref }})"
 
 on:
   workflow_call:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,5 +1,6 @@
 name: Publish Release
-run-name: "Publish Release"
+run-name: "Publish Release (pypi_target=${{ inputs.pypi_source }}, repo_release_ref=${{ inputs.repo_release_ref }})"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,6 +19,7 @@ on:
         required: true
         type: choice
         options:
+          - "pypi.org"
           - "test.pypi.org"
         default: "test.pypi.org"
       repo_release_ref:
@@ -81,20 +82,35 @@ jobs:
         env: 
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.set_version.outputs.gitlint_version }}
 
-      - name: Publish (gitlint-core)
+      - name: Publish gitlint-core (pypi.org)
+        run: hatch publish
+        working-directory: ./gitlint-core
+        env:
+          HATCH_INDEX_USER: ${{ secrets.PYPI_GITLINT_CORE_USERNAME }}
+          HATCH_INDEX_AUTH: ${{ secrets.PYPI_GITLINT_CORE_PASSWORD }}
+        if: inputs.pypi_target == 'pypi.org'
+
+      - name: Publish gitlint (pypi.org)
+        run: hatch publish
+        env:
+          HATCH_INDEX_USER: ${{ secrets.PYPI_GITLINT_USERNAME }}
+          HATCH_INDEX_AUTH: ${{ secrets.PYPI_GITLINT_PASSWORD }}
+        if: inputs.pypi_target == 'pypi.org'
+
+      - name: Publish gitlint-core (test.pypi.org)
         run: hatch publish -r test
         working-directory: ./gitlint-core
         env:
           HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_GITLINT_CORE_USERNAME }}
           HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_CORE_PASSWORD }}
-        if: inputs.pypi_target == 'test.pypi.org' && inputs.repo_release_ref == 'main'
+        if: inputs.pypi_target == 'test.pypi.org'
 
-      - name: Publish (gitlint)
+      - name: Publish gitlint (test.pypi.org)
         run: hatch publish -r test
         env:
           HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_GITLINT_USERNAME }}
           HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_GITLINT_PASSWORD }}
-        if: inputs.pypi_target == 'test.pypi.org' && inputs.repo_release_ref == 'main'
+        if: inputs.pypi_target == 'test.pypi.org'
 
   # Wait for gitlint package to be available in PyPI for installation
   wait-for-package:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,23 +40,19 @@ take weeks or months before merged code actually gets released - we know that ca
 understand it's a well-considered trade-off based on available time.
 
 ### Dev Builds
-While final releases are usually months apart, we do dev builds on every commit to `main` that get published
-to **test.pypi.org**:
+While final releases are usually months apart, we do dev builds on every commit to `main`:
 
-- **gitlint**: [https://test.pypi.org/project/gitlint/#history](https://test.pypi.org/project/gitlint/#history)
-- **gitlint-core**:  [https://test.pypi.org/project/gitlint-core/#history](https://test.pypi.org/project/gitlint-core/#history)
+- **gitlint**: [https://pypi.org/project/gitlint/#history](https://pypi.org/project/gitlint/#history)
+- **gitlint-core**:  [https://pypi.org/project/gitlint-core/#history](https://pypi.org/project/gitlint-core/#history)
 
-It usually takes about 15 min after merging a PR to `main` for new builds to show up. Note that the installation
-of a recently published version can still fail for a few minutes after a build shows up on (test) PyPI while the package
+It usually takes about 5 min after merging a PR to `main` for new dev builds to show up. Note that the installation
+of a recently published version can still fail for a few minutes after a new version shows up on PyPI while the package
 is replicated to all download mirrors.
 
 To install a dev build of gitlint:
 ```sh
-export VERSION="0.19.0.dev68"
-pip install --no-cache-dir -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple gitlint==$VERSION
-# Explanation:
-# --no-cache-dir: don't use local cache, this ensures pip checks for the latest version online
-# --extra-index-url: use regular PyPI to download dependencies
+# Find latest dev build on https://pypi.org/project/gitlint/#history
+pip install gitlint=="0.19.0.dev68"
 ```
 
 


### PR DESCRIPTION
Before only publishing to test.pypi.org was supported, now also to
pypi.org.

Autopublishing on every commit to main still happens to test.pypi.org.
