### PR TITLE
disable log.showSignature config for git commands by default

### DIFF
--- a/gitlint-core/gitlint/shell.py
+++ b/gitlint-core/gitlint/shell.py
@@ -42,7 +42,8 @@ def git(*command_parts: str, **kwargs: Any) -> ShResult:
     Implemented as separate function here, so we can do a 'sh' style imports:
     `from shell import git`
     """
-    args = ["git", *list(command_parts)]
+    default_configs = ["-c", "log.showSignature=false"]
+    args = ["git", *default_configs, *list(command_parts)]
     return _exec(*args, **kwargs)
 
 


### PR DESCRIPTION
gitlint doesnt work properly if the configuration of the users enables log.showSignature config. See below as an example:

```
 git log
commit 4d9119760056492eabc201bfad5de2f9e660b85f (HEAD -> main,
upstream/main, upstream/HEAD)
gpg: Signature made Sat 02 Sep 2023 08:25:48 AM UTC
gpg:                using RSA key 4AEE18F83AFDEB23
gpg: Can't check signature: No public key
Author: dependabot[bot]
<49699333+dependabot[bot]@users.noreply.github.com>
Date:   Sat Sep 2 10:25:48 2023 +0200

    Bump python from 3.11.4-alpine to 3.11.5-alpine (#525)

    Bumps python from 3.11.4-alpine to 3.11.5-alpine.

    ---
    updated-dependencies:

 gitlint
An error occurred while executing 'git log gpg: Signature made Sat 02
Sep 2023 08:25:48 AM UTCgpg:                using RSA key
4AEE18F83AFDEB23gpg: Can't check signature: No public
key4d9119760056492eabc201bfad5de2f9e660b85f -1
--pretty=%aN%x00%aE%x00%ai%x00%P%n%B': b"fatal: invalid object name
'gpg'."
```

After disabling log.showSignature config for git runs made by gitlint, it works as expected.

```
 hatch run dev:gitlint
An error occurred while executing 'git log gpg: Signature made Sat 02
Sep 2023 08:25:48 AM UTCgpg:                using RSA key
4AEE18F83AFDEB23gpg: Can't check signature: No public
key4d9119760056492eabc201bfad5de2f9e660b85f -1
--pretty=%aN%x00%aE%x00%ai%x00%P%n%B': b"fatal: invalid object name
'gpg'."

^^ this is before fix in dev environment

 hatch run dev:gitlint
^^ this is after fix as expected
```

<!--- THIS IS A COMMENT BLOCK, REMOVE IT BEFORE SUBMITTING YOUR PR

Thank you for your interest in gitlint and putting in the effort to create a PR!

A few quick notes:

- It's really just me (https://github.com/jorisroovers) maintaining gitlint, and I do so in a hobby capacity. More recently it has become harder for me to find time to maintain gitlint on a regular basis, which in practice means that it might take me a while (sometimes months) to get back to you. Rest assured though, I absolutely look at all PRs as soon as they come in - I just tend to only "work" on gitlint a few times a year.
- Similarly, after your code is merged, it typically still takes months before I do another release that contains your code. Please don't let that deter you from contributing - I appreciate your patience and understanding!
- Please review: http://jorisroovers.github.io/gitlint/contributing/

-->

Enter your PR details here
