### PR TITLE
0.19.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file documents notable changes introduced in gitlint releases.
 
-# v0.19.0 (Unreleased)
+# v0.19.0 (2023-03-07)
 
 This release was primarily focussed on modernizing gitlint's build and test tooling (details: [#378](https://github.com/jorisroovers/gitlint/issues/378)).
 
@@ -26,6 +26,7 @@ This release was primarily focussed on modernizing gitlint's build and test tool
   - Gitlint now publishes a [`latest_dev` docker image](https://hub.docker.com/r/jorisroovers/gitlint/tags?name=latest_dev) on every commit to main ([#451](https://github.com/jorisroovers/gitlint/issues/452)) ([#452](https://github.com/jorisroovers/gitlint/issues/451))
   - Dependencies updated
   - Many improvements to the [CI/CD worfklows](https://github.com/jorisroovers/gitlint/tree/main/.github/workflows)
+  - Fixed coveralls integration: [coveralls.io/github/jorisroovers/gitlint](https://coveralls.io/github/jorisroovers/gitlint)
   - Improve unit test coverage ([#453](https://github.com/jorisroovers/gitlint/issues/453))
   - Integration test fixes on windows ([#392](https://github.com/jorisroovers/gitlint/issues/392), [#397](https://github.com/jorisroovers/gitlint/issues/397))
   - Devcontainer improvements ([#428](https://github.com/jorisroovers/gitlint/issues/428))


### PR DESCRIPTION
This release was primarily focussed on modernizing gitlint's build and test
tooling (details: #378).

General

    Python 3.6 no longer supported (EOL since 2021-12-23) (#379)
    This is the last release to support the sh library (used under-the-hood to
    execute git commands) by setting GITLINT_USE_SH_LIB=1. This is already
    disabled by default since v0.18.0.

Features

    Allow for a single commit in the --commits cmd-line param (#412)
    Gitlint now separates FILE_ENCODING (always UTF-8) from TERMINAL_ENCODING
    (terminal dependent), this should improve issues with unicode. Use
    gitlint --debug to inspect these values. (#424)

Bugfixes

    ignore-by-author-name crashes without --staged (#445)
    Various documentation fixes (#401, #433) - Thanks scop

Development

    Adopted hatch for project management (#384). This significantly improves
    the developer workflow, please read the updated CONTRIBUTING page.
    Adopted ruff for linting, replacing pylint (#404)
    Gitlint now publishes dev builds on every commit to main (#429)
    Gitlint now publishes a latest_dev docker image on every commit to
    main (#451) (#452)
    Dependencies updated
    Many improvements to the CI/CD worfklows
    Improve unit test coverage (#453)
    Integration test fixes on windows (#392, #397)
    Devcontainer improvements (#428)
    Removal of Dockerfile.dev (#390)
    Fix most integration tests on Windows
    Fix Windows unit tests (#383)
    Introduce a gate/check GHA job (#375)

Full Release details in CHANGELOG.md.
