### PR TITLE
docs: fix example

### DIFF
--- a/docs/rules/contrib_rules.md
+++ b/docs/rules/contrib_rules.md
@@ -61,7 +61,7 @@ Enforces [Conventional Commits](https://www.conventionalcommits.org/) commit mes
 
     ```ini
     [contrib-title-conventional-commits]
-    line-length=bugfix,user-story,epic
+    types=bugfix,user-story,epic
     ```
 
 


### PR DESCRIPTION
Fixed example in docs for conventional comits contrib rule.