### PR TITLE
📦 Enable support for git archive installs

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Force LF line endings for text files
+* text=auto eol=lf
+
+# Needed for setuptools-scm-git-archive
+.git_archival.txt  export-subst

--- a/gitlint-core/.git_archival.txt
+++ b/gitlint-core/.git_archival.txt
@@ -1,0 +1,1 @@
+../.git_archival.txt


### PR DESCRIPTION
This patch enables the end-users to succeed installing from GitHub source Git archive URLs, letting `setuptools-scm` calculate the distribution version correctly, including the exports of non-tagged commits [[1]]. `setuptools-scm` is the underlying library that `hatch-vcs` wraps, which is why the configuration pre-requisites and runtime assumptions are inherited.

Resolves #464.

[1]: https://github.com/pypa/setuptools_scm#git-archives