### PR TITLE
🧪🔧 Switch to using `pypa/build` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install pypa/build
+        run: python -m pip install build==0.10.0
+
       - name: Install Hatch
         run: python -m pip install hatch==1.6.3
 
@@ -74,12 +77,12 @@ jobs:
 
       - name: Build test (gitlint)
         run: |
-          hatch build
+          python -m build
           hatch clean
 
       - name: Build test (gitlint-core)
         run: |
-          hatch build
+          python -m build
           hatch clean
         working-directory: ./gitlint-core
       

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install pypa/build
+        run: python -m pip install build==0.10.0
+
       - name: Install Hatch
         run: python -m pip install hatch==1.6.3
 
@@ -76,13 +79,13 @@ jobs:
           echo "gitlint_version=$(hatch version | cut -d+ -f1)" >> $GITHUB_OUTPUT
 
       - name: Build (gitlint-core)
-        run: hatch build
+        run: python -m build
         working-directory: ./gitlint-core
         env: 
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.set_version.outputs.gitlint_version }}
 
       - name: Build (gitlint)
-        run: hatch build
+        run: python -m build
         env: 
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.set_version.outputs.gitlint_version }}
 


### PR DESCRIPTION
This patch switches the CI/CD workflows to use the PyPA-endorsed PEP 517 build front-end called `build`. It is called without `--sdist` and `--wheel` CLI options, in which case `build` creates an sdist from the Git checkout but the following wheel build is made from that sdist tarball as opposed to using the Git checkout.

This has a side effect of smoke-testing that it's possible to build wheels from the published sdists. And this is the flow that `pip install` follows when it's requested to install from an sdist.

Ref: https://github.com/jorisroovers/gitlint/issues/460#issuecomment-1462121899
