### PR TITLE
Recommend installing with `pipx`

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,11 @@
 ## Fully supported
 
-### Pip (recommended)
+### Pipx (recommended)
+```{.sh .copy}
+pipx install gitlint --include-deps
+```
+
+### Pip
 ```{.sh .copy}
 pip install gitlint
 ```


### PR DESCRIPTION
This PR changes the documentation to recommend installing with `pipx` rather than `pip`.  There are two reasons why I think this is a useful change:
- `pipx` installs packages into their own virtual environments, so their dependencies are completely isolated from the rest of the system.  My understanding is that this is currently considered the best practice when it comes to installing packages that are meant to be used via the command-line (as opposed to those that are meant to be used as libraries), and I think `gitlint` falls squarely in that category.
- The `pipx install` command isn't trivial, in that it requires the unusual `--include-deps` flag.  The reason is that the `gitlint` package is a sort-of dummy package that pins dependency versions but doesn't directly provide the executable.  `pipx` notices this and complains about it, unless the above flag is given.

If you don't want to change the recommendation from `pip` to `pipx`, feel free to close this PR.  I just made it because it took me a little bit to figure out what was going on, and I thought it might save some other people the trouble.