### PR TITLE
Implement missing repr methods

### DIFF
--- a/gitlint-core/gitlint/config.py
+++ b/gitlint-core/gitlint/config.py
@@ -362,7 +362,6 @@ class LintConfig:
             f"ignore_squash_commits={self.ignore_squash_commits!r}, "
             f"ignore_stdin={self.ignore_stdin!r}, "
             f"regex_style_search={self.regex_style_search!r}, "
-            f"rules={self.rules!r}, "
             f"staged={self.staged!r}, "
             f"target={self.target!r}, "
             f"verbosity={self.verbosity!r})"
@@ -438,7 +437,9 @@ class RuleCollection:
                     option_val_repr = option_value.value
                 return_str += f"     {option_name}={option_val_repr}\n"
         return return_str
-
+    
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._rules!r})"
 
 @dataclass
 class LintConfigBuilder:

--- a/gitlint-core/gitlint/config.py
+++ b/gitlint-core/gitlint/config.py
@@ -346,7 +346,7 @@ class LintConfig:
             f"target: {self.target}\n"
             f"[RULES]\n{self.rules}"
         )
-    
+
     def __repr__(self):
         return (
             f"{self.__class__.__name__}("
@@ -437,9 +437,10 @@ class RuleCollection:
                     option_val_repr = option_value.value
                 return_str += f"     {option_name}={option_val_repr}\n"
         return return_str
-    
+
     def __repr__(self):
         return f"{self.__class__.__name__}({self._rules!r})"
+
 
 @dataclass
 class LintConfigBuilder:

--- a/gitlint-core/gitlint/config.py
+++ b/gitlint-core/gitlint/config.py
@@ -305,22 +305,22 @@ class LintConfig:
     def __eq__(self, other):
         return (
             isinstance(other, LintConfig)
-            and self.rules == other.rules
-            and self.verbosity == other.verbosity
-            and self.target == other.target
-            and self.extra_path == other.extra_path
             and self.contrib == other.contrib
-            and self.ignore_merge_commits == other.ignore_merge_commits
-            and self.ignore_fixup_commits == other.ignore_fixup_commits
-            and self.ignore_fixup_amend_commits == other.ignore_fixup_amend_commits
-            and self.ignore_squash_commits == other.ignore_squash_commits
-            and self.ignore_revert_commits == other.ignore_revert_commits
-            and self.ignore_stdin == other.ignore_stdin
-            and self.staged == other.staged
-            and self.fail_without_commits == other.fail_without_commits
-            and self.regex_style_search == other.regex_style_search
             and self.debug == other.debug
+            and self.extra_path == other.extra_path
+            and self.fail_without_commits == other.fail_without_commits
             and self.ignore == other.ignore
+            and self.ignore_fixup_amend_commits == other.ignore_fixup_amend_commits
+            and self.ignore_fixup_commits == other.ignore_fixup_commits
+            and self.ignore_merge_commits == other.ignore_merge_commits
+            and self.ignore_revert_commits == other.ignore_revert_commits
+            and self.ignore_squash_commits == other.ignore_squash_commits
+            and self.ignore_stdin == other.ignore_stdin
+            and self.regex_style_search == other.regex_style_search
+            and self.rules == other.rules
+            and self.staged == other.staged
+            and self.target == other.target
+            and self.verbosity == other.verbosity
             and self._config_path == other._config_path
         )
 
@@ -345,6 +345,27 @@ class LintConfig:
             f"debug: {self.debug}\n"
             f"target: {self.target}\n"
             f"[RULES]\n{self.rules}"
+        )
+    
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"contrib={self.contrib!r}, "
+            f"debug={self.debug!r}, "
+            f"extra_path={self.extra_path!r}, "
+            f"fail_without_commits={self.fail_without_commits!r}, "
+            f"ignore={self.ignore!r}, "
+            f"ignore_fixup_amend_commits={self.ignore_fixup_amend_commits!r}, "
+            f"ignore_fixup_commits={self.ignore_fixup_commits!r}, "
+            f"ignore_merge_commits={self.ignore_merge_commits!r}, "
+            f"ignore_revert_commits={self.ignore_revert_commits!r}, "
+            f"ignore_squash_commits={self.ignore_squash_commits!r}, "
+            f"ignore_stdin={self.ignore_stdin!r}, "
+            f"regex_style_search={self.regex_style_search!r}, "
+            f"rules={self.rules!r}, "
+            f"staged={self.staged!r}, "
+            f"target={self.target!r}, "
+            f"verbosity={self.verbosity!r})"
         )
 
 

--- a/gitlint-core/gitlint/tests/config/test_config.py
+++ b/gitlint-core/gitlint/tests/config/test_config.py
@@ -280,23 +280,23 @@ class LintConfigTests(BaseTestCase):
 
         # Ensure LintConfig are not equal if they differ on their attributes
         attrs = [
-            ("verbosity", 1),
-            ("rules", []),
-            ("ignore_stdin", True),
-            ("fail_without_commits", True),
-            ("regex_style_search", True),
+            ("contrib", ["CC1"]),
             ("debug", True),
+            ("extra_path", self.get_sample_path("user_rules")),
+            ("fail_without_commits", True),
             ("ignore", ["T1"]),
-            ("staged", True),
-            ("_config_path", self.get_sample_path()),
+            ("ignore_stdin", True),
             ("ignore_merge_commits", False),
             ("ignore_fixup_commits", False),
             ("ignore_fixup_amend_commits", False),
             ("ignore_squash_commits", False),
             ("ignore_revert_commits", False),
-            ("extra_path", self.get_sample_path("user_rules")),
+            ("regex_style_search", True),
+            ("rules", []),
+            ("staged", True),
             ("target", self.get_sample_path()),
-            ("contrib", ["CC1"]),
+            ("verbosity", 1),
+            ("_config_path", self.get_sample_path()),
         ]
         for attr, val in attrs:
             config = LintConfig()


### PR DESCRIPTION
Implement missing `__repr__` methods where it makes sense.

Not required for dataclasses as they have them already implemented.
Not required for a few classes with only static methods.

This closes #321 
