### PR TITLE
Enable pre-commit stage for gitlint-ci hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,4 +13,4 @@
   entry: gitlint
   always_run: true
   pass_filenames: false
-  stages: [manual]
+  stages: [manual, pre-commit]


### PR DESCRIPTION
Relates to #191, specifically to simplify use of gitlint-ci hook with the https://pre-commit.ci CI service.
