### PR TITLE
Hatch autofix script: always run black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ format = "black --check --diff {args:.}"
 lint = "ruff {args:gitlint-core/gitlint qa}"
 autoformat = "black {args:.}"
 autofix = [
-    "ruff --fix {args:gitlint-core/gitlint qa}",
+    "- ruff --fix {args:gitlint-core/gitlint qa}",
     "autoformat",                                #
 ]
 


### PR DESCRIPTION
Before this patch, we didn't run black as part of autofix if `ruff
--fix` returned an error. This patch ensures the exit status of `ruff
--fix` is ignored and black always runs.
