### PR TITLE
Default to general.regex-style-search=True

### DIFF
--- a/docs/configuration/general_options.md
+++ b/docs/configuration/general_options.md
@@ -460,12 +460,12 @@ Whether to use Python `re.search()` instead of `re.match()` semantics in all bui
 
 | Default value    | Type            | CLI flag                                | Env var       |
 | ---------------- | --------------- | --------------------------------------- | ------------- |
-| `#!python false` | `#!python bool` | `-c general.regex-style-search=<value>` | Not Available |
+| `#!python true` | `#!python bool` | `-c general.regex-style-search=<value>` | Not Available |
 
 !!! important
-    At this time, `regex-style-search` is **disabled** by default, but it will be **enabled** by default in the future.
+    At this time, `regex-style-search` is **enabled** by default, but you can still manually **disable** it.
+    Future versions of gitlint will no longer allow this, please follow the steps below to migrate. 
     
-
 
 Gitlint will log a warning when you're using a rule that uses a custom regex and this option is not enabled:
 

--- a/gitlint-core/gitlint/config.py
+++ b/gitlint-core/gitlint/config.py
@@ -90,7 +90,7 @@ class LintConfig:
             "fail-without-commits", False, "Hard fail when the target commit range is empty"
         )
         self._regex_style_search = options.BoolOption(
-            "regex-style-search", False, "Use `search` instead of `match` semantics for regex rules"
+            "regex-style-search", True, "Use `search` instead of `match` semantics for regex rules"
         )
 
     @property

--- a/gitlint-core/gitlint/tests/config/test_config.py
+++ b/gitlint-core/gitlint/tests/config/test_config.py
@@ -55,7 +55,7 @@ class LintConfigTests(BaseTestCase):
         self.assertFalse(config.ignore_stdin)
         self.assertFalse(config.staged)
         self.assertFalse(config.fail_without_commits)
-        self.assertFalse(config.regex_style_search)
+        self.assertTrue(config.regex_style_search)
         self.assertFalse(config.debug)
         self.assertEqual(config.verbosity, 3)
         active_rule_classes = tuple(type(rule) for rule in config.rules)
@@ -291,7 +291,7 @@ class LintConfigTests(BaseTestCase):
             ("ignore_fixup_amend_commits", False),
             ("ignore_squash_commits", False),
             ("ignore_revert_commits", False),
-            ("regex_style_search", True),
+            ("regex_style_search", False),
             ("rules", []),
             ("staged", True),
             ("target", self.get_sample_path()),

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_debug_1
@@ -19,7 +19,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: False
 fail-without-commits: False
-regex-style-search: False
+regex-style-search: True
 verbosity: 1
 debug: True
 target: {target}

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_input_stream_debug_2
@@ -19,7 +19,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: False
 fail-without-commits: False
-regex-style-search: False
+regex-style-search: True
 verbosity: 3
 debug: True
 target: {target}

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_msg_filename_2
@@ -19,7 +19,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: True
 fail-without-commits: False
-regex-style-search: False
+regex-style-search: True
 verbosity: 3
 debug: True
 target: {target}

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_lint_staged_stdin_2
@@ -19,7 +19,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: True
 fail-without-commits: False
-regex-style-search: False
+regex-style-search: True
 verbosity: 3
 debug: True
 target: {target}

--- a/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
+++ b/gitlint-core/gitlint/tests/expected/cli/test_cli/test_named_rules_2
@@ -19,7 +19,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: False
 fail-without-commits: False
-regex-style-search: False
+regex-style-search: True
 verbosity: 3
 debug: True
 target: {target}

--- a/gitlint-core/gitlint/tests/rules/test_configuration_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_configuration_rules.py
@@ -1,7 +1,6 @@
 from gitlint import rules
 from gitlint.config import LintConfig
 from gitlint.tests.base import (
-    EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING,
     BaseTestCase,
 )
 
@@ -25,7 +24,6 @@ class ConfigurationRuleTests(BaseTestCase):
         self.assertEqual(config, expected_config)
 
         expected_log_messages = [
-            EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING.format("I1", "ignore-by-title"),
             "DEBUG: gitlint.rules Ignoring commit because of rule 'I1': "
             "Commit title 'Releäse' matches the regex '^Releäse(.*)', ignoring rules: all",
         ]
@@ -62,7 +60,6 @@ class ConfigurationRuleTests(BaseTestCase):
         self.assertEqual(config, expected_config)
 
         expected_log_messages = [
-            EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING.format("I2", "ignore-by-body"),
             "DEBUG: gitlint.rules Ignoring commit because of rule 'I2': "
             "Commit message line ' a relëase body' matches the regex '(.*)relëase(.*)',"
             " ignoring rules: all",
@@ -119,7 +116,6 @@ class ConfigurationRuleTests(BaseTestCase):
         self.assertEqual(config, expected_config)
 
         expected_log_messages += [
-            EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING.format("I4", "ignore-by-author-name"),
             "DEBUG: gitlint.rules Ignoring commit because of rule 'I4': "
             "Commit Author Name 'Tëst nåme' matches the regex '(.*)ëst(.*)',"
             " ignoring rules: all",
@@ -164,7 +160,6 @@ class ConfigurationRuleTests(BaseTestCase):
         self.assertEqual(commit1, expected_commit)
         self.assertEqual(config, LintConfig())  # config shouldn't have been modified
         expected_log_messages = [
-            EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING.format("I3", "ignore-body-lines"),
             "DEBUG: gitlint.rules Ignoring line ' a relëase body' because it " + "matches '(.*)relëase(.*)'",
         ]
         self.assert_logged(expected_log_messages)

--- a/gitlint-core/gitlint/tests/rules/test_meta_rules.py
+++ b/gitlint-core/gitlint/tests/rules/test_meta_rules.py
@@ -1,6 +1,5 @@
 from gitlint.rules import AuthorValidEmail, RuleViolation
 from gitlint.tests.base import (
-    EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING,
     BaseTestCase,
 )
 
@@ -75,6 +74,3 @@ class MetaRuleTests(BaseTestCase):
             commit = self.gitcommit("", author_email=email)
             violations = rule.validate(commit)
             self.assertListEqual(violations, [RuleViolation("M1", "Author email for commit is invalid", email)])
-
-        # When a custom regex is used, a warning should be logged by default
-        self.assert_logged([EXPECTED_REGEX_STYLE_SEARCH_DEPRECATION_WARNING.format("M1", "author-valid-email")])

--- a/qa/expected/test_commits/test_ignore_commits_1
+++ b/qa/expected/test_commits/test_ignore_commits_1
@@ -1,5 +1,3 @@
-WARNING: I1 - ignore-by-title: gitlint will be switching from using Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. Please review your ignore-by-title.regex option accordingly. To remove this warning, set general.regex-style-search=True. More details: https://jorisroovers.github.io/gitlint/configuration/general_options/#regex-style-search
-WARNING: I2 - ignore-by-body: gitlint will be switching from using Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. Please review your ignore-by-body.regex option accordingly. To remove this warning, set general.regex-style-search=True. More details: https://jorisroovers.github.io/gitlint/configuration/general_options/#regex-style-search
 Commit {commit_sha0}:
 1: T3 Title has trailing punctuation (.): "Sïmple title4."
 

--- a/qa/expected/test_commits/test_lint_staged_msg_filename_1
+++ b/qa/expected/test_commits/test_lint_staged_msg_filename_1
@@ -20,7 +20,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: True
 fail-without-commits: False
-regex-style-search: False
+regex-style-search: True
 verbosity: 3
 debug: True
 target: {target}

--- a/qa/expected/test_commits/test_lint_staged_stdin_1
+++ b/qa/expected/test_commits/test_lint_staged_stdin_1
@@ -20,7 +20,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: True
 fail-without-commits: False
-regex-style-search: False
+regex-style-search: True
 verbosity: 3
 debug: True
 target: {target}

--- a/qa/expected/test_config/test_config_from_env_1
+++ b/qa/expected/test_config/test_config_from_env_1
@@ -20,7 +20,7 @@ ignore-revert-commits: True
 ignore-stdin: True
 staged: False
 fail-without-commits: True
-regex-style-search: False
+regex-style-search: True
 verbosity: 2
 debug: True
 target: {target}

--- a/qa/expected/test_config/test_config_from_env_2
+++ b/qa/expected/test_config/test_config_from_env_2
@@ -20,7 +20,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: True
 fail-without-commits: False
-regex-style-search: False
+regex-style-search: True
 verbosity: 0
 debug: True
 target: {target}

--- a/qa/expected/test_config/test_config_from_file_debug_1
+++ b/qa/expected/test_config/test_config_from_file_debug_1
@@ -20,7 +20,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: False
 fail-without-commits: False
-regex-style-search: False
+regex-style-search: True
 verbosity: 2
 debug: True
 target: {target}

--- a/qa/expected/test_gitlint/test_commit_binary_file_1
+++ b/qa/expected/test_gitlint/test_commit_binary_file_1
@@ -20,7 +20,7 @@ ignore-revert-commits: True
 ignore-stdin: False
 staged: False
 fail-without-commits: False
-regex-style-search: False
+regex-style-search: True
 verbosity: 3
 debug: True
 target: {target}


### PR DESCRIPTION
This will make all rules use re.search() by default.
It's still possible to manually reverse this behavior by setting:
general.regex-style-search=False

Relates to #254
