### PR TITLE
Docs: enable toc extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,9 @@ markdown_extensions:
     - pymdownx.superfences
     - pymdownx.details # Collapsible admonitions
     - tables
+    
+    - toc:
+        permalink: true
 
     - pymdownx.highlight:
         anchor_linenums: true


### PR DESCRIPTION
Adds an anchor link at the end of each headline.
