### PR TITLE
Remove GITLINT_USE_SH_LIB debug logging

### DIFF
--- a/gitlint-core/gitlint/cli.py
+++ b/gitlint-core/gitlint/cli.py
@@ -66,7 +66,6 @@ def log_system_info():
     LOG.debug("Python version: %s", sys.version)
     LOG.debug("Git version: %s", git_version())
     LOG.debug("Gitlint version: %s", gitlint.__version__)
-    LOG.debug("GITLINT_USE_SH_LIB: %s", os.environ.get("GITLINT_USE_SH_LIB", "[NOT SET]"))
     LOG.debug("TERMINAL_ENCODING: %s", gitlint.utils.TERMINAL_ENCODING)
     LOG.debug("FILE_ENCODING: %s", gitlint.utils.FILE_ENCODING)
 

--- a/gitlint-core/gitlint/tests/cli/test_cli.py
+++ b/gitlint-core/gitlint/tests/cli/test_cli.py
@@ -37,7 +37,6 @@ class CLITests(BaseTestCase):
             "platform": platform.platform(),
             "python_version": sys.version,
             "gitlint_version": __version__,
-            "GITLINT_USE_SH_LIB": BaseTestCase.GITLINT_USE_SH_LIB,
             "target": os.path.realpath(os.getcwd()),
             "TERMINAL_ENCODING": TERMINAL_ENCODING,
             "FILE_ENCODING": FILE_ENCODING,

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
@@ -3,7 +3,6 @@ DEBUG: gitlint.cli Platform: {platform}
 DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.cli Git version: git version 1.2.3
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
-DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
 DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
@@ -3,7 +3,6 @@ DEBUG: gitlint.cli Platform: {platform}
 DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.cli Git version: git version 1.2.3
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
-DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
 DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
@@ -3,7 +3,6 @@ DEBUG: gitlint.cli Platform: {platform}
 DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.cli Git version: git version 1.2.3
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
-DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
 DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
@@ -3,7 +3,6 @@ DEBUG: gitlint.cli Platform: {platform}
 DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.cli Git version: git version 1.2.3
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
-DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
 DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
@@ -3,7 +3,6 @@ DEBUG: gitlint.cli Platform: {platform}
 DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.cli Git version: git version 1.2.3
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
-DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
 DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration

--- a/qa/base.py
+++ b/qa/base.py
@@ -21,7 +21,6 @@ class BaseTestCase(TestCase):
     maxDiff = None
     tmp_git_repo = None
 
-    GITLINT_USE_SH_LIB = os.environ.get("GITLINT_USE_SH_LIB", "[NOT SET]")
     GIT_CONTEXT_ERROR_CODE = 254
     GITLINT_USAGE_ERROR = 253
 
@@ -198,7 +197,6 @@ class BaseTestCase(TestCase):
             "python_version": sys.version,
             "git_version": expected_git_version,
             "gitlint_version": expected_gitlint_version,
-            "GITLINT_USE_SH_LIB": BaseTestCase.GITLINT_USE_SH_LIB,
             "TERMINAL_ENCODING": TERMINAL_ENCODING,
             "FILE_ENCODING": FILE_ENCODING,
         }

--- a/qa/expected/test_commits/test_lint_staged_msg_filename_1
+++ b/qa/expected/test_commits/test_lint_staged_msg_filename_1
@@ -4,7 +4,6 @@ DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
-DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
 DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration

--- a/qa/expected/test_commits/test_lint_staged_stdin_1
+++ b/qa/expected/test_commits/test_lint_staged_stdin_1
@@ -4,7 +4,6 @@ DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
-DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
 DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration

--- a/qa/expected/test_config/test_config_from_env_1
+++ b/qa/expected/test_config/test_config_from_env_1
@@ -4,7 +4,6 @@ DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
-DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
 DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration

--- a/qa/expected/test_config/test_config_from_env_2
+++ b/qa/expected/test_config/test_config_from_env_2
@@ -4,7 +4,6 @@ DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
-DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
 DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration

--- a/qa/expected/test_config/test_config_from_file_debug_1
+++ b/qa/expected/test_config/test_config_from_file_debug_1
@@ -4,7 +4,6 @@ DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
-DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
 DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration

--- a/qa/expected/test_gitlint/test_commit_binary_file_1
+++ b/qa/expected/test_gitlint/test_commit_binary_file_1
@@ -4,7 +4,6 @@ DEBUG: gitlint.cli Python version: {python_version}
 DEBUG: gitlint.git ('--version',)
 DEBUG: gitlint.cli Git version: {git_version}
 DEBUG: gitlint.cli Gitlint version: {gitlint_version}
-DEBUG: gitlint.cli GITLINT_USE_SH_LIB: {GITLINT_USE_SH_LIB}
 DEBUG: gitlint.cli TERMINAL_ENCODING: {TERMINAL_ENCODING}
 DEBUG: gitlint.cli FILE_ENCODING: {FILE_ENCODING}
 DEBUG: gitlint.cli Configuration


### PR DESCRIPTION
With the removal of the `sh` libary from gitlint, the GITLINT_USE_SH_LIB
environment variable is no longer meaningful and neither has logging its value.
