### PR TITLE
Conventional commits: allow restricting the scopes

### DIFF
--- a/docs/rules/contrib_rules.md
+++ b/docs/rules/contrib_rules.md
@@ -52,9 +52,10 @@ Enforces [Conventional Commits](https://www.conventionalcommits.org/) commit mes
 
 #### Options
 
-| Name          | Type           | Default       | gitlint version                    | Description                   |
-| ------------- | -------------- | ------------- | ---------------------------------- | ----------------------------- |
-| `types` | `#!python str` | `fix,feat,chore,docs,style,refactor,perf,test,revert,ci,build` | [:octicons-tag-24: v0.12.0][v0.12.0] | Comma separated list of allowed commit types. |
+| Name       | Type           | Default                                                        | gitlint version                      | Description                                      |
+|------------| -------------- |----------------------------------------------------------------|--------------------------------------|--------------------------------------------------|
+| `types`    | `#!python str` | `fix,feat,chore,docs,style,refactor,perf,test,revert,ci,build` | [:octicons-tag-24: v0.12.0][v0.12.0] | Comma separated list of allowed commit types.    |
+| `scopes`   | `#!python str` |                                                                | [:octicons-tag-24: v0.12.0][v0.12.0] | Optional comma separated list of allowed scopes. |
 
 
 === ":octicons-file-code-16:  .gitlint"

--- a/gitlint-core/gitlint/tests/config/test_config.py
+++ b/gitlint-core/gitlint/tests/config/test_config.py
@@ -135,14 +135,23 @@ class LintConfigTests(BaseTestCase):
         self.assertEqual(actual_rule.name, "contrib-title-conventional-commits")
         self.assertEqual(actual_rule.target, rules.CommitMessageTitle)
 
-        expected_rule_option = options.ListOption(
-            "types",
-            ["fix", "feat", "chore", "docs", "style", "refactor", "perf", "test", "revert", "ci", "build"],
-            "Comma separated list of allowed commit types.",
-        )
+        expected_rule_options = [
+            options.ListOption(
+                "types",
+                ["fix", "feat", "chore", "docs", "style", "refactor", "perf", "test", "revert", "ci", "build"],
+                "Comma separated list of allowed commit types.",
+            ),
+            options.ListOption(
+                "scopes",
+                [],
+                "Comma separated list of allowed scopes.",
+            ),
+        ]
 
-        self.assertListEqual(actual_rule.options_spec, [expected_rule_option])
-        self.assertDictEqual(actual_rule.options, {"types": expected_rule_option})
+        self.assertListEqual(actual_rule.options_spec, expected_rule_options)
+        self.assertDictEqual(
+            actual_rule.options, {"types": expected_rule_options[0], "scopes": expected_rule_options[1]}
+        )
 
         # Check contrib-body-requires-signed-off-by contrib rule
         actual_rule = config.rules.find_rule("contrib-body-requires-signed-off-by")

--- a/gitlint-core/gitlint/tests/contrib/rules/test_conventional_commit.py
+++ b/gitlint-core/gitlint/tests/contrib/rules/test_conventional_commit.py
@@ -80,3 +80,19 @@ class ContribConventionalCommitTests(BaseTestCase):
         for typ in ["föo123", "123bär"]:
             violations = rule.validate(typ + ": hür dur", None)
             self.assertListEqual([], violations)
+
+        # assert no violation in case of valid scope
+        rule = ConventionalCommit({"scopes": ["föo", "bär"]})
+        for scope in ["föo", "bär"]:
+            violations = rule.validate("feat(" + scope + "): yep", None)
+            self.assertListEqual([], violations)
+
+        # assert violation in case of invalid scope
+        expected_violation = RuleViolation(
+            "CT1",
+            "Title does not use one of these scopes: föo, bär",
+            "feat(invalid): nope",
+        )
+        rule = ConventionalCommit({"scopes": ["föo", "bär"]})
+        violations = rule.validate("feat(invalid): nope", None)
+        self.assertListEqual([expected_violation], violations)


### PR DESCRIPTION
This pull request adds another list option "scopes" to the conventional commits rule (CT1). It allows to restrict the used scopes to the ones configured. By default, the list is empty, meaning, there is no restriction on scopes.