### PR TITLE
Integration Tests: remove harcoded UTF-8 terminal encoding

### DIFF
--- a/qa/expected/test_commits/test_lint_staged_msg_filename_1
+++ b/qa/expected/test_commits/test_lint_staged_msg_filename_1
@@ -5,7 +5,7 @@ DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli TERMINAL_ENCODING: UTF-8
+DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: None

--- a/qa/expected/test_config/test_config_from_env_1
+++ b/qa/expected/test_config/test_config_from_env_1
@@ -5,7 +5,7 @@ DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli TERMINAL_ENCODING: UTF-8
+DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: None

--- a/qa/expected/test_config/test_config_from_env_2
+++ b/qa/expected/test_config/test_config_from_env_2
@@ -5,7 +5,7 @@ DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli TERMINAL_ENCODING: UTF-8
+DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: None

--- a/qa/expected/test_config/test_config_from_file_debug_1
+++ b/qa/expected/test_config/test_config_from_file_debug_1
@@ -5,7 +5,7 @@ DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli TERMINAL_ENCODING: UTF-8
+DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: {config_path}

--- a/qa/expected/test_gitlint/test_commit_binary_file_1
+++ b/qa/expected/test_gitlint/test_commit_binary_file_1
@@ -5,7 +5,7 @@ DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
 DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
-DEBUG: gitlint.cli TERMINAL_ENCODING: UTF-8
+DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration
 config-path: None


### PR DESCRIPTION
This broke the tests on windows before, checking whether it still does.
