### PR TITLE
GHA: Smoke test sdist package for downstream packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,30 +129,58 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Checkout sdist tarball (gitlint)
-        uses: re-actors/checkout-python-sdist@release/v1
-        with:
-          workflow-artifact-name: sdist-gitlint-${{ matrix.python-version }}
+      # TODO: continue here. Need to create working dirs for gitlint and gitlint-core,
+      # then use working-dir in the checkout action steps below
 
-      - name: Checkout sdist tarball (gitlint-core)
-        uses: re-actors/checkout-python-sdist@release/v1
+      # - name: Checkout sdist tarball (gitlint)
+      #   uses: re-actors/checkout-python-sdist@release/v1
+      #   with:
+      #     workflow-artifact-name: sdist-gitlint-${{ matrix.python-version }}
+
+      # - name: Checkout sdist tarball (gitlint-core)
+      #   uses: re-actors/checkout-python-sdist@release/v1
+      #   with:
+      #     workflow-artifact-name: sdist-gitlint-core-${{ matrix.python-version }}
+
+      - name: Download sdist artifact (gitlint)
+        uses: actions/download-artifact@v3
         with:
-          workflow-artifact-name: sdist-gitlint-core-${{ matrix.python-version }}
+          name: sdist-gitlint-${{ matrix.python-version }}
+          path: gitlint
+
+      - name: Download sdist artifact (gitlint-core)
+        uses: actions/download-artifact@v3
+        with:
+          name: sdist-gitlint-core-${{ matrix.python-version }}
+          path: gitlint-core
+
+      - name: Extract sdist tarball (gitlint)
+        run: tar xzvf *.tar.gz --strip-components=1
+        working-directory: ./gitlint
+
+      - name: Extract sdist tarball (gitlint-core)
+        run: tar xzvf *.tar.gz --strip-components=1
+        working-directory: ./gitlint-core
       
       - name: Install pypa/build
         run: python -m pip install build==0.10.0
 
+      - name: Build test (gitlint)
+        run: python -m build
+        working-directory: ./gitlint
+
       - name: Build test (gitlint-core)
         run: python -m build
+        working-directory: ./gitlint-core
 
       - name: List wheels
         run: |
-          ls dist
-          echo "---------"
-          ls dist/*.whl
+          ls gitlint/dist
+          echo "----"
+          ls gitlint-core/dist
 
       - name: Install from wheel (gitlint and gitlint-core)
-        run: python -m pip install dist/*.whl
+        run: python -m pip install gitlint-core/dist/*.whl gitlint/dist/*.whl
 
       - name: gitlint --version
         run: gitlint --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
         run: hatch run docs:validate
   
   upload-coveralls:
-    needs: checks
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Upload coverage to coveralls
@@ -190,7 +190,7 @@ jobs:
     if: always()  # Ref: https://github.com/marketplace/actions/alls-green#why
 
     needs:
-      - checks
+      - tests
       - build-test
       - sdist-build-smoke-test
       - doc-checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,11 @@ jobs:
         with:
           workflow-artifact-name: sdist-tarball-3.8
       
+      - name: Install pypa/build
+        run: python -m pip install build==0.10.0
+
       - name: Build test (gitlint-core)
-        run: |
-          python -m build
+        run: python -m build
       
 
   doc_checks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,9 +185,10 @@ jobs:
 
     needs:
       - checks
-      - sdist_build_smoke_test
-      - doc_checks
-      - upload_coveralls
+      - build-test
+      - sdist-build-smoke-test
+      - doc-checks
+      - upload-coveralls
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,7 @@ jobs:
           if: matrix.os == 'ubuntu-latest'
 
         - name: Build test (gitlint-core)
-          run: |
-            python -m build
+          run: python -m build
           working-directory: ./gitlint-core
   
         - name: Upload sdist tarball (gitlint-core)
@@ -165,6 +164,7 @@ jobs:
       - name: Install from wheel (gitlint and gitlint-core)
         run: python -m pip install gitlint-core/dist/*.whl gitlint/dist/*.whl
 
+      # Make sure gitlint works
       - name: gitlint --version
         run: gitlint --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,14 @@ jobs:
       - name: Build test (gitlint-core)
         run: |
           python -m build
-          hatch clean
         working-directory: ./gitlint-core
-      
+
+      - name: "Upload sdist tarball"
+        uses: actions/upload-artifact@v3
+        with:
+          name: sdist-tarball-${{ matrix.python-version }}
+          path: ./gitlint-core/dist/*.tar.gz
+        
       # Run gitlint. Skip during PR runs, since PR commit messages are transient and usually full of gitlint violations.
       # PRs get squashed and get a proper commit message during merge.
       - name: gitlint --debug
@@ -96,6 +101,22 @@ jobs:
           git-commit: ${{ github.event.pull_request.head.sha }}
           flag-name: gitlint-${{ matrix.os }}-${{ matrix.python-version }}
           parallel: true
+
+  sdist_build_check:
+    runs-on: "ubuntu-latest"
+    # strategy:
+    #   matrix:
+    #     python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", pypy-3.9]
+    #     os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+    steps:
+      - uses: re-actors/checkout-python-sdist@release/v1
+        with:
+          workflow-artifact-name: sdist-tarball-3.8
+      
+      - name: Build test (gitlint-core)
+        run: |
+          python -m build
+      
 
   doc_checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  checks:
+  tests:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
@@ -124,12 +124,18 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", pypy-3.9]
     steps:
-      - name: Setup python
+      - name: Setup python ${{ matrix.python-version }}
         uses: actions/setup-python@v4.6.1
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: re-actors/checkout-python-sdist@release/v1
+      - name: Checkout sdist tarball (gitlint)
+        uses: re-actors/checkout-python-sdist@release/v1
+        with:
+          workflow-artifact-name: sdist-gitlint-${{ matrix.python-version }}
+
+      - name: Checkout sdist tarball (gitlint-core)
+        uses: re-actors/checkout-python-sdist@release/v1
         with:
           workflow-artifact-name: sdist-gitlint-core-${{ matrix.python-version }}
       
@@ -145,8 +151,8 @@ jobs:
           echo "---------"
           ls dist/*.whl
 
-      - name: Install from wheel
-        run: python -m pip install dist/gitlint_core*.whl
+      - name: Install from wheel (gitlint and gitlint-core)
+        run: python -m pip install dist/*.whl
 
       - name: gitlint --version
         run: gitlint --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: "Upload sdist tarball"
         uses: actions/upload-artifact@v3
         with:
-          name: sdist-tarball-${{ matrix.python-version }}
+          name: sdist-gitlint-core-${{ matrix.python-version }}
           path: ./gitlint-core/dist/*.tar.gz
         
       # Run gitlint. Skip during PR runs, since PR commit messages are transient and usually full of gitlint violations.
@@ -105,21 +105,25 @@ jobs:
   sdist_build_smoke_test:
     needs: checks
     runs-on: "ubuntu-latest"
-    # strategy:
-    #   matrix:
-    #     python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", pypy-3.9]
-    #     os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", pypy-3.9]
     steps:
       - uses: re-actors/checkout-python-sdist@release/v1
         with:
-          workflow-artifact-name: sdist-tarball-3.8
+          workflow-artifact-name: sdist-gitlint-core-${{ matrix.python-version }}
       
       - name: Install pypa/build
         run: python -m pip install build==0.10.0
 
       - name: Build test (gitlint-core)
         run: python -m build
-      
+
+      - name: Install from wheel
+        run: python -m pip install *.whl
+
+      - name: gitlint --version
+        run: gitlint --version
 
   doc_checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,8 @@ jobs:
           if: matrix.os == 'ubuntu-latest'
   
   sdist-build-smoke-test:
+    # Ensure we can re-build gitlint from its sdist tarball (and that gitlint works after that)
+    # This is important for downstream packages (e.g. debian, homebrew, etc)
     needs: build-test
     runs-on: "ubuntu-latest"
     strategy:
@@ -128,19 +130,6 @@ jobs:
         uses: actions/setup-python@v4.6.1
         with:
           python-version: ${{ matrix.python-version }}
-
-      # TODO: continue here. Need to create working dirs for gitlint and gitlint-core,
-      # then use working-dir in the checkout action steps below
-
-      # - name: Checkout sdist tarball (gitlint)
-      #   uses: re-actors/checkout-python-sdist@release/v1
-      #   with:
-      #     workflow-artifact-name: sdist-gitlint-${{ matrix.python-version }}
-
-      # - name: Checkout sdist tarball (gitlint-core)
-      #   uses: re-actors/checkout-python-sdist@release/v1
-      #   with:
-      #     workflow-artifact-name: sdist-gitlint-core-${{ matrix.python-version }}
 
       - name: Download sdist artifact (gitlint)
         uses: actions/download-artifact@v3
@@ -172,12 +161,6 @@ jobs:
       - name: Build test (gitlint-core)
         run: python -m build
         working-directory: ./gitlint-core
-
-      - name: List wheels
-        run: |
-          ls gitlint/dist
-          echo "----"
-          ls gitlint-core/dist
 
       - name: Install from wheel (gitlint and gitlint-core)
         run: python -m pip install gitlint-core/dist/*.whl gitlint/dist/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install pypa/build
-        run: python -m pip install build==0.10.0
-
       - name: Install Hatch
         run: python -m pip install hatch==1.7.0
 
@@ -51,17 +48,14 @@ jobs:
         run: hatch run test:type-check
 
       - name: Install local gitlint for integration tests
-        run: |
-          hatch run qa:install-local
+        run: hatch run qa:install-local
 
       - name: Integration tests
-        run: |
-          hatch run qa:integration-tests
+        run: hatch run qa:integration-tests
         if: matrix.os != 'windows-latest'
 
       - name: Integration tests (GITLINT_QA_USE_SH_LIB=0)
-        run: |
-          hatch run qa:integration-tests -k "not(test_commit_hook_continue or test_commit_hook_abort or test_commit_hook_edit)" qa
+        run: hatch run qa:integration-tests -k "not(test_commit_hook_continue or test_commit_hook_abort or test_commit_hook_edit)" qa
         env:
           GITLINT_QA_USE_SH_LIB: 0
         if: matrix.os != 'windows-latest'
@@ -71,22 +65,6 @@ jobs:
           hatch run qa:integration-tests -k "not (test_commit_hook_continue or test_commit_hook_abort or test_commit_hook_edit or test_lint_staged_stdin or test_stdin_file or test_stdin_pipe_empty)" qa
         if: matrix.os == 'windows-latest'
 
-      - name: Build test (gitlint)
-        run: |
-          python -m build
-          hatch clean
-
-      - name: Build test (gitlint-core)
-        run: |
-          python -m build
-        working-directory: ./gitlint-core
-
-      - name: "Upload sdist tarball"
-        uses: actions/upload-artifact@v3
-        with:
-          name: sdist-gitlint-core-${{ matrix.python-version }}
-          path: ./gitlint-core/dist/*.tar.gz
-        
       # Run gitlint. Skip during PR runs, since PR commit messages are transient and usually full of gitlint violations.
       # PRs get squashed and get a proper commit message during merge.
       - name: gitlint --debug
@@ -102,13 +80,55 @@ jobs:
           flag-name: gitlint-${{ matrix.os }}-${{ matrix.python-version }}
           parallel: true
 
-  sdist_build_smoke_test:
-    needs: checks
+  build-test:
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", pypy-3.9]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+    steps:
+        - uses: actions/checkout@v3.3.0
+          with:
+            ref: ${{ github.event.pull_request.head.sha }} # Checkout pull request HEAD commit instead of merge commit
+            fetch-depth: 0 # checkout all history, needed for hatch versioning
+            
+        - name: Install pypa/build
+          run: python -m pip install build==0.10.0
+
+        - name: Build test (gitlint)
+          run: python -m build
+
+        - name: Upload sdist tarball (gitlint)
+          uses: actions/upload-artifact@v3
+          with:
+            name: sdist-gitlint-core-${{ matrix.python-version }}
+            path: ./gitlint-core/dist/*.tar.gz
+          if: matrix.os == 'ubuntu-latest'
+
+        - name: Build test (gitlint-core)
+          run: |
+            python -m build
+          working-directory: ./gitlint-core
+  
+        - name: Upload sdist tarball (gitlint-core)
+          uses: actions/upload-artifact@v3
+          with:
+            name: sdist-gitlint-core-${{ matrix.python-version }}
+            path: ./gitlint-core/dist/*.tar.gz
+          if: matrix.os == 'ubuntu-latest'
+  
+  sdist-build-smoke-test:
+    needs: build-test
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", pypy-3.9]
     steps:
+      - name: Setup python
+        uses: actions/setup-python@v4.6.1
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - uses: re-actors/checkout-python-sdist@release/v1
         with:
           workflow-artifact-name: sdist-gitlint-core-${{ matrix.python-version }}
@@ -119,13 +139,19 @@ jobs:
       - name: Build test (gitlint-core)
         run: python -m build
 
+      - name: List wheels
+        run: |
+          ls
+          echo "---------"
+          ls *.whl
+
       - name: Install from wheel
         run: python -m pip install *.whl
 
       - name: gitlint --version
         run: gitlint --version
 
-  doc_checks:
+  doc-checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.3.0
@@ -143,7 +169,7 @@ jobs:
       - name: Docs validation (mkdocs build & linkchecker)
         run: hatch run docs:validate
   
-  upload_coveralls:
+  upload-coveralls:
     needs: checks
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,8 @@ jobs:
           flag-name: gitlint-${{ matrix.os }}-${{ matrix.python-version }}
           parallel: true
 
-  sdist_build_check:
+  sdist_build_smoke_test:
+    needs: checks
     runs-on: "ubuntu-latest"
     # strategy:
     #   matrix:
@@ -152,6 +153,7 @@ jobs:
 
     needs:
       - checks
+      - sdist_build_smoke_test
       - doc_checks
       - upload_coveralls
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,8 @@ jobs:
         - name: Upload sdist tarball (gitlint)
           uses: actions/upload-artifact@v3
           with:
-            name: sdist-gitlint-core-${{ matrix.python-version }}
-            path: ./gitlint-core/dist/*.tar.gz
+            name: sdist-gitlint-${{ matrix.python-version }}
+            path: dist/*.tar.gz
           if: matrix.os == 'ubuntu-latest'
 
         - name: Build test (gitlint-core)
@@ -141,12 +141,12 @@ jobs:
 
       - name: List wheels
         run: |
-          ls
+          ls dist
           echo "---------"
-          ls *.whl
+          ls dist/*.whl
 
       - name: Install from wheel
-        run: python -m pip install *.whl
+        run: python -m pip install dist/gitlint_core*.whl
 
       - name: gitlint --version
         run: gitlint --version


### PR DESCRIPTION
Smoke test sdist tarballs (gitlint and gitlint-core) for downstream packaging:
- Upload and re-downloading them in a separate job
- Extract the tarballs and rebuild wheels using pypa/build
- Install the wheels
- Run gitlint to ensure everything its not failing

Closes #468