### PR TITLE
GHA: auto-publish dev docs on commit to main

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,24 @@
+name: Publish Docs
+
+on:
+  push:
+    branches:
+      - main
+  
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.3.0
+      - uses: actions/setup-python@v4.6.1
+        with:
+          python-version: 3.11
+
+      - name: Install Hatch
+        run: python -m pip install hatch==1.6.3
+
+      - name: Deploy dev docs
+        run: hatch run docs:mike deploy --force --update-aliases dev

--- a/docs/contributing/tests_formatting_docs.md
+++ b/docs/contributing/tests_formatting_docs.md
@@ -63,12 +63,19 @@ hatch run test:autofix
 We use [mkdocs](https://www.mkdocs.org/) with [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) and
 [mike](https://github.com/jimporter/mike) for generating our documentation from markdown.
 
-To use it:
+To browse the documentation locally (live reload enabled):
 ```{.sh .copy}
 hatch run docs:serve
 ```
 
 Then access the documentation website on [http://localhost:8000]().
+
+!!! note "Documentation versioning"
+    When browsing the docs locally, they will show up under the `latest` version ([http://localhost:8000/latest]()).
+    
+    However, the online docs at [https://jorisroovers.github.io/gitlint]() are versioned, with new changes first
+    being published to `dev` ([https://jorisroovers.github.io/gitlint/dev]()) when they're merged in the `main` branch.
+    Only with gitlint releases are the versioned docs updated - `latest` always points to the latest gitlint release.
 
 ## Tools
 We keep a small set of scripts in the `tools/` directory:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,8 @@ dependencies = [
 
 [tool.hatch.envs.docs.scripts]
 build = "mkdocs build --clean --strict"
-serve = "mike serve"
+serve = "mkdocs serve"
+# Note: `mike serve` will add the doc version selector but doesn't do auto-reload
 
 validate = [
     "build", #


### PR DESCRIPTION
Use GHA to automatically publish docs to the dev version when merged to
main.
