### PR TITLE
tools/create-test-repo.sh: use subshell

### DIFF
--- a/tools/create-test-repo.sh
+++ b/tools/create-test-repo.sh
@@ -6,6 +6,8 @@ BLUE="\033[94m"
 GREEN="\033[32m"
 NO_COLOR="\033[0m"
 
+GITLINT_DIR=$(pwd)
+
 # Create the repo
 echo -e "${YELLOW}Creating new temp repo...${NO_COLOR}"
 cd /tmp
@@ -28,7 +30,7 @@ git commit -m "test cömmit title" -m "test cömmit body that has a bit more tex
 
 
 echo -e "${YELLOW}Reconfiguring hatch...${NO_COLOR}"
-hatch config set projects.gitlint /workspaces/gitlint
+hatch config set projects.gitlint $GITLINT_DIR
 
 
 # Let the user know
@@ -36,4 +38,10 @@ echo -e "${YELLOW}All Done!${NO_COLOR}"
 echo ""
 echo -e "Entering subshell at $GREEN/tmp/${reponame}$NO_COLOR. Type 'exit' to exit."
 
-bash --rcfile <(echo "source ~/.bash_profile; cd /tmp/$reponame; alias gitlint='HATCH_PROJECT=gitlint hatch run dev:gitlint --target /tmp/$reponame'")
+rcfile="""
+source ~/.bash_profile;
+cd /tmp/$reponame;
+alias gitlint='HATCH_PROJECT=gitlint hatch run dev:gitlint --target /tmp/$reponame'
+"""
+
+bash --rcfile <(echo "$rcfile")

--- a/tools/create-test-repo.sh
+++ b/tools/create-test-repo.sh
@@ -6,12 +6,12 @@ BLUE="\033[94m"
 GREEN="\033[32m"
 NO_COLOR="\033[0m"
 
-CWD="$(pwd)"
-echo "pwd=$CWD"
 # Create the repo
+echo -e "${YELLOW}Creating new temp repo...${NO_COLOR}"
 cd /tmp
 reponame=$(date +gitlint-test-%Y-%m-%d_%H-%M-%S)
 git init --initial-branch main $reponame
+
 cd $reponame
 
 # Do some basic config
@@ -25,11 +25,15 @@ echo "tëst 123" > test.txt
 git add test.txt
 # commit -m -> use multiple -m args to add multiple paragraphs (/n in strings are ignored)
 git commit -m "test cömmit title" -m "test cömmit body that has a bit more text"
-cd $CWD
+
+
+echo -e "${YELLOW}Reconfiguring hatch...${NO_COLOR}"
+hatch config set projects.gitlint /workspaces/gitlint
+
 
 # Let the user know
+echo -e "${YELLOW}All Done!${NO_COLOR}"
 echo ""
-echo -e "Created $GREEN/tmp/${reponame}$NO_COLOR"
-echo "Hit key up to access 'cd /tmp/$reponame'"
-echo "(Run this script using 'source' for this to work)"
-history -s "cd /tmp/$reponame"
+echo -e "Entering subshell at $GREEN/tmp/${reponame}$NO_COLOR. Type 'exit' to exit."
+
+bash --rcfile <(echo "source ~/.bash_profile; cd /tmp/$reponame; alias gitlint='HATCH_PROJECT=gitlint hatch run dev:gitlint --target /tmp/$reponame'")


### PR DESCRIPTION
tools/create-test-repo.sh will now enter a subshell
immediately inside the temporary git repo directory, and reconfigure
hatch to be able to run from that that directory.

This avoids developers having to manually type the cd command to enter
the correct temp repo after creation and having to reconfigure hatch.

