### PR TITLE
GHA: Guard notify job from direct pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,3 +278,5 @@ jobs:
               repo: context.repo.repo,
               body: body
             });
+        # Don't run this step if there is no PR number, i.e. on a direct push to main
+        if: ${{ env.PR_NUMBER != '' }}


### PR DESCRIPTION
When directly pushing to main, don't try to post a comment on the
releated PR (as no such PR will exist).
