### PR TITLE
Switch hatch-vcs version scheme to release-branch-semver

### DIFF
--- a/gitlint-core/pyproject.toml
+++ b/gitlint-core/pyproject.toml
@@ -49,7 +49,7 @@ gitlint = "gitlint.cli:cli"
 
 [tool.hatch.version]
 source = "vcs"
-raw-options = { root = ".." }
+raw-options = { root = "..", version_scheme = "release-branch-semver"}
 
 [tool.hatch.build]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 
 [tool.hatch.version]
 source = "vcs"
+raw-options = { version_scheme = "release-branch-semver" }
 
 [tool.hatch.build]
 exclude = ["*"]


### PR DESCRIPTION
- Correctly increase dev versions when micro tag versions are present
- Removes the need to maintain dev tags

Relates to #456
