### PR TITLE
Docs: info on testing different python versions

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,7 +1,6 @@
 #!/bin/sh -x
 
 brew install asdf
-brew install hatch
 source "$(brew --prefix asdf)/libexec/asdf.sh"
 
 # Install latest python
@@ -10,15 +9,17 @@ asdf install python 3.11.0
 asdf global python 3.11.0
 
 # You can easily install other python versions like so:
-# asdf install python 3.6.15
 # asdf install python 3.7.15
 # asdf install python 3.8.15
 # asdf install python 3.9.15
 # asdf install python 3.10.8
 # asdf install python pypy3.9-7.3.9
 
+# If you do this, you also need to install hatch for each python version
+# asdf global python 3.7.15
+# pip install hatch==1.6.3
+
 # Setup virtualenv, install all dependencies
 cd /workspaces/gitlint
-$(asdf which python) -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt -r test-requirements.txt -r doc-requirements.txt
+pip install hatch==1.6.3
+hatch env create

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -66,9 +66,10 @@ You do not need to setup a `virtualenv`, hatch will take care of that for you.
 pip install hatch
 ```
 
-### Github Devcontainer
+### Github Codespace
 
-We provide a devcontainer on github to make it easier to get started with gitlint development using VSCode.
+We provide a devcontainer to use with github codespaces to make it easier to get started with gitlint development
+using VSCode.
 
 To start one, click the plus button under the *Code* dropdown on
 [the gitlint repo on github](https://github.com/jorisroovers/gitlint). 
@@ -88,11 +89,20 @@ source "$(brew --prefix asdf)/libexec/asdf.sh"
 
 # Install python 3.9.15
 asdf install python 3.9.15
+# Make python 3.9.15 the default python
+asdf global python 3.9.15
+
+# IMPORTANT: install hatch for this python version
+pip install hatch==1.6.3
+# You also need to prune your hatch environment first before running other commands
+hatch env prune
+
 # List all available python versions
 asdf list all python
 # List installed python versions
 asdf list python
 ```
+
 
 ## Running tests
 ```sh


### PR DESCRIPTION
The docs were missing important steps on how to test gitlint against
different python versions on the dev container.

Also fixes the Devcontainer's postCreateCommand.sh to install hatch
using pip instead of homebrew.
