### PR TITLE
GHA: Improvements for auto-deploy docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,6 @@ jobs:
   auto-publish-dev:
     needs:
       - check
-      - doc_checks
 
     if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/publish-release.yml
@@ -155,3 +154,14 @@ jobs:
       environment: "production"
       repo_release_ref: "main"
       docker_image_tag: "latest_dev"
+
+  # When on main, auto publish docs
+  auto-publish-docs:
+    needs:
+      - check
+
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/publish-docs.yml
+    secrets: inherit # pass all secrets (required to access secrets in a called workflow)
+    with:
+      docs_version: "dev"

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,9 +1,18 @@
 name: Publish Docs
 
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      docs_version:
+        description: "Version to build docs for (dev | latest | 0.19.x | ...)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      docs_version:
+        description: "Version to build docs for (dev | latest | 0.19.x | ...)"
+        type: string
+        default: dev
   
 permissions:
   contents: write
@@ -21,4 +30,4 @@ jobs:
         run: python -m pip install hatch==1.6.3
 
       - name: Deploy dev docs
-        run: hatch run docs:mike deploy --force --update-aliases dev
+        run: hatch run docs:mike deploy --push --update-aliases ${{ inputs.docs_version }}


### PR DESCRIPTION
- Change incorrect --deploy parameter to --push
- Allow for manual trigger of workflow
- Call publish-docs workflow from ci workflow when committing on main
