### PR TITLE
GHA: github release workflow

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,14 @@
+name: Github Release Publish
+run-name: "Github Release Publish (tag=${{github.ref_name}})"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-release:
+    uses: ./.github/workflows/publish-release.yml
+    secrets: inherit # pass all secrets (required to access secrets in a called workflow)
+    with:
+      pypi_target: "test.pypi.org"
+      repo_release_ref: ${{ github.ref_name }} 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,6 +2,7 @@ name: Publish Release
 run-name: "Publish Release (pypi_target=${{ inputs.pypi_target }}, repo_release_ref=${{ inputs.repo_release_ref }})"
 
 on:
+  # Trigger release workflow from other workflows (e.g. release dev build as part of CI)
   workflow_call:
     inputs:
       pypi_target:
@@ -13,6 +14,8 @@ on:
         description: "Gitlint git reference to publish release for"
         type: string
         default: "main"
+  
+  # Manually trigger a release
   workflow_dispatch:
     inputs:
       pypi_target:


### PR DESCRIPTION
A new GHA workflow that publishes gitlint when new gitlint releases are
created on github.
