### PR TITLE
fix: Bump click to 8.1.8

### DIFF
--- a/gitlint-core/pyproject.toml
+++ b/gitlint-core/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 [project.optional-dependencies]
 trusted-deps = [
     "arrow==1.2.3",
-    "Click==8.1.7",
+    "Click==8.1.8",
 ]
 
 [project.scripts]


### PR DESCRIPTION
I wanted to use the asyncmq package which requires click 8.1.8. Do you mind bumping it here?