### PR TITLE
Remove hatch-vcs metadata hook that uses commit_hash

### DIFF
--- a/gitlint-core/LICENSE
+++ b/gitlint-core/LICENSE
@@ -1,1 +1,22 @@
-../LICENSE
+The MIT License (MIT)
+
+Copyright (c) 2015 Joris Roovers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/gitlint-core/README.md
+++ b/gitlint-core/README.md
@@ -1,1 +1,26 @@
-../README.md
+# Gitlint-core
+
+# gitlint: [jorisroovers.github.io/gitlint](http://jorisroovers.github.io/gitlint/) #
+
+[![Tests](https://github.com/jorisroovers/gitlint/workflows/Tests%20and%20Checks/badge.svg)](https://github.com/jorisroovers/gitlint/actions?query=workflow%3A%22Tests+and+Checks%22)
+[![Coverage Status](https://coveralls.io/repos/github/jorisroovers/gitlint/badge.svg?branch=fix-coveralls)](https://coveralls.io/github/jorisroovers/gitlint?branch=fix-coveralls)
+[![PyPi Package](https://img.shields.io/pypi/v/gitlint.png)](https://pypi.python.org/pypi/gitlint)
+![Supported Python Versions](https://img.shields.io/pypi/pyversions/gitlint.svg)
+
+Git commit message linter written in python, checks your commit messages for style.
+
+**See [jorisroovers.github.io/gitlint](http://jorisroovers.github.io/gitlint/) for full documentation.**
+
+<a href="http://jorisroovers.github.io/gitlint/" target="_blank">
+<img src="https://raw.githubusercontent.com/jorisroovers/gitlint/main/docs/images/readme-gitlint.png" />
+</a>
+
+## Contributing ##
+All contributions are welcome and very much appreciated!
+
+**I'm [looking for contributors](https://github.com/jorisroovers/gitlint/issues/134) that are interested in taking a more active co-maintainer role as it's becoming increasingly difficult for me to find time to maintain gitlint. Please leave a comment in [#134](https://github.com/jorisroovers/gitlint/issues/134) if you're interested!**
+
+See [jorisroovers.github.io/gitlint/contributing](http://jorisroovers.github.io/gitlint/contributing) for details on
+how to get started - it's easy!
+
+We maintain a [loose project plan on Github Projects](https://github.com/users/jorisroovers/projects/1/views/1).

--- a/gitlint-core/pyproject.toml
+++ b/gitlint-core/pyproject.toml
@@ -67,4 +67,5 @@ Homepage = "https://jorisroovers.github.io/gitlint"
 Documentation = "https://jorisroovers.github.io/gitlint"
 Source = "https://github.com/jorisroovers/gitlint/tree/main/gitlint-core"
 Changelog = "https://github.com/jorisroovers/gitlint/blob/main/CHANGELOG.md"
-'Source Commit' = "https://github.com/jorisroovers/gitlint/tree/{commit_hash}/gitlint-core"
+# TODO(jorisroovers): Temporary disable until fixed in hatch-vcs
+# 'Source Commit' = "https://github.com/jorisroovers/gitlint/tree/{commit_hash}/gitlint-core"

--- a/gitlint-core/pyproject.toml
+++ b/gitlint-core/pyproject.toml
@@ -67,5 +67,5 @@ Homepage = "https://jorisroovers.github.io/gitlint"
 Documentation = "https://jorisroovers.github.io/gitlint"
 Source = "https://github.com/jorisroovers/gitlint/tree/main/gitlint-core"
 Changelog = "https://github.com/jorisroovers/gitlint/blob/main/CHANGELOG.md"
-# TODO(jorisroovers): Temporary disable until fixed in hatch-vcs
+# TODO(jorisroovers): Temporary disable until fixed in hatch-vcs (see #460)
 # 'Source Commit' = "https://github.com/jorisroovers/gitlint/tree/{commit_hash}/gitlint-core"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,9 @@ Homepage = "https://jorisroovers.github.io/gitlint"
 Documentation = "https://jorisroovers.github.io/gitlint"
 Source = "https://github.com/jorisroovers/gitlint"
 Changelog = "https://github.com/jorisroovers/gitlint/blob/main/CHANGELOG.md"
-'Source Archive' = "https://github.com/jorisroovers/gitlint/archive/{commit_hash}.zip"
-'Source Commit' = "https://github.com/jorisroovers/gitlint/tree/{commit_hash}"
+# TODO(jorisroovers): Temporary disable until fixed in hatch-vcs (see #460)
+# 'Source Archive' = "https://github.com/jorisroovers/gitlint/archive/{commit_hash}.zip"
+# 'Source Commit' = "https://github.com/jorisroovers/gitlint/tree/{commit_hash}"
 
 # Use metadata hooks specified in 'hatch_build.py'
 # (this line is critical when building wheels, when building sdist it seems optional)


### PR DESCRIPTION
Temporarily comment out dynamic URLs using the `commit_hash` variable in the
tool.hatch.metadata.hooks.vcs.urls section in pyproject.toml.

Required to fix builds from sdist.

Relates to #460
