### PR TITLE
Using python3 in commit-msg hook.

### DIFF
--- a/gitlint-core/gitlint/files/commit-msg
+++ b/gitlint-core/gitlint/files/commit-msg
@@ -26,7 +26,7 @@ exit_code=$?
 # This is the case for Atlassian SourceTree, where $PATH deviates from the user's shell $PATH.
 if [ $exit_code -eq 127 ]; then
     echo "Fallback to python module execution"
-    python -m gitlint.cli --staged --msg-filename "$1" run-hook
+    python3 -m gitlint.cli --staged --msg-filename "$1" run-hook
     exit_code=$?
 fi
 


### PR DESCRIPTION
Hi,

gitlint works just fine with python 3.x, however, most distributions such as Debian, RedHat and their derivatives use python3 as the name for the 3.x interpreter.

Regards,
Daniel