### PR TITLE
Improve regexes in docs

### DIFF
--- a/docs/configuration/gitlint_file.md
+++ b/docs/configuration/gitlint_file.md
@@ -83,7 +83,7 @@ regex=My-Commit-Tag: foo$ # (10)
 
 [author-valid-email]
 # E.g.: Only allow email addresses from foo.com
-regex=[^@]+@foo.com # (11)
+regex=[^@]+@foo\.com$ # (11)
 
 
 ### NAMED RULES ### (20)
@@ -104,20 +104,20 @@ max-line-count = 5
 ### IGNORE RULES CONFIGURATION ### (13)
 [ignore-by-title]
 # Ignore rules for commits of which the title matches a regex
-regex=^Release(.*) # (14)
+regex=^Release.* # (14)
 ignore=T1,body-min-length # (15)
 
 [ignore-by-body]
 # Ignore rules for commits of which the body has a line that matches a regex
-regex=(.*)release(.*) # (16)
+regex=.*release.* # (16)
 ignore=T1,body-min-length
 
 [ignore-body-lines]
 # Ignore all lines that start with 'Co-Authored-By'
-regex=^Co-Authored-By # (17)
+regex=^Co-Authored-By.* # (17)
 
 [ignore-by-author-name]
-regex=(.*)dependabot(.*) # (18)
+regex=.*dependabot.* # (18)
 ignore=T1,body-min-length
 ```
 
@@ -168,7 +168,7 @@ ignore=T1,body-min-length
     for commits made by `dependabot`. You can also ignore the the commit all-together by setting `ignore=all`:
     ```ini
     [ignore-by-author-name]
-    regex=(.*)dependabot(.*) # (18)
+    regex=.*dependabot.* # (18)
     ignore=all
     ```
     

--- a/docs/ignoring_commits.md
+++ b/docs/ignoring_commits.md
@@ -13,12 +13,12 @@ Here's a few examples:
     ```ini
     [ignore-by-title]
     # Match commit titles starting with "Release"
-    regex=^Release(.*)
+    regex=^Release.*
     ignore=title-max-length,body-min-length # (1)
 
     [ignore-by-body]
     # Match commits message bodies that have a line that contains 'release'
-    regex=(.*)release(.*)
+    regex=.*release.*
     ignore=all
 
     [ignore-by-author-name]
@@ -30,7 +30,7 @@ Here's a few examples:
     1. Ignore all rules by setting `ignore` to 'all'. 
     ```ini
     [ignore-by-title]
-    regex=^Release(.*)
+    regex=^Release.*
     ignore=all
     ```
 
@@ -43,7 +43,7 @@ ones,  you can do that using the
     ```ini
     # Ignore all lines that start with 'Co-Authored-By'
     [ignore-body-lines]
-    regex=^Co-Authored-By
+    regex=^Co-Authored-By.*
     ```
 
 !!! warning

--- a/docs/rules/builtin_rules.md
+++ b/docs/rules/builtin_rules.md
@@ -223,11 +223,11 @@ Body must match a given regex.
     ```ini
     # Ensure the body ends with Reviewed-By: <some value>
     [body-match-regex]
-    regex=Reviewed-By:(.*)$
+    regex=Reviewed-By: .+
 
     # Ensure body contains the word "Foo" somewhere
     [body-match-regex]
-    regex=(*.)Foo(.*)
+    regex=.*\bFoo\b.*
     ```
 
 ## M1: author-valid-email
@@ -252,7 +252,7 @@ Author email address must be a valid email address.
     ```ini
     # Only allow email addresses from a foo.com domain
     [author-valid-email]
-    regex=[^@]+@foo.com
+    regex=[^@]+@foo\.com$
     ```
 
 ## I1: ignore-by-title
@@ -273,12 +273,12 @@ Ignore a commit based on matching its title.
     # Match commit titles starting with Release
     # For those commits, ignore title-max-length and body-min-length rules
     [ignore-by-title]
-    regex=^Release(.*)
+    regex=^Release.*
     ignore=title-max-length,body-min-length,B6 # (1)
 
     # Ignore all rules by setting ignore to 'all'
     [ignore-by-title]
-    regex=^Release(.*)
+    regex=^Release.*
     ignore=all
     ```
 
@@ -303,12 +303,12 @@ Ignore a commit based on matching its body.
     # Ignore all commits with a commit message body with a line that contains 'release'
     # For matching commits, only ignore rules T1, body-min-length, B6.
     [ignore-by-body]
-    regex=(.*)release(.*)
+    regex=.*release.*
     ignore=T1,body-min-length,B6 # (1)
 
     # Ignore all rules by setting ignore to 'all'
     [ignore-by-body]
-    regex=(.*)release(.*)
+    regex=.*release.*
     ignore=all
     ```
 
@@ -331,15 +331,15 @@ Ignore certain lines in a commit body that match a regex.
     ```ini
     # Ignore all lines that start with 'Co-Authored-By'
     [ignore-body-lines]
-    regex=^Co-Authored-By
+    regex=^Co-Authored-By.*
 
     # Ignore lines that start with 'Co-Authored-By' or with 'Signed-off-by'
     [ignore-body-lines]
-    regex=(^Co-Authored-By)|(^Signed-off-by)
+    regex=^(Co-Authored-By|Signed-off-by).*
 
     # Ignore lines that contain 'foobar'
     [ignore-body-lines]
-    regex=(.*)foobar(.*)
+    regex=.*foobar.*
     ```
 
 ## I4: ignore-by-author-name
@@ -365,7 +365,7 @@ Ignore a commit based on matching its author name.
 
     # For commits made by authors with "[bot]" in their name, ignore specific rules
     [ignore-by-author-name]
-    regex=(.*)\[bot\](.*)
+    regex=.*\[bot\].*
     ignore=T1,body-min-length,B6 # (1)
     ```
 

--- a/gitlint-core/gitlint/files/gitlint
+++ b/gitlint-core/gitlint/files/gitlint
@@ -99,12 +99,12 @@
 # [author-valid-email]
 # python-style regex that the commit author email address must match.
 # For example, use the following regex if you only want to allow email addresses from foo.com
-# regex=[^@]+@foo.com
+# regex=[^@]+@foo\.com$
 
 # [ignore-by-title]
 # Ignore certain rules for commits of which the title matches a regex
 # E.g. Match commit titles that start with "Release"
-# regex=^Release(.*)
+# regex=^Release.*
 
 # Ignore certain rules, you can reference them by their id or by their full name
 # Use 'all' to ignore all rules
@@ -113,7 +113,7 @@
 # [ignore-by-body]
 # Ignore certain rules for commits of which the body has a line that matches a regex
 # E.g. Match bodies that have a line that that contain "release"
-# regex=(.*)release(.*)
+# regex=.*release.*
 #
 # Ignore certain rules, you can reference them by their id or by their full name
 # Use 'all' to ignore all rules
@@ -122,12 +122,12 @@
 # [ignore-body-lines]
 # Ignore certain lines in a commit body that match a regex.
 # E.g. Ignore all lines that start with 'Co-Authored-By'
-# regex=^Co-Authored-By
+# regex=^Co-Authored-By.*
 
 # [ignore-by-author-name]
 # Ignore certain rules for commits of which the author name matches a regex
 # E.g. Match commits made by dependabot
-# regex=(.*)dependabot(.*)
+# regex=.*dependabot.*
 #
 # Ignore certain rules, you can reference them by their id or by their full name
 # Use 'all' to ignore all rules

--- a/qa/samples/config/ignore-release-commits
+++ b/qa/samples/config/ignore-release-commits
@@ -1,7 +1,7 @@
 [ignore-by-title]
-regex=^Release(.*)
+regex=^Release.*
 ignore=T5,T3
 
 [ignore-by-body]
-regex=(.*)relëase(.*)
+regex=.*relëase.*
 ignore=T3,B3


### PR DESCRIPTION
Remove unneeded capturing group parenthesis as there's no significance to the groups, misc strictness fixes, make do the right thing with both match and search style regex matching.


